### PR TITLE
Fix to update last_compilation time on bundle build

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -240,7 +240,6 @@ class ResourceRegistryControlPanelView(RequireJsView):
         bundle = self.get_bundles().get(req.form['bundle'])
         if bundle:
             bundle.last_compilation = datetime.now()
-            bundle.jscompilation = '++plone++' + filepath
         return json.dumps({
             'success': True,
             'filepath': '++plone++' + filepath
@@ -256,7 +255,6 @@ class ResourceRegistryControlPanelView(RequireJsView):
         bundle = self.get_bundles().get(req.form['bundle'])
         if bundle:
             bundle.last_compilation = datetime.now()
-            bundle.csscompilation = '++plone++' + filepath
         return json.dumps({
             'success': True,
             'filepath': '++plone++' + filepath


### PR DESCRIPTION
Compiling bundle TTW does on currently last compilation time, which is required to update compiled resource URL for caches.

But I'm not sure is it ok to update also jscompilation and csscompilation paths. What would happen if one would delete the override later?
