### PR TITLE
Do not use kss_field_decorator_view.

### DIFF
--- a/Products/CMFPlone/skins/plone_content/event_view.pt
+++ b/Products/CMFPlone/skins/plone_content/event_view.pt
@@ -9,9 +9,7 @@
 
 <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core"
-                        tal:define="kssClassesView context/@@kss_field_decorator_view;
-                                    getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
-                                    templateId template/getId;
+                        tal:define="templateId template/getId;
                                     toLocalizedTime nocall:context/@@plone/toLocalizedTime;">
 
         <div class="eventDetails vcard">
@@ -27,10 +25,8 @@
                                               i18n:translate="event_when_differentday">
                                 <abbr i18n:name="startdate"
                                       metal:define-macro="startdate-field-view"
-                                      tal:define="kss_class python:getKssClasses('startDate',
-                                                  templateId=templateId, macro='startdate-field-view');"
                                       id="parent-fieldname-startDate"
-                                      tal:attributes="class string:$kss_class dtstart;
+                                      tal:attributes="class string:$dtstart;
                                                       title python:context.start().ISO8601()">
                                   <span metal:define-slot="inside" class="explain">
                                     <span tal:replace="python:toLocalizedTime(context.start())">Start Date</span>
@@ -42,10 +38,8 @@
                                 <br i18n:name="linebreak" />
                                 <abbr i18n:name="enddate"
                                       metal:define-macro="enddate-field-view"
-                                      tal:define="kss_class python:getKssClasses('endDate',
-                                                  templateId=templateId, macro='enddate-field-view');"
                                       id="parent-fieldname-endDate"
-                                      tal:attributes="class string:$kss_class dtend;
+                                      tal:attributes="class string:$dtend;
                                                       title python:context.end().ISO8601()">
                                    <span metal:define-slot="inside" class="explain">
                                      <span tal:replace="python:toLocalizedTime(context.end())">End Date</span>
@@ -63,10 +57,8 @@
                                 <br i18n:name="linebreak" />
                                 from
                                 <abbr metal:define-macro="startdatesame-field-view"
-                                      tal:define="kss_class python:getKssClasses('startDate',
-                                                  templateId=templateId, macro='startdatesame-field-view');"
                                       id="parent-fieldname-startDate"
-                                      tal:attributes="class string:$kss_class dtstart;
+                                      tal:attributes="class string:$dtstart;
                                                       title python:context.start().ISO8601()"
                                       i18n:name="starttime">
                                       <span metal:define-slot="inside"
@@ -74,10 +66,8 @@
                                             tal:content="python:toLocalizedTime(context.start(), time_only=1)">Start Time</span>
                                 </abbr> to
                                 <abbr metal:define-macro="enddatesame-field-view"
-                                      tal:define="kss_class python:getKssClasses('endDate',
-                                                  templateId=templateId, macro='enddatesame-field-view');"
                                       id="parent-fieldname-endDate"
-                                      tal:attributes="class string:$kss_class dtend;
+                                      tal:attributes="class string:$dtend;
                                                       title python:context.end().ISO8601()"
                                       i18n:name="endtime">
                                       <span metal:define-slot="inside"

--- a/Products/CMFPlone/skins/plone_content/folder_listing.pt
+++ b/Products/CMFPlone/skins/plone_content/folder_listing.pt
@@ -10,19 +10,15 @@
 
 <metal:content-core fill-slot="content-core">
 <metal:block define-macro="content-core"
-                    tal:define="kssClassesView context/@@kss_field_decorator_view;
-                                getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
-                                templateId template/getId">
+                    tal:define="templateId template/getId">
 
     <div metal:define-macro="text-field-view"
          id="parent-fieldname-text" class="stx"
-         tal:define="kss_class python:getKssClasses('text',
-                     templateId=templateId, macro='text-field-view');
-                     has_text exists:context/aq_explicit/getText;
+         tal:define="has_text exists:context/aq_explicit/getText;
                      text python:has_text and here.getText() or ''"
          tal:condition="text"
          tal:attributes="class python:test(context.Format() in ('text/structured',
-                                               'text/x-rst', ), 'stx' + kss_class, 'plain' + kss_class)">
+                                               'text/x-rst', ), 'stx', 'plain')">
         <div metal:define-slot="inside" tal:replace="structure text">The body</div>
     </div>
 

--- a/Products/CMFPlone/skins/plone_content/image_view.pt
+++ b/Products/CMFPlone/skins/plone_content/image_view.pt
@@ -9,9 +9,7 @@
 <body>
     <metal:content-core fill-slot="content-core">
         <metal:block define-macro="content-core"
-                     tal:define="kssClassesView context/@@kss_field_decorator_view;
-                                 getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
-                                 size context/size;
+                     tal:define="size context/size;
                                  portal_state context/@@plone_portal_state;
                                  context_state context/@@plone_context_state;
                                  tag python:context.tag(scale='preview');

--- a/Products/CMFPlone/skins/plone_content/newsitem_view.pt
+++ b/Products/CMFPlone/skins/plone_content/newsitem_view.pt
@@ -9,9 +9,7 @@
 
 <metal:content-core fill-slot="content-core">
     <metal:block define-macro="content-core"
-          tal:define="kssClassesView context/@@kss_field_decorator_view;
-                      getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
-                      templateId template/getId;
+          tal:define="templateId template/getId;
                       text python:context.CookedBody(stx_level=2);
                       len_text python:len(text.strip())">
 
@@ -39,12 +37,10 @@
 
         <div metal:define-macro="text-field-view"
              id="parent-fieldname-text" class="stx"
-             tal:define="kss_class python:getKssClasses('text',
-                         templateId=templateId, macro='text-field-view');
-                         text text|context/getText|nothing"
+             tal:define="text text|context/getText|nothing"
              tal:condition="text"
              tal:attributes="class python:test(context.Format() in ('text/structured',
-                                                   'text/x-rst', ), 'stx' + kss_class, 'plain' + kss_class)">
+                                                   'text/x-rst', ), 'stx', 'plain')">
             <div metal:define-slot="inside" tal:replace="structure text">The body</div>
         </div>
     </metal:block>

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,9 @@ For what's new in this release, see CHANGES.txt.
 - Removed portal_interface tool (PLIP #13770)
   [ale-rt]
 
+- Removed kss_field_decorator_view support
+  [maurits, jaroel]
+
 4.3.3 (unreleased)
 ------------------
 


### PR DESCRIPTION
This is defined in Products.Archetypes, which is no longer a dependency.
