### PR TITLE
Wait for last form field to appear.

### DIFF
--- a/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -232,10 +232,10 @@ I enter valid credentials
 
 I enter valid user data
     Wait until page contains element  name=form.password_ctl
-    Input text for sure form.username       myuser
-    Input text for sure form.email          my@email.eu
-    Input text for sure form.password       123123
-    Input text for sure form.password_ctl   123123
+    Input text for sure  form.username       myuser
+    Input text for sure  form.email          my@email.eu
+    Input text for sure  form.password       123123
+    Input text for sure  form.password_ctl   123123
 
 I enter valid register user data
     Wait until page contains element  name=form.username


### PR DESCRIPTION
Hopefully this fixes "New user overlay closes on valid data"

RF test Jenkins currently fails:
http://jenkins.plone.org/job/plone-5.0-python-2.7/477/testReport/Products.CMFPlone.tests.test_robot/RobotTestCase/Scenario_New_user_overlay_closes_on_valid_data/)

Have reproduced  this locally, but not reliably.
What we saw locally was that email or username gets filled in as fullname, and
email stays empty. Maybe a timing issue.

Is it worth trying at all?
