### PR TITLE
Fix to dev.plone.org ticket #13514: Law of Demeter when profile_id is None

### DIFF
--- a/Products/CMFPlone/events.py
+++ b/Products/CMFPlone/events.py
@@ -21,7 +21,10 @@ def profileImportedEventHandler(event):
     When a profile is imported with the keyword "latest", it needs to
     be reconfigured with the actual number.
     """
-    profile_id = event.profile_id.replace('profile-', '')
+    profile_id = event.profile_id
+    if profile_id is None:
+        return
+    profile_id = profile_id.replace('profile-', '')
     gs = event.tool
     qi = getToolByName(gs, 'portal_quickinstaller', None)
     if qi is None:


### PR DESCRIPTION
More details here: https://dev.plone.org/ticket/13514

Essentially, when doing a simple import of an export using _Products.CMFCore.exportimport.content.exportSiteStructure_, error is encountered because **profile_id** is set to **None**, so Law of Demeter is broken and _AttributeError_ thrown.

Solution commit is similar to that of the Import Event Handler within [_Products.GenericSetup.events.handleProfileImportedEvent_](http://zope3.pov.lt/trac/browser/Products.GenericSetup/trunk/Products/GenericSetup/events.py#L47)

```
2013-04-08 15:39:09 ERROR Zope.SiteErrorLog 1365399549.760.408159064119 http://localhost:8080/Site/portal_setup/manage_importTarball
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module Products.GenericSetup.tool, line 565, in manage_importTarball
  Module Products.GenericSetup.tool, line 350, in runAllImportStepsFromProfile
  Module Products.GenericSetup.tool, line 1080, in _runImportStepsFromContext
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module Products.CMFPlone.events, line 24, in profileImportedEventHandler
AttributeError: 'NoneType' object has no attribute 'replace'
```
