### PR TITLE
Prepare for p.a.users z3cform conversion

### DIFF
--- a/Products/CMFPlone/skins/plone_login/registered.pt
+++ b/Products/CMFPlone/skins/plone_login/registered.pt
@@ -60,8 +60,8 @@
                 <form action=""
                       method="post"
                       tal:define="form request/form;
-                                  username python: form.get('form.username');
-                                  password python: form.get('form.password');
+                                  username python: form.get('form.widgets.username') or form.get('form.username');
+                                  password python: form.get('form.widgets.password') or form.get('form.password');
                                   ac_name auth/name_cookie|string:__ac_name;
                                   ac_password auth/pw_cookie|string:__ac_password;
                                   portal_url context/portal_url;"

--- a/Products/CMFPlone/tests/csrf.txt
+++ b/Products/CMFPlone/tests/csrf.txt
@@ -49,6 +49,20 @@ So first we need a logged in user with manager rights:
   >>> browser.getLink('Site Setup')
   <Link text='Site Setup' url='http://nohost/plone/@@overview-controlpanel'>
 
+Coincidentally the portal happens to be configured for users to get to pick
+their own passwords.  Again, this is only relevant for this test as otherwise
+outgoing mails would have to be handled making things unnecessarily
+complicated:
+
+  >>> self.portal.validate_email = False
+  >>> transaction.commit()
+
+We need to know what the register button is called, it might vary with form
+frameworks:
+
+  >>> browser.open('http://nohost/plone/@@register')
+  >>> buttonName = browser.getControl('Register').name
+
 Also, the form used for the attack needs to be created.  Normally this would
 happen on another domain, but for the purposes of this test it will happen on
 the same site, since it is the only one the testbrowser knows about:
@@ -63,18 +77,11 @@ the same site, since it is the only one the testbrowser knows about:
   ... <input type="hidden" name="password" value="johnnyrulez" /> \
   ... <input type="hidden" name="password_confirm" value="johnnyrulez" /> \
   ... <input type="hidden" name="form.submitted" value="1" /> \
-  ... <input type="submit" name="form.actions.register" value="Click me!" /> \
+  ... <input type="submit" name="' + buttonName + '" value="Click me!" /> \
   ... </form> \
   ... ', mimetype='text/html')
   >>> folder.important.getField('text').default_output_type = 'text/html'
   >>> portal.portal_workflow.doActionFor(folder.important, 'publish')
-
-Coincidentally the portal happens to be configured for users to get to pick
-their own passwords.  Again, this is only relevant for this test as otherwise
-outgoing mails would have to be handled making things unnecessarily
-complicated:
-
-  >>> self.portal.validate_email = False
   >>> transaction.commit()
 
 Now let's say with some social engineering the user who logged in above is

--- a/Products/CMFPlone/tests/emaillogin.txt
+++ b/Products/CMFPlone/tests/emaillogin.txt
@@ -41,10 +41,10 @@ We then visit the registration form.  We can fill in a user name
 there:
 
     >>> browser.open('http://nohost/plone/@@register')
-    >>> browser.getControl(name='form.username').value='username'
-    >>> browser.getControl(name='form.email').value='username@example.org'
-    >>> browser.getControl(name='form.password').value = SITE_OWNER_PASSWORD
-    >>> browser.getControl(name='form.password_ctl').value = SITE_OWNER_PASSWORD
+    >>> browser.getControl('User Name').value='username'
+    >>> browser.getControl('E-mail').value='username@example.org'
+    >>> browser.getControl('Password').value = SITE_OWNER_PASSWORD
+    >>> browser.getControl('Confirm password').value = SITE_OWNER_PASSWORD
     >>> browser.getControl('Register').click()
     >>> self.assertTrue('You have been registered.' in browser.contents)
 
@@ -67,13 +67,13 @@ Now we visit the registration form.  The user name field is no longer
 there:
 
     >>> browser.open('http://nohost/plone/@@register')
-    >>> self.assertRaises(LookupError, browser.getControl, name='username')
+    >>> self.assertRaises(LookupError, browser.getControl, 'User Name')
 
 We fill in the rest of the form:
 
-    >>> browser.getControl(name='form.email').value='email@example.org'
-    >>> browser.getControl(name='form.password').value = SITE_OWNER_PASSWORD
-    >>> browser.getControl(name='form.password_ctl').value = SITE_OWNER_PASSWORD
+    >>> browser.getControl('E-mail').value='email@example.org'
+    >>> browser.getControl('Password').value = SITE_OWNER_PASSWORD
+    >>> browser.getControl('Confirm password').value = SITE_OWNER_PASSWORD
     >>> browser.getControl('Register').click()
     >>> self.assertTrue('You have been registered.' in browser.contents)
 


### PR DESCRIPTION
z3cform uses different field names, so make these tests and the registered skin agnostic.

Possibly I should convert the skin into a view that lives in plone.app.users, but probably a different task.
