### PR TITLE
Fix sitemap to show CSS content type icons

### DIFF
--- a/Products/CMFPlone/skins/plone_deprecated/portlet_navtree_macro.pt
+++ b/Products/CMFPlone/skins/plone_deprecated/portlet_navtree_macro.pt
@@ -19,9 +19,10 @@
                 isCurrent  node/currentItem;"
     tal:condition="python: bottomLevel &lt;= 0 or level &lt; bottomLevel-1">
 
-    <tal:level define="item_wf_state_class python: 'state-' + normalizeString(item.review_state);">
+    <tal:level define="item_wf_state_class python: 'state-' + normalizeString(item.review_state);
+                       item_type_class python:'contenttype-' + normalizeString(item.portal_type)">
 
-    <div tal:define="itemClass string:$item_wf_state_class;
+    <div tal:define="itemClass string:$item_wf_state_class $item_type_class;
                      itemClass python:test(isCurrent, itemClass + ' navTreeCurrentItem', itemClass);">
 
         <a tal:attributes="href python:test(linkRemote, item.getRemoteUrl, itemUrl);

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -8,6 +8,9 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
+- Fix sitemap to show CSS content type icons.
+  [danjacka]
+
 - Fix prefs_install_product_readme so files with non-ascii characters are
   rendered. This fixes https://dev.plone.org/ticket/12342
   [ericof]


### PR DESCRIPTION
I would commit this directly but the template is in `plone_deprecated`. Is it ok to change those templates?
