### PR TITLE
Add a registry key for the i18n-wrapper in mockup.

### DIFF
--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -624,6 +624,10 @@
       <value key="js">++resource++mockupjs/i18n.js</value>
   </records>
 
+  <records prefix="plone.resources/translate"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++resource++mockupjs/i18n-wrapper</value>
+  </records>
 
  <!-- Patterns -->
 


### PR DESCRIPTION
This pull request is related to the one in mockup.
We add here a new registry entry for the i18n wrapper.

Please read: https://github.com/plone/mockup/pull/452
