### PR TITLE
Update rolemap.xml

### DIFF
--- a/Products/CMFPlone/profiles/default/rolemap.xml
+++ b/Products/CMFPlone/profiles/default/rolemap.xml
@@ -78,6 +78,7 @@
       <role name="Member"/>
     </permission>
     <permission name="Mail forgotten password" acquire="True">
+      <role name="Manager"/>
       <role name="Site Administrator"/>
     </permission>
     <permission name="Manage properties" acquire="True">


### PR DESCRIPTION
Managers should also be granted to trigger a password-reset, see also: http://www.uwosh.edu/ploneprojects/docs/how-tos/mailing-forgotten-passwords-has-been-disabled-error
