### PR TITLE
Add event to fix products installed with latest keyword

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -105,4 +105,7 @@
         file="configure.zcml"
         />
 
+  <subscriber for="Products.GenericSetup.events.ProfileImportedEvent"
+              handler=".events.profileImportedEventHandler"/>
+
 </configure>

--- a/Products/CMFPlone/events.py
+++ b/Products/CMFPlone/events.py
@@ -1,9 +1,25 @@
 from zope.interface import implements
 from zope.component.interfaces import ObjectEvent
 
+from Products.CMFCore.utils import getToolByName
+
 from interfaces import ISiteManagerCreatedEvent
 
 
 class SiteManagerCreatedEvent(ObjectEvent):
 
     implements(ISiteManagerCreatedEvent)
+
+
+def profileImportedEventHandler(event):
+    """
+    When a profile is imported with the keyword "latest", it needs to
+    be reconfigured with the actual number.
+    """
+    profile_id = event.profile_id.replace('profile-', '')
+    gs = event.tool
+    qi = getToolByName(gs, 'portal_quickinstaller')
+    installed_version = gs.getLastVersionForProfile(profile_id)
+    if installed_version == (u'latest',):
+        actual_version = qi.getLatestUpgradeStep(profile_id)
+        gs.setLastVersionForProfile(profile_id, actual_version)

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -20,6 +20,11 @@ Changelog
   Fixes https://dev.plone.org/ticket/12877
   [davidjb]
 
+- Add event to fix products installed with latest keyword 
+  activated by default. Event finds new products installed with 
+  the latest keyword and updates them to the last profile version.
+  [eleddy]
+
 4.2rc1 (2012-05-07)
 -------------------
 


### PR DESCRIPTION
I missed this in the last release cycle. I will fix the changes.txt on merge
