### PR TITLE
Make inline validation of AT multiple selection widget work

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
@@ -38,7 +38,7 @@ jQuery(function ($) {
         }
 
         // if value is an Array, it will be send as value[]=value1&value[]=value2 by $.post
-        // turn it into something that will be useable or value will be considered omitted from the request
+        // turn it into something that will be useable or value will be omitted from the request
         params = $.param({uid: uid, fname: fname, value: value}, traditional=true)
 
         if ($field && uid && fname) {


### PR DESCRIPTION
Inline validation of multiple selection widget did not work because either nothing was selected and 'null' was sent as value to at_validate_field or if values were selected, the sent value key was turned into value[] and bunch of warnings like <p><strong>Invalid request</strong></p>  The parameter, <em>value</em>, was omitted from the request.<p> were displayed in the Zope log...

Please review and merge ;-)

Gauthier
