### PR TITLE
Fix attribute values in selector expressions of  mark_special_links.js

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/mark_special_links.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/mark_special_links.js
@@ -36,7 +36,7 @@ function scanforlinks() {
 
     if (elonw) {
         // all http links (without the link-plain class), not within this site
-        jQuery('a[href^=http]:not(.link-plain):not([href^=' + url + '])')
+        jQuery('a[href^="http"]:not(.link-plain):not([href^="' + url + '"])')
             .attr('target', '_blank');
     }
 
@@ -47,12 +47,12 @@ function scanforlinks() {
       // All links with an http href (without the link-plain class), not within this site,
       // and no img children should be wrapped in a link-external span
       contentarea.find(
-          'a[href^=http]:not(.link-plain):not([href^=' + url + ']):not(:has(img))')
+          'a[href^="http"]:not(.link-plain):not([href^="' + url + '"]):not(:has(img))')
           .wrap('<span></span>').parent().addClass('link-external');
       // All links without an http href (without the link-plain class), not within this site,
       // and no img children should be wrapped in a link-[protocol] span
       contentarea.find(
-          'a[href]:not([href^=http]):not(.link-plain):not([href^=' + url + ']):not(:has(img))')
+          'a[href]:not([href^="http"]):not(.link-plain):not([href^="' + url + '"]):not(:has(img))')
           .each(function() {
               // those without a http link may have another interesting protocol
               // wrap these in a link-[protocol] span

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 4.3rc2 (unreleased)
 --------------------
 
+- Fix attribute values in selector expressions of  mark_special_links.js.
+  [mathias.leimgruber]
+
 - Add indexer for location so metadata is included in catalog
   [vangheem]
 


### PR DESCRIPTION
According to http://api.jquery.com/category/selectors/attribute-selectors

If you activate the `mark_special_link.js` it breaks all js (ex. Menus/Overlays/etc.) in Plone 4.3rc1. 

![Screen shot 2013-03-26 at 6 54 10 PM](https://f.cloud.github.com/assets/437933/304497/3116a992-963e-11e2-8649-3a02b3b366da.png)
