### PR TITLE
fix passing 'show_inactive' to getFolderContents

### DIFF
--- a/Products/CMFPlone/skins/plone_scripts/getFolderContents.py
+++ b/Products/CMFPlone/skins/plone_scripts/getFolderContents.py
@@ -31,8 +31,11 @@ if contentFilter.get('path', None) is None:
     path['depth'] = 1
     contentFilter['path'] = path
 
-show_inactive = mtool.checkPermission(
-                    'Access inactive portal content', context)
+if 'show_inactive' in contentFilter:
+    show_inactive = contentFilter.get('show_inactive')
+else:
+    show_inactive = mtool.checkPermission(
+        'Access inactive portal content', context)
 
 # Provide batching hints to the catalog
 b_start = int(context.REQUEST.get('b_start', 0))

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 4.3.4 (unreleased)
 ------------------
 
+- Fix getFolderContents to no longer ignore 'show_inactive' in contentFilter.
+  This is part of a fix for https://dev.plone.org/ticket/8353.
+  [pbauer]
+
 - Fix link to the mail_password_form on the login_form for sites using VHM
   [fRiSi]
 


### PR DESCRIPTION
This is part 1 of a possible fix for https://dev.plone.org/ticket/8353, part 2 is https://github.com/plone/plone.app.content/pull/17 
