### PR TITLE
Hidden TinyMCE controls in any but the first tab needlessly trigger unloadProtection

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/formUnload.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/formUnload.js
@@ -115,8 +115,15 @@ if (!window.beforeunload) {(function($) {
     c.checkbox = c.radio = function(ele) {
         return ele.checked !== ele.defaultChecked;
     };
-    c.file = c.password = c.textarea = c.text = function(ele) {
+    c.file = c.password = function(ele) {
         return ele.value !== ele.defaultValue;
+    };
+    c.text = c.textarea = function(ele) {
+        if ($(ele).hasClass('mce_editable') && typeof(tinyMCE) != "undefined") {
+            return tinyMCE.get(ele.id).getContent() != ele.defaultValue;
+        } else {
+            return ele.value !== ele.defaultValue;
+        }
     };
     // hidden: cannot tell on Mozilla without special treatment
     c.hidden = function(ele) {


### PR DESCRIPTION
If a hidden textarea or possibly a hidden text field is defined as a tinyMCE control in any but the first tab on a tabbed form unloadProtection warnings appear when they need not to.
## Steps to reproduce
- Define a tabbed form with a hidden tinyMCE textarea in the second tab.
- Create a new item with this form
- Open the item edit form
- Select the second tab (do not change anything)
- Try to navigate away from the from
## Behavior

After completing the steps above, the unload protection message will pop up, even though nothing has changed
## Expected behavior

The unload protection message will not pop up, as nothing has changed
## Cause

I'm not quite sure yet why this happens. It happens to me regularly on my forms, but the steps described above do not always trigger the error. I tried doing it hastily, slowly, with Chrome, Firefox. The error happens about every second try.
## Fix

My change uses the getContent function of tinyMCE, which always yields the actual value. Without this change, the element.value may contain tinyMCE code like this:

``` html
<p><br data-mce-bogus="1"></p>
```

With my fix the error does not appear anymore at all.
## Notes

I'm not totally sure this should be solved like this, it's just the most obvious place / fix I could find. I'm also not sure if I need to do anything else to get this fix into Plone. Please let me know what you think and if there's something I'm missing / not doing right.
