### PR TITLE
Add navigation_root_url to js variables.

### DIFF
--- a/Products/CMFPlone/browser/jsvariables.py
+++ b/Products/CMFPlone/browser/jsvariables.py
@@ -7,6 +7,7 @@ from Products.CMFPlone import PloneMessageFactory as _
 
 TEMPLATE = """\
 var portal_url = '%(portal_url)s';
+var navigation_root_url = '%(navigation_root_url)s';
 var form_modified_message = '%(form_modified)s';
 var form_resubmit_message = '%(form_resubmit)s';
 var external_links_open_new_window = '%(open_links)s';
@@ -36,6 +37,9 @@ class JSVariables(BrowserView):
 
         props = getToolByName(context, 'portal_properties').site_properties
         portal_url = getToolByName(context, 'portal_url')()
+
+        portal_state = context.restrictedTraverse('@@plone_portal_state')
+        navigation_root_url = portal_state.navigation_root_url()
 
         # the following are flags for mark_special_links.js
         # links get the target="_blank" attribute


### PR DESCRIPTION
p.a.search checks for window.navigation_root_url || window.portal_url.
When the navigation root is a subpage (/nl or /en) and modernizr is installed, p.a.search's search.js redirect to portal_url, because the navigation_root_url is missing.

This pull request add the navigation_root_url.
