### PR TITLE
Inline validation JavaScript for z3c.form only sends request when field ...

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
@@ -65,15 +65,17 @@ jQuery(function ($) {
             fset = $input.closest('fieldset').attr('data-fieldset'),
             fname = $field.attr('data-fieldname');
 
-        $form.ajaxSubmit({
-            url: $form.attr('action') + '/@@z3cform_validate_field',
-            data: {fname: fname, fset: fset},
-            iframe: false,
-            success: function (data) {
-                render_error($field, data.errmsg);
-            },
-            dataType: 'json'
-        });
+        if (fname) {
+            $form.ajaxSubmit({
+                url: $form.attr('action') + '/@@z3cform_validate_field',
+                data: {fname: fname, fset: fset},
+                iframe: false,
+                success: function (data) {
+                    render_error($field, data.errmsg);
+                },
+                dataType: 'json'
+            });
+        }
     };
     $('.z3cformInlineValidation input[type="text"]').live('blur', function () { z3cform_validate_field(this); });
     $('.z3cformInlineValidation input[type="password"]').live('blur', function () { z3cform_validate_field(this); });

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 4.3.3 (unreleased)
 ------------------
 
+- Inline validation JavaScript for z3c.form only sends request when
+  field name can be obtained from DOM for a widget (#13741).
+  [seanupton]
+
 - Return a 404 instead of "AttributeError: (dynamic view)" if a user attempts to
   view a still-temporary PortalFactory item.
   [esteele]


### PR DESCRIPTION
...name can be obtained from DOM for a widget (#13741).

Note: I propose this get merged first to 4.3.x branch, then merged appropriately to master.  

Related:
https://dev.plone.org/ticket/13741
https://github.com/plone/plone.app.z3cform/pull/11

Between this pull request and the one on plone.app.z3cform, there should be increased robustness in validation on the view and better behavior on the JavaScript client-side.
