### PR TITLE
Removed the profile selection from the Plonesite add view.

### DIFF
--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -108,55 +108,6 @@ class FrontPage(BrowserView):
 
 class AddPloneSite(BrowserView):
 
-    default_extension_profiles = (
-        'plonetheme.classic:default',
-        'plonetheme.sunburst:default',
-        )
-
-    def profiles(self):
-        base_profiles = []
-        extension_profiles = []
-
-        # profiles available for install/uninstall, but hidden at the time
-        # the Plone site is created
-        not_installable = [
-            'kupu:default',
-            'plonetheme.classic:uninstall',
-            'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow',
-            'plone.app.registry:default',
-            'plone.app.z3cform:default',
-        ]
-        utils = getAllUtilitiesRegisteredFor(INonInstallable)
-        for util in utils:
-            not_installable.extend(util.getNonInstallableProfiles())
-
-        for info in profile_registry.listProfileInfo():
-            if info.get('type') == EXTENSION and \
-               info.get('for') in (IPloneSiteRoot, None):
-                profile_id = info.get('id')
-                if profile_id not in not_installable:
-                    if profile_id in self.default_extension_profiles:
-                        info['selected'] = 'selected'
-                    extension_profiles.append(info)
-
-        def _key(v):
-            # Make sure implicitly selected items come first
-            selected = v.get('selected') and 'automatic' or 'manual'
-            return '%s-%s' % (selected, v.get('title', ''))
-        extension_profiles.sort(key=_key)
-
-        for info in profile_registry.listProfileInfo():
-            if info.get('type') == BASE and \
-               info.get('for') in (IPloneSiteRoot, None) and \
-               info.get('id') != u'Products.kupu:default':
-                base_profiles.append(info)
-
-        return dict(
-            base=tuple(base_profiles),
-            default=_DEFAULT_PROFILE,
-            extensions=tuple(extension_profiles),
-        )
-
     def browser_language(self):
         language = 'en'
         pl = IUserPreferredLanguages(self.request)

--- a/Products/CMFPlone/browser/templates/plone-addsite.pt
+++ b/Products/CMFPlone/browser/templates/plone-addsite.pt
@@ -35,11 +35,7 @@
   <form action="#"
         method="post"
         tal:attributes="action string:${context/absolute_url}/@@plone-addsite"
-        tal:define="profiles view/profiles;
-                    base_profiles profiles/base;
-                    default_profile profiles/default;
-                    extension_profiles profiles/extensions;
-                    advanced request/advanced|nothing;">
+        tal:define="advanced request/advanced|nothing;">
 
       <div class="field">
         <label for="site_id" i18n:translate="">
@@ -102,84 +98,6 @@
       <tal:content tal:condition="not:advanced">
         <input type="hidden" name="setup_content:boolean" value="true" />
       </tal:content>
-
-
-
-      <tal:baseprofile condition="python: len(base_profiles) > 1">
-        <div class="field">
-          <label for="profile_id" i18n:translate="">
-            Base configuration
-          </label>
-
-          <div class="formHelp" i18n:translate="">
-            You normally don't need to change anything here unless you have
-            specific reasons and know what you are doing.
-          </div>
-
-          <dl>
-            <tal:bases tal:repeat="info base_profiles">
-              <dt>
-                <input type="radio"
-                       name="profile_id:string"
-                       value="profile"
-                       tal:attributes="id info/id;
-                                       value info/id;
-                                       checked python: default_profile==info['id'] and 'checked' or nothing"
-                       />
-                <label tal:attributes="for info/id"
-                       tal:content="info/title">
-                    Profile title
-                </label>
-              </dt>
-              <dd tal:content="info/description">
-                Profile description
-              </dd>
-            </tal:bases>
-          </dl>
-        </div>
-      </tal:baseprofile>
-
-      <tal:extensionprofiles condition="extension_profiles">
-        <fieldset id="add-on-list">
-          <legend i18n:translate="">
-            Add-ons
-          </legend>
-
-          <div class="formHelp" i18n:translate="">
-              Select any add-ons you want to activate immediately. You can
-              also activate add-ons after the site has been created using the
-              Add-ons control panel.
-          </div>
-
-          <dl id="extension_ids">
-            <tal:addons tal:repeat="info extension_profiles">
-              <tal:info tal:define="selected info/selected|nothing">
-                <tal:normal tal:condition="python: not selected or advanced">
-                  <dt>
-                    <input type="checkbox" name="extension_ids:list" value=""
-                           tal:attributes="value info/id;
-                                           id info/id;
-                                           checked info/selected|nothing;" />
-                    <label
-                        tal:attributes="for info/id"
-                        tal:content="info/title">
-                      profile title
-                    </label>
-                  </dt>
-                  <dd tal:content="info/description">
-                    profile description
-                  </dd>
-                </tal:normal>
-                <tal:hidden tal:condition="python: selected and not advanced">
-                  <input type="hidden" name="extension_ids:list" value=""
-                         tal:attributes="value info/id;
-                                         checked info/selected|nothing;" />
-                </tal:hidden>
-              </tal:info>
-            </tal:addons>
-          </dl>
-        </fieldset>
-      </tal:extensionprofiles>
 
       <div class="formControls">
         <input type="hidden" name="form.submitted:boolean" value="True" />


### PR DESCRIPTION
 Applying the selected profiles directly after adding the Plone site sometimes fails. This seems to be due to the random order a dict stores its keys.
The interface is also not very user friendly and confuses a lot of new Plone users (ie using the unified installer).
