### PR TITLE
Retrieve flag var from right scope

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/unlockOnFormUnload.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/unlockOnFormUnload.js
@@ -33,7 +33,7 @@ plone.UnlockHandler = {
         // (formUnload.js) and signifies that we are in the
         // form submit process. This means: no unlock needed,
         // and it also would be harmful (ConflictError)
-        if (this.submitting) {return;}
+        if (plone.UnlockHandler.submitting) {return;}
         $.ajax({url: plone.UnlockHandler._baseUrl() + '/@@plone_lock_operations/safe_unlock', async: false});
     },
     

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -55,6 +55,10 @@ Changelog
   resources are registered in the portal_css tool
   [keul]
 
+- Small scoping fix in locking js code
+  [do3cc]
+
+
 4.3.3 (2014-02-19)
 ------------------
 - Fix incorrect use of dict get method in CatalogTool.search, introduced by


### PR DESCRIPTION
Thanks to sentry I found this bug.
When working on objects during creation (AT) and syndication is
enabled for this specific content type, submitting the form with failures
like missing name will result in errros in the backend, triggered by
safe_unlock. Safe_unlock should not be called on submitting forms
and there is unloadForm.js that sets the submitting variable in
unlockOnFormUnload.js. Unfortunately the variable was looked up in the
wrong context.
