### PR TITLE
Take the "template_id" parameter of folder_position.cpy into account (https://dev.plone.org/ticket/13089)

### DIFF
--- a/Products/CMFPlone/skins/plone_scripts/folder_position.cpy.metadata
+++ b/Products/CMFPlone/skins/plone_scripts/folder_position.cpy.metadata
@@ -2,5 +2,5 @@
 title = Order items
 
 [actions]
-action.failure=traverse_to:string:folder_contents
-action.success=redirect_to:string:folder_contents
+action.failure=traverse_to:python:request.get('template_id', 'folder_contents')
+action.success=redirect_to:python:request.get('template_id', 'folder_contents')


### PR DESCRIPTION
This takes the "template_id" parameter given to folder_position.cpy into account so this script can be used on other templates than "folder_contents".  See https://dev.plone.org/ticket/13089.  If that seem right, I will also propose pull requests for branches 4.1 and 4.2...

Thank you!

Gauthier
