### PR TITLE
Fixed bug blocking adding portlets to content types from 'typesUseViewActionInListings' list.

### DIFF
--- a/Products/CMFPlone/browser/navigation.py
+++ b/Products/CMFPlone/browser/navigation.py
@@ -24,7 +24,7 @@ from plone.app.layout.navigation.navtree import buildFolderTree
 
 def get_url(item):
     if not item:
-        return None
+        return ''
     if hasattr(aq_base(item), 'getURL'):
         # Looks like a brain
         return item.getURL()
@@ -33,7 +33,7 @@ def get_url(item):
 
 def get_id(item):
     if not item:
-        return None
+        return ''
     getId = getattr(item, 'getId')
     if not utils.safe_callable(getId):
         # Looks like a brain

--- a/Products/CMFPlone/tests/typesUseViewActionInListings_with_portlet.txt
+++ b/Products/CMFPlone/tests/typesUseViewActionInListings_with_portlet.txt
@@ -1,0 +1,28 @@
+Portlets defined for content types with '/view'
+=====================================
+
+There is a problem with adding first portlet to content types added to 'typesUseViewActionInListings' site property.
+To confirm that problem is resolved we add 'Document' to the list::
+
+  >>> portal.portal_properties.site_properties.manage_changeProperties(typesUseViewActionInListings=('File', 'Document'))
+  
+
+Let's start with adding a page::
+
+  >>> self.loginAsPortalOwner()
+  >>> portal.invokeFactory('Document', 'testpage', title=u"Test document")
+  'testpage'
+
+
+Now add new portlet::
+
+    >>> testpage = self.portal.testpage
+    >>> from zope.component import getUtility
+    >>> from plone.portlets.interfaces import IPortletType
+    >>> portlet = getUtility(IPortletType, name='plone.portlet.static.Static')
+    >>> mapping = testpage.restrictedTraverse('++contextportlets++plone.leftcolumn')
+    >>> addview = mapping.restrictedTraverse('+/' + portlet.addview)
+    >>> output = addview()
+
+
+If bug is resolved that test will pass.


### PR DESCRIPTION
Fixed bug with adding the first portlet to objects if content type is added to typesUseViewActionInListings property. (Image and File by default.).
If portlet with edit form (i.e. calendar portlet is working) is added the error is raised as None is concatenated with string.