### PR TITLE
fix markup for user/group control panel nav

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/controlpanel_usergroups_layout.pt
+++ b/Products/CMFPlone/controlpanel/browser/controlpanel_usergroups_layout.pt
@@ -23,35 +23,23 @@
     Portal status message
   </div>
 
-  <div id="layout-contents">
+  <div id="content-core">
 
-      <div id="edit-bar">
-          <ul class="contentViews" id="content-views">
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-userprefs"
-                 i18n:translate="label_users">Users</a>
-            </li>
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                 i18n:translate="label_groups">Groups</a>
-            </li>
-            <li class="selected">
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@usergroup-controlpanel"
-                 i18n:translate="label_usergroup_settings">Settings</a>
-            </li>
-            <li>
-              <a href=""
-                 tal:attributes="href string:$portal_url/@@member-registration"
-                 i18n:translate="label_member_registration">Member Registration</a>
-            </li>
-          </ul>
-          <div class="contentActions">&nbsp;</div>
+    <div class="autotabs">
+      <div class="autotoc-nav">
+        <a href="${portal_url}/@@usergroup-userprefs"
+           i18n:translate="label_users">Users</a>
+        <a href="${portal_url}/@@usergroup-groupprefs"
+           i18n:translate="label_groups">Groups</a>
+        <a class="active"
+           href="${portal_url}/@@usergroup-controlpanel"
+           i18n:translate="label_usergroup_settings">Settings</a>
+        <a href="${portal_url}/@@member-registration"
+           i18n:translate="label_member_registration">Member Registration</a>
       </div>
+      <span tal:replace="structure view/contents" />
+    </div>
 
-    <span tal:replace="structure view/contents" />
   </div>
 
 </div>

--- a/Products/CMFPlone/controlpanel/browser/usergroups.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups.py
@@ -21,7 +21,7 @@ from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 class UserGroupsSettingsControlPanel(AutoExtensibleForm, form.EditForm):
     schema = IUserGroupsSettingsSchema
     id = "usergroupsettings-control-panel"
-    label = _("User/Groups settings")
+    label = _("Users and Groups")
     description = _("User and groups settings for this site.")
     form_name = _("User/Groups settings")
     control_panel_view = "usergroups-controlpanel"

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupdetails.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupdetails.pt
@@ -14,239 +14,211 @@
                  groupquery python:view.makeQuery(groupname=view.groupname);
                  groupkeyquery python:view.makeQuery(key=view.groupname)">
 
-    <div class="documentEditable">
-        <!-- simulating views on the groups/user pages until we have real objects. -->
-        <div id="edit-bar" tal:condition="view/group">
-            <ul class="contentViews" id="content-views">
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@usergroup-groupmembership?${groupquery}"
-                   i18n:translate="label_group_members">Group Members</a>
-              </li>
-              <li class="selected">
-                <a href=""
-                   tal:attributes="href string:$portal_url/${template_id}?${groupquery}"
-                   i18n:translate="label_group_properties">Group Properties</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:${portal_url}/@@manage-group-portlets?${groupkeyquery}"
-                   i18n:translate="label_group_portlets">Group Portlets</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:${portal_url}/@@manage-group-dashboard?${groupkeyquery}"
-                   i18n:translate="label_group_dashboard">Group Dashboard</a>
-              </li>
 
-            </ul>
+  <!-- When no group is specified, this gets used as the add group page page -->
+  <article id="content" tal:condition="not:view/group">
+      <metal:block metal:use-macro="template/macros/props">
+          <metal:title metal:fill-slot="content-title">
+              <h1 class="documentFirstHeading"
+                  i18n:translate="heading_create_group">Create a Group</h1>
+          </metal:title>
 
-            <div class="contentActions">&nbsp;</div>
+          <metal:name metal:fill-slot="name">
+              <div class="field">
+                  <label for="addname" i18n:translate="label_name">Name</label>
+
+                  <span class="fieldRequired" title="Required"
+                        i18n:attributes="title title_required;"
+                        i18n:translate="label_required">(Required)</span>
+
+                   <div class="formHelp" i18n:translate="help_groupname">
+                   A unique identifier for the group. Can not be changed after creation.
+                   </div>
+
+                  <input type="text" name="addname" value="groupname"
+                         id="addname"
+                         tal:attributes="value view/groupname | string:"/>
+              </div>
+          </metal:name>
+      </metal:block>
+  </article>
+
+  <article id="content" tal:condition="view/group | nothing">
+    <metal:block define-macro="props">
+
+      <a href="${portal_url}/@@usergroup-groupprefs"
+         class="link-parent"
+         i18n:translate="label_up_to_groups_overview">
+         Up to Groups Overview
+      </a>
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_edit_groupproperties"
+          metal:define-slot="content-title">Group: ${view/grouptitle|nothing}</h1>
+
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+        Portal status message
+      </div>
+
+      <div id="content-core">
+        <div class="autotabs">
+         
+          <nav class="autotoc-nav">
+            <a href="${portal_url}/@@usergroup-groupmembership?${groupquery}"
+               i18n:translate="label_group_members">Group Members</a>
+            <a class="active"
+               href="${portal_url}/@@usergroup-groupdetails?${groupquery}"
+               i18n:translate="label_group_properties">Group Properties</a>
+            <a href="${portal_url}/@@manage-group-portlets?${groupkeyquery}"
+               i18n:translate="label_group_portlets">Group Portlets</a>
+            <a href="${portal_url}/@@manage-group-dashboard?${groupkeyquery}"
+               i18n:translate="label_group_dashboard">Group Dashboard</a>
+          </nav>
+
+          <form action=""
+                id="createGroup"
+                name="groups"
+                method="post"
+                class="enableUnloadProtection enableAutoFocus"
+                tal:attributes="action string:$portal_url/$template_id"
+                tal:define="targetobject context/portal_groupdata;
+                            targetGetProperty nocall:view/group/getProperty | nocall:context/returnNone;">
+
+              <fieldset>
+                  <div class="field" metal:define-slot="name">
+                     <label for="groupname" i18n:translate="label_name">Name</label>
+
+                     <div tal:content="view/groupname | string:" />
+                     <input type="hidden" name="groupname" value="groupname"
+                            id="groupname"
+                            tal:attributes="value view/groupname | string:"/>
+                  </div>
+
+                   <tal:set tal:condition="targetobject/management_page_charset|nothing"
+                            tal:define="dummy python:request.set('management_page_charset_tag','')" />
+
+                   <tal:set tal:condition="not:targetobject/management_page_charset|nothing">
+                      <tal:defines define="dummy python:request.set('management_page_charset','UTF-8');
+                                           dummy python:request.set('management_page_charset_tag','UTF-8:');" />
+                   </tal:set>
+
+                  <tal:properties repeat="property targetobject/propertyMap">
+                      <div class="field"
+                           tal:define="id property/id;
+                                       type property/type;
+                                       propertyvalue python:targetGetProperty(id, None);">
+
+                      <label for="value"
+                              tal:attributes="for id"
+                              i18n:translate=""
+                              tal:content="python:targetobject.propertyLabel(id).capitalize()">Property Value</label>
+
+                      <div tal:define="propertyitem python:targetobject.getProperty(id);
+                                       disabled python:None if (not view.group or view.group.canWriteProperty(id)) else 'disabled';"
+                      tal:condition="python:'w' in property.get('mode', 'awd')">
+
+                      <input type="text" name="id" size="35"
+                              tal:condition="python:type in ('int', 'long')"
+                              tal:attributes="name string:$id:$type;
+                                              id id;
+                                              value python:propertyvalue if propertyvalue else '';
+                                              disabled disabled;" />
+
+                      <input type="text" name="id" size="35"
+                              tal:condition="python:type in ('float','date')"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
+                                              id id;
+                                              value python:propertyvalue if propertyvalue else '';
+                                              disabled disabled;" />
+
+                      <input type="text" name="string and ustring" size="35"
+                              tal:condition="python:type in ('string','ustring')"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
+                                              id id;
+                                              value python:propertyvalue if propertyvalue else '';
+                                              disabled disabled;" />
+
+                      <input type="checkbox"
+                              class="noborder"
+                              name="id"
+                              id="cb-checkbox"
+                              tal:condition="python: type in ('boolean',)"
+                              tal:attributes="name string:$id:$type;
+                                              id id;
+                                              checked python:'checked' if propertyvalue else '';
+                                              disabled disabled;" />
+
+                      <input name="tokens and utokens" value="" type="text" size="35"
+                              tal:condition="python:type in ('tokens', 'utokens')"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
+                                              value python:propertyvalue if propertyvalue else '';
+                                              disabled disabled;" />
+
+                      <textarea name="text and utext"
+                              rows="6"
+                              cols="35"
+                              tal:condition="python: type in ('text', 'utext')"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
+                                              disabled disabled;"
+                              tal:content="propertyvalue">some data</textarea>
+
+                      <textarea name="lines and ulines"
+                              rows="6"
+                              cols="35"
+                              tal:condition="python: type in ('lines', 'ulines')"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
+                                              disabled disabled;"
+                              tal:content="python: propertyvalue and '\n'.join(propertyvalue) or ''">
+                      </textarea>
+
+
+                      <tal:selections tal:condition="python:type in ('selection', 'multiple selection')"
+                                      tal:define="select_variable python:property.get('select_variable','');
+                                      select_value python:select_variable and path('context/%s' %select_variable) or [];">
+
+                      <select name="selection" tal:condition="python:type in ('selection',)"
+                          tal:attributes="name string:$id:${request/management_page_charset_tag}text;
+                                          disabled disabled;">
+                          <tal:values repeat="option select_value">
+                              <option tal:attributes="SELECTED python:'SELECTED' if propertyvalue==option else ''"
+                                  tal:content="option">value</option>
+                          </tal:values>
+                      </select>
+
+                      <select name="multiple selection" multiple="multiple" tal:condition="python:type in ('multiple selection',)"
+                              tal:attributes="name string:$id:${request/management_page_charset_tag}list:string;
+                                              size python:min(7, len(select_value));
+                                              disabled disabled;">
+                          <tal:values repeat="option select_value">
+                              <option tal:attributes="SELECTED python:'selected' if (propertyvalue and option in propertyvalue) else ''"
+                                      tal:content="option">value</option>
+                          </tal:values>
+                      </select>
+
+                      </tal:selections>
+
+                      </div>
+
+                      </div>
+                  </tal:properties>
+
+                  <input type="hidden" name="form.submitted" value="1" />
+
+                  <div class="formControls">
+                      <input class="context"
+                             type="submit"
+                             name="form.button.Save"
+                             value="Save"
+                             i18n:attributes="value label_save;" />
+                  </div>
+              </fieldset>
+
+              <input tal:replace="structure context/@@authenticator/authenticator" />
+          </form>
         </div>
-
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-          Portal status message
-        </div>
-
-        <!-- When no group is specified, this gets used as the add group page page -->
-        <article id="content" tal:condition="not:view/group">
-            <metal:block metal:use-macro="template/macros/props">
-                <metal:title metal:fill-slot="content-title">
-                    <h1 class="documentFirstHeading"
-                        i18n:translate="heading_create_group">Create a Group</h1>
-                </metal:title>
-
-                <metal:name metal:fill-slot="name">
-                    <div class="field">
-                        <label for="addname" i18n:translate="label_name">Name</label>
-
-                        <span class="fieldRequired" title="Required"
-                              i18n:attributes="title title_required;"
-                              i18n:translate="label_required">(Required)</span>
-
-                         <div class="formHelp" i18n:translate="help_groupname">
-                         A unique identifier for the group. Can not be changed after creation.
-                         </div>
-
-                        <input type="text" name="addname" value="groupname"
-                               id="addname"
-                               tal:attributes="value view/groupname | string:"/>
-                    </div>
-                </metal:name>
-            </metal:block>
-        </article>
-
-        <article id="content" tal:condition="view/group | nothing">
-            <metal:block define-macro="props">
-
-                <h1 class="documentFirstHeading"
-                    i18n:translate="heading_edit_groupproperties"
-                    metal:define-slot="content-title">
-                    Edit Group Properties for <span tal:content="view/grouptitle | default" tal:omit-tag="" i18n:name="groupname">unavailable</span>
-                </h1>
-
-                <div class="documentDescription" i18n:translate="description_edit_groupproperties">
-                Groups are logical collections of users, like departments and business units.
-                They are not directly related to permissions on a global level, you normally
-                use Roles for that - and let certain Groups have a particular role.
-                </div>
-
-                <div id="content-core">
-                    <a href=""
-                       class="link-parent"
-                       tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                       i18n:translate="label_up_to_groups_overview">
-                       Up to Groups Overview
-                    </a>
-
-                    <form action=""
-                          id="createGroup"
-                          name="groups"
-                          method="post"
-                          class="enableUnloadProtection enableAutoFocus"
-                          tal:attributes="action string:$portal_url/$template_id"
-                          tal:define="targetobject context/portal_groupdata;
-                                      targetGetProperty nocall:view/group/getProperty | nocall:context/returnNone;">
-
-                        <fieldset>
-                            <legend i18n:translate="link_group_properties">Group Properties</legend>
-
-                            <div class="field" metal:define-slot="name">
-                               <label for="groupname" i18n:translate="label_name">Name</label>
-
-                               <div tal:content="view/groupname | string:" />
-                               <input type="hidden" name="groupname" value="groupname"
-                                      id="groupname"
-                                      tal:attributes="value view/groupname | string:"/>
-                            </div>
-
-                             <tal:set tal:condition="targetobject/management_page_charset|nothing"
-                                      tal:define="dummy python:request.set('management_page_charset_tag','')" />
-
-                             <tal:set tal:condition="not:targetobject/management_page_charset|nothing">
-                                <tal:defines define="dummy python:request.set('management_page_charset','UTF-8');
-                                                     dummy python:request.set('management_page_charset_tag','UTF-8:');" />
-                             </tal:set>
-
-                            <tal:properties repeat="property targetobject/propertyMap">
-                                <div class="field"
-                                     tal:define="id property/id;
-                                                 type property/type;
-                                                 propertyvalue python:targetGetProperty(id, None);">
-
-                                <label for="value"
-                                        tal:attributes="for id"
-                                        i18n:translate=""
-                                        tal:content="python:targetobject.propertyLabel(id).capitalize()">Property Value</label>
-
-                                <div tal:define="propertyitem python:targetobject.getProperty(id);
-                                                 disabled python:None if (not view.group or view.group.canWriteProperty(id)) else 'disabled';"
-                                tal:condition="python:'w' in property.get('mode', 'awd')">
-
-                                <input type="text" name="id" size="35"
-                                        tal:condition="python:type in ('int', 'long')"
-                                        tal:attributes="name string:$id:$type;
-                                                        id id;
-                                                        value python:propertyvalue if propertyvalue else '';
-                                                        disabled disabled;" />
-
-                                <input type="text" name="id" size="35"
-                                        tal:condition="python:type in ('float','date')"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
-                                                        id id;
-                                                        value python:propertyvalue if propertyvalue else '';
-                                                        disabled disabled;" />
-
-                                <input type="text" name="string and ustring" size="35"
-                                        tal:condition="python:type in ('string','ustring')"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
-                                                        id id;
-                                                        value python:propertyvalue if propertyvalue else '';
-                                                        disabled disabled;" />
-
-                                <input type="checkbox"
-                                        class="noborder"
-                                        name="id"
-                                        id="cb-checkbox"
-                                        tal:condition="python: type in ('boolean',)"
-                                        tal:attributes="name string:$id:$type;
-                                                        id id;
-                                                        checked python:'checked' if propertyvalue else '';
-                                                        disabled disabled;" />
-
-                                <input name="tokens and utokens" value="" type="text" size="35"
-                                        tal:condition="python:type in ('tokens', 'utokens')"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
-                                                        value python:propertyvalue if propertyvalue else '';
-                                                        disabled disabled;" />
-
-                                <textarea name="text and utext"
-                                        rows="6"
-                                        cols="35"
-                                        tal:condition="python: type in ('text', 'utext')"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
-                                                        disabled disabled;"
-                                        tal:content="propertyvalue">some data</textarea>
-
-                                <textarea name="lines and ulines"
-                                        rows="6"
-                                        cols="35"
-                                        tal:condition="python: type in ('lines', 'ulines')"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}$type;
-                                                        disabled disabled;"
-                                        tal:content="python: propertyvalue and '\n'.join(propertyvalue) or ''">
-                                </textarea>
-
-
-                                <tal:selections tal:condition="python:type in ('selection', 'multiple selection')"
-                                                tal:define="select_variable python:property.get('select_variable','');
-                                                select_value python:select_variable and path('context/%s' %select_variable) or [];">
-
-                                <select name="selection" tal:condition="python:type in ('selection',)"
-                                    tal:attributes="name string:$id:${request/management_page_charset_tag}text;
-                                                    disabled disabled;">
-                                    <tal:values repeat="option select_value">
-                                        <option tal:attributes="SELECTED python:'SELECTED' if propertyvalue==option else ''"
-                                            tal:content="option">value</option>
-                                    </tal:values>
-                                </select>
-
-                                <select name="multiple selection" multiple="multiple" tal:condition="python:type in ('multiple selection',)"
-                                        tal:attributes="name string:$id:${request/management_page_charset_tag}list:string;
-                                                        size python:min(7, len(select_value));
-                                                        disabled disabled;">
-                                    <tal:values repeat="option select_value">
-                                        <option tal:attributes="SELECTED python:'selected' if (propertyvalue and option in propertyvalue) else ''"
-                                                tal:content="option">value</option>
-                                    </tal:values>
-                                </select>
-
-                                </tal:selections>
-
-                                </div>
-
-                                </div>
-                            </tal:properties>
-
-                            <input type="hidden" name="form.submitted" value="1" />
-
-                            <div class="formControls">
-                                <input class="context"
-                                       type="submit"
-                                       name="form.button.Save"
-                                       value="Save"
-                                       i18n:attributes="value label_save;" />
-                            </div>
-                        </fieldset>
-
-                        <input tal:replace="structure context/@@authenticator/authenticator" />
-                    </form>
-                </div>
-            </metal:block>
-        </article>
-
-
-    </div>
+      </div>
+    </metal:block>
+  </article>
 
 </metal:main>
 

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -19,325 +19,305 @@
                  b_start python:0 if showAll or view.newSearch else view.atoi(request.get('b_start',0));
                  b_start python:b_start if b_start &lt;= resultcount else resultcount - resultcount % b_size;
                  b_start python:b_start if b_start &lt; resultcount else max(b_start - b_size, 0);
-                 portal_url context/portal_url;">
+                 portal_url context/portal_url;
+                 groupquery python:view.makeQuery(groupname=view.groupname);
+                 groupkeyquery python:view.makeQuery(key=view.groupname);">
 
-    <div class="documentEditable">
-        <!-- simulating views on the groups/user pages until we have real objects. -->
-        <div id="edit-bar">
-            <ul class="contentViews" id="content-views">
-              <li class="selected">
-                    <a href=""
-                   tal:attributes="href string:$portal_url/${template_id}?${view/groupquery}"
-                   i18n:translate="label_group_members">Group Members</a>
-              </li>
-              <li>
-                    <a href=""
-                   tal:attributes="href string:${portal_url}/@@usergroup-groupdetails?${view/groupquery}"
-                       i18n:translate="label_group_properties">Group Properties</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:${portal_url}/@@manage-group-portlets?${view/groupkeyquery}"
-                   i18n:translate="label_group_portlets">Group Portlets</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:${portal_url}/@@manage-group-dashboard?${view/groupkeyquery}"
-                   i18n:translate="label_group_dashboard">Group Dashboard</a>
-              </li>
-            </ul>
+  <article id="content">
 
-            <div class="contentActions">
-              &nbsp;
-            </div>
-        </div>
+    <a href=""
+       class="link-parent"
+       tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
+       i18n:translate="label_up_to_groups_overview">
+      Up to Groups Overview
+    </a>
 
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-          Portal status message
-        </div>
+    <tal:ifnogroups tal:condition="not:view/group | nothing">
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_group_members">Group Members</h1>
 
-        <article id="content">
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+        Portal status message
+      </div>
 
-            <tal:ifnogroups tal:condition="not:view/group | nothing">
-              <h1 class="documentFirstHeading"
-                  i18n:translate="heading_group_members">Group Members</h1>
+      <div id="content-core">
+        <p i18n:translate="label_no_group_specified">No group was specified.</p>
+        <p>
+          <a href="@@usergroup-groupprefs" i18n:translate="label_find_group">Find a group here</a>
+        </p>
+      </div>
+    </tal:ifnogroups>
 
-              <div id="content-core">
-                  <a href=""
-                     class="link-parent"
-                     tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                     i18n:translate="label_up_to_groups_overview">
-                    Up to Groups Overview
-                  </a>
+    <tal:ifgroups tal:condition="view/group | nothing">
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_group_members_of">Group: ${view/grouptitle}</h1>
 
-                  <p i18n:translate="label_no_group_specified">No group was specified.</p>
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+        Portal status message
+      </div>
 
-                  <p>
-                    <a href="@@usergroup-groupprefs" i18n:translate="label_find_group">Find a group here</a>
-                  </p>
-              </div>
-            </tal:ifnogroups>
+      <div id="content-core">
 
-            <tal:ifgroups tal:condition="view/group | nothing">
-              <h1 class="documentFirstHeading"
-                  i18n:translate="heading_group_members_of">
-                  Members of the <span tal:content="view/grouptitle" tal:omit-tag="" i18n:name="groupname">Groupname</span> group
-              </h1>
+        <div class="autotabs">
+         
+          <nav class="autotoc-nav">
+            <a class="active"
+               href="${portal_url}/@@usergroup-groupmembership?${groupquery}"
+               i18n:translate="label_group_members">Group Members</a>
+            <a href="${portal_url}/@@usergroup-groupdetails?${groupquery}"
+               i18n:translate="label_group_properties">Group Properties</a>
+            <a href="${portal_url}/@@manage-group-portlets?${groupkeyquery}"
+               i18n:translate="label_group_portlets">Group Portlets</a>
+            <a href="${portal_url}/@@manage-group-dashboard?${groupkeyquery}"
+               i18n:translate="label_group_dashboard">Group Dashboard</a>
+          </nav>
 
-              <div id="content-core">
-                  <a href=""
-                     class="link-parent"
-                     tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                     i18n:translate="label_up_to_groups_overview">
-                    Up to Groups Overview
-                  </a>
+          <p i18n:translate="description_group_members_of">
+            You can add or remove groups and users from this particular group here. Note that this
+            doesn't actually delete the group or user, it is only removed from this group.
+          </p>
 
-                  <p i18n:translate="description_group_members_of">
-                    You can add or remove groups and users from this particular group here. Note that this
-                    doesn't actually delete the group or user, it is only removed from this group.
-                  </p>
+          <form action=""
+                    name="groups"
+                    method="post"
+                    tal:attributes="action string:$portal_url/$template_id?groupname=${view/groupname}"
+                    tal:define="batch python:Batch(view.searchResults, b_size, int(b_start));
+                                batchformkeys python:['searchstring','_authenticator','groupname','form.submitted'];
+                                many_users view/many_users">
+            <h2 i18n:translate="heading_groupmembers_current">Current group members</h2>
+              <table class="listing" summary="Group Members Listing"
+                 tal:condition="view/groupMembers">
 
-                  <form action=""
-                            name="groups"
-                            method="post"
-                            tal:attributes="action string:$portal_url/$template_id?groupname=${view/groupname}"
-                            tal:define="batch python:Batch(view.searchResults, b_size, int(b_start));
-                                        batchformkeys python:['searchstring','_authenticator','groupname','form.submitted'];
-                                        many_users view/many_users">
-                    <h2 i18n:translate="heading_groupmembers_current">Current group members</h2>
-                      <table class="listing" summary="Group Members Listing"
-                         tal:condition="view/groupMembers">
+                  <tr>
+                      <th>
+                          <input class="noborder"
+                                 type="checkbox"
+                                 src="select_all_icon.png"
+                                 name="selectButton"
+                                 title="Select all items"
+                                 onClick="toggleSelect(this, 'delete:list');"
+                                 tal:attributes="src string:$portal_url/select_all_icon.png"
+                                 alt="Select all items"
+                                 i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                                 <!--Remove user from this group-->
+                      </th>
+                      <th i18n:translate="listingheader_user_name">User name</th>
+                      <th i18n:translate="listingheader_email_address">E-mail Address</th>
+                  </tr>
 
-                          <tr>
-                              <th>
-                                  <input class="noborder"
-                                         type="checkbox"
-                                         src="select_all_icon.png"
-                                         name="selectButton"
-                                         title="Select all items"
-                                         onClick="toggleSelect(this, 'delete:list');"
-                                         tal:attributes="src string:$portal_url/select_all_icon.png"
-                                         alt="Select all items"
-                                         i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
-                                         <!--Remove user from this group-->
-                              </th>
-                              <th i18n:translate="listingheader_user_name">User name</th>
-                              <th i18n:translate="listingheader_email_address">E-mail Address</th>
-                          </tr>
+                  <tal:block tal:repeat="this_user view/groupMembers">
+                    <tr tal:condition="python:this_user is not None"
+                        tal:define="oddrow repeat/this_user/odd"
+                        tal:attributes="class python:oddrow and 'odd' or 'even'">
+                        <td class="listingCheckbox">
+                            <input
+                                   type="checkbox"
+                                   class="noborder notify"
+                                   name="delete:list"
+                                   tal:attributes="value this_user/getId;
+                                                   disabled python:this_user.canRemoveFromGroup(view.groupname) and default or 'disabled'" />
+                        </td>
 
-                          <tal:block tal:repeat="this_user view/groupMembers">
-                            <tr tal:condition="python:this_user is not None"
-                                tal:define="oddrow repeat/this_user/odd"
-                                tal:attributes="class python:oddrow and 'odd' or 'even'">
-                                <td class="listingCheckbox">
-                                    <input
-                                           type="checkbox"
-                                           class="noborder notify"
-                                           name="delete:list"
-                                           tal:attributes="value this_user/getId;
-                                                           disabled python:this_user.canRemoveFromGroup(view.groupname) and default or 'disabled'" />
-                                </td>
-
-                                <tal:block tal:condition="python: view.isGroup(this_user)">
-                                  <td>
-                                    <img src="group.png" alt="" />
-                                    <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())" >
-                                      <span tal:replace="this_user/getGroupTitleOrName | default" />
-                                      (<span tal:replace="this_user/id" />)
-                                    </a>
-                                  </td>
-                                </tal:block>
-
-                                <tal:block tal:condition="python: not view.isGroup(this_user)">
-                                  <td>
-                                    <img src="user.png" alt="" />
-                                    <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
-                                                               title this_user/getId">
-                                        <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
-                                        <tal:userid tal:condition="not:view/email_as_username">
-                                            (<span tal:replace="this_user/getUserName | default" />)
-                                        </tal:userid>
-                                    </a>
-                                  </td>
-                                </tal:block>
-
-                                <td tal:define="email python: this_user.getProperty('email')">
-                                    <a  href="#"
-                                        tal:attributes="href string:mailto:${email}"
-                                        title="Send a mail to this user"
-                                        i18n:attributes="title title_send_mail_to_user;"
-                                        tal:condition="email">
-                                        <span tal:replace="email" />
-                                    </a>
-                                </td>
-                            </tr>
-                          </tal:block>
-                      </table>
-
-
-                      <p tal:condition="not:view/groupMembers" i18n:translate="decription_no_members_assigned">There is no group or user attached to this group.</p>
-
-                      <input class="destructive"
-                             type="submit"
-                             name="form.button.Edit"
-                             value="Remove selected groups / users"
-                             i18n:attributes="value label_remove_selected_users;"
-                             tal:condition="view/groupMembers" />
-
-                    <tal:addusers tal:condition="view/canAddUsers">
-
-                        <h2 i18n:translate="heading_search_newmembers">Search for new group members</h2>
-
-                        <input type="hidden" name="form.submitted" value="1" />
-
-                        <table class="listing" summary="Groups">
-                          <tr>
-                            <th colspan="3">
-                              <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
-                                <input class="quickSearch"
-                                       type="text"
-                                       name="searchstring"
-                                       value=""
-                                       tal:attributes="value view/searchString;"
-                                       />
-
-                                <input type="submit"
-                                       class="searchButton"
-                                       name="form.button.Search"
-                                       value="Search"
-                                       i18n:attributes="value label_search;" />
-                                <input type="submit"
-                                       class="searchButton"
-                                       name="form.button.FindAll"
-                                       value="Show all"
-                                       i18n:attributes="value label_search_large;"
-                                       tal:condition="not:many_users" />
-                            </th>
-                          </tr>
-                          <tr tal:condition="batch">
-                            <th>
-                                <input class="noborder"
-                                       type="checkbox"
-                                       src="select_all_icon.png"
-                                       name="selectButton"
-                                       title="Select all items"
-                                       onClick="toggleSelect(this, 'add:list');"
-                                       tal:attributes="src string:$portal_url/select_all_icon.png"
-                                       alt="Select all items"
-                                       i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
-                            </th>
-
-                            <th i18n:translate="listingheader_group_user_name">Group/User name</th>
-                            <th i18n:translate="listingheader_email_address">E-mail Address</th>
-                          </tr>
-
-                          <tal:block repeat="this_user batch">
-                            <tr tal:define="oddrow repeat/this_user/odd"
-                                tal:condition="python:this_user is not None"
-                                tal:attributes="class python:oddrow and 'odd' or 'even'">
-
-                              <td class="listingCheckbox">
-                                <input type="checkbox"
-                                       class="noborder"
-                                       name="add:list"
-                                       value="value"
-                                       tal:attributes="value this_user/getId;
-                                                       disabled python:this_user.canAddToGroup(view.groupname) and default or 'disabled'" />
-                              </td>
-
-                              <td>
-                                  <tal:block tal:condition="python:not view.isGroup(this_user)">
-                                      <img src="user.png" alt="" />
-                                      <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
-                                                                 title this_user/getId">
-                                        <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
-                                        <tal:userid tal:condition="not:view/email_as_username">
-                                            (<span tal:replace="this_user/getUserName | default" />)
-                                        </tal:userid>
-                                      </a>
-                                  </tal:block>
-                                  <tal:block tal:condition="python: view.isGroup(this_user)">
-                                      <img src="group.png" alt="" />
-                                      <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())">
-                                          <span tal:replace="this_user/getGroupTitleOrName | default" />
-                                          (<span tal:replace="this_user/id | default" />)
-                                      </a>
-                                  </tal:block>
-                              </td>
-                              <td tal:define="email python: this_user.getProperty('email')">
-                                  <a  href="#"
-                                      tal:attributes="href string:mailto:${email}"
-                                      title="Send a mail to this user"
-                                      i18n:attributes="title title_send_mail_to_user;"
-                                      tal:condition="email">
-                                      <span tal:replace="email" />
-                                  </a>
-                              </td>
-                            </tr>
-                          </tal:block>
-
-                          <tr tal:condition="not:batch">
-
-                            <td tal:condition="view/searchString"
-                              i18n:translate="text_nomatches"
-                              style="text-align:center;">No matches</td>
-
-                            <tal:block tal:condition="not:view/searchString">
-                              <td tal:condition="site_properties/many_users"
-                                class="discreet"
-                                i18n:translate="text_no_searchstring_large"
-                                style="text-align:center; font-size: 100%;">
-                                Enter a group or user name to search for.
-                              </td>
-                              <td tal:condition="not:site_properties/many_users"
-                                class="discreet"
-                                i18n:translate="text_no_searchstring"
-                                style="text-align:center; font-size: 100%;">
-                                Enter a group or user name to search for or click 'Show All'.
-                              </td>
-                            </tal:block>
-
-                          </tr>
-
-                        </table>
-
-                        <input type="hidden" value="b_start" name="b_start"
-                               tal:attributes="value b_start"/>
-
-                        <input type="hidden" value="" name="showAll"
-                               tal:attributes="value showAll"/>
-
-                        <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                        <div class="showAllSearchResults"
-                             tal:condition="python:batch.next or batch.previous"
-                             tal:define="mq python:modules['ZTUtils'].make_query;
-                                         keys batchformkeys|nothing;
-                                         linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                         url batch_base_url | string:${context/absolute_url}/${template_id}">
-                            <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                               i18n:translate="description_pas_show_all_search_results">
-                                Show all search results
+                        <tal:block tal:condition="python: view.isGroup(this_user)">
+                          <td>
+                            <img src="group.png" alt="" />
+                            <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())" >
+                              <span tal:replace="this_user/getGroupTitleOrName | default" />
+                              (<span tal:replace="this_user/id" />)
                             </a>
-                        </div>
+                          </td>
+                        </tal:block>
 
-                        <input class="context"
-                                type="submit"
-                                name="form.button.Add"
-                                value="Add selected groups and users to this group"
-                                tal:condition="batch"
-                                i18n:attributes="value label_add_users_to_group;" />
+                        <tal:block tal:condition="python: not view.isGroup(this_user)">
+                          <td>
+                            <img src="user.png" alt="" />
+                            <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
+                                                       title this_user/getId">
+                                <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
+                                <tal:userid tal:condition="not:view/email_as_username">
+                                    (<span tal:replace="this_user/getUserName | default" />)
+                                </tal:userid>
+                            </a>
+                          </td>
+                        </tal:block>
 
-                    </tal:addusers>
+                        <td tal:define="email python: this_user.getProperty('email')">
+                            <a  href="#"
+                                tal:attributes="href string:mailto:${email}"
+                                title="Send a mail to this user"
+                                i18n:attributes="title title_send_mail_to_user;"
+                                tal:condition="email">
+                                <span tal:replace="email" />
+                            </a>
+                        </td>
+                    </tr>
+                  </tal:block>
+              </table>
 
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
 
-                  </form>
-              </div>
-            </tal:ifgroups>
+              <p tal:condition="not:view/groupMembers" i18n:translate="decription_no_members_assigned">There is no group or user attached to this group.</p>
 
-        </article>
-    </div>
+              <input class="destructive"
+                     type="submit"
+                     name="form.button.Edit"
+                     value="Remove selected groups / users"
+                     i18n:attributes="value label_remove_selected_users;"
+                     tal:condition="view/groupMembers" />
+
+            <tal:addusers tal:condition="view/canAddUsers">
+
+                <h2 i18n:translate="heading_search_newmembers">Search for new group members</h2>
+
+                <input type="hidden" name="form.submitted" value="1" />
+
+                <table class="listing" summary="Groups">
+                  <tr>
+                    <th colspan="3">
+                      <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
+                        <input class="quickSearch"
+                               type="text"
+                               name="searchstring"
+                               value=""
+                               tal:attributes="value view/searchString;"
+                               />
+
+                        <input type="submit"
+                               class="searchButton"
+                               name="form.button.Search"
+                               value="Search"
+                               i18n:attributes="value label_search;" />
+                        <input type="submit"
+                               class="searchButton"
+                               name="form.button.FindAll"
+                               value="Show all"
+                               i18n:attributes="value label_search_large;"
+                               tal:condition="not:many_users" />
+                    </th>
+                  </tr>
+                  <tr tal:condition="batch">
+                    <th>
+                        <input class="noborder"
+                               type="checkbox"
+                               src="select_all_icon.png"
+                               name="selectButton"
+                               title="Select all items"
+                               onClick="toggleSelect(this, 'add:list');"
+                               tal:attributes="src string:$portal_url/select_all_icon.png"
+                               alt="Select all items"
+                               i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                    </th>
+
+                    <th i18n:translate="listingheader_group_user_name">Group/User name</th>
+                    <th i18n:translate="listingheader_email_address">E-mail Address</th>
+                  </tr>
+
+                  <tal:block repeat="this_user batch">
+                    <tr tal:define="oddrow repeat/this_user/odd"
+                        tal:condition="python:this_user is not None"
+                        tal:attributes="class python:oddrow and 'odd' or 'even'">
+
+                      <td class="listingCheckbox">
+                        <input type="checkbox"
+                               class="noborder"
+                               name="add:list"
+                               value="value"
+                               tal:attributes="value this_user/getId;
+                                               disabled python:this_user.canAddToGroup(view.groupname) and default or 'disabled'" />
+                      </td>
+
+                      <td>
+                          <tal:block tal:condition="python:not view.isGroup(this_user)">
+                              <img src="user.png" alt="" />
+                              <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
+                                                         title this_user/getId">
+                                <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
+                                <tal:userid tal:condition="not:view/email_as_username">
+                                    (<span tal:replace="this_user/getUserName | default" />)
+                                </tal:userid>
+                              </a>
+                          </tal:block>
+                          <tal:block tal:condition="python: view.isGroup(this_user)">
+                              <img src="group.png" alt="" />
+                              <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())">
+                                  <span tal:replace="this_user/getGroupTitleOrName | default" />
+                                  (<span tal:replace="this_user/id | default" />)
+                              </a>
+                          </tal:block>
+                      </td>
+                      <td tal:define="email python: this_user.getProperty('email')">
+                          <a  href="#"
+                              tal:attributes="href string:mailto:${email}"
+                              title="Send a mail to this user"
+                              i18n:attributes="title title_send_mail_to_user;"
+                              tal:condition="email">
+                              <span tal:replace="email" />
+                          </a>
+                      </td>
+                    </tr>
+                  </tal:block>
+
+                  <tr tal:condition="not:batch">
+
+                    <td tal:condition="view/searchString"
+                      i18n:translate="text_nomatches"
+                      style="text-align:center;">No matches</td>
+
+                    <tal:block tal:condition="not:view/searchString">
+                      <td tal:condition="site_properties/many_users"
+                        class="discreet"
+                        i18n:translate="text_no_searchstring_large"
+                        style="text-align:center; font-size: 100%;">
+                        Enter a group or user name to search for.
+                      </td>
+                      <td tal:condition="not:site_properties/many_users"
+                        class="discreet"
+                        i18n:translate="text_no_searchstring"
+                        style="text-align:center; font-size: 100%;">
+                        Enter a group or user name to search for or click 'Show All'.
+                      </td>
+                    </tal:block>
+
+                  </tr>
+
+                </table>
+
+                <input type="hidden" value="b_start" name="b_start"
+                       tal:attributes="value b_start"/>
+
+                <input type="hidden" value="" name="showAll"
+                       tal:attributes="value showAll"/>
+
+                <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+                <div class="showAllSearchResults"
+                     tal:condition="python:batch.next or batch.previous"
+                     tal:define="mq python:modules['ZTUtils'].make_query;
+                                 keys batchformkeys|nothing;
+                                 linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                                 url batch_base_url | string:${context/absolute_url}/${template_id}">
+                    <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                       i18n:translate="description_pas_show_all_search_results">
+                        Show all search results
+                    </a>
+                </div>
+
+                <input class="context"
+                        type="submit"
+                        name="form.button.Add"
+                        value="Add selected groups and users to this group"
+                        tal:condition="batch"
+                        i18n:attributes="value label_add_users_to_group;" />
+
+            </tal:addusers>
+
+            <input tal:replace="structure context/@@authenticator/authenticator" />
+
+          </form>
+        </div>
+      </div>
+    </tal:ifgroups>
+
+  </article>
 
 </metal:main>
 </body>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
@@ -21,259 +21,244 @@
                  batchformkeys python:['searchstring','_authenticator'];
                  portal_url context/portal_url;">
 
-    <div class="documentEditable">
+  <article id="content">
+    <a href=""
+       id="setup-link"
+       tal:attributes="href string:$portal_url/plone_control_panel"
+       i18n:translate="">
+      Site Setup
+    </a>
+    <h1 class="documentFirstHeading"
+        i18n:translate="heading_groups_overview">Groups Overview</h1>
 
-        <div id="edit-bar">
-           <ul class="contentViews" id="content-views">
-             <li>
-               <a href=""
-                  tal:attributes="href string:$portal_url/@@usergroup-userprefs"
-                  i18n:translate="label_users">Users</a>
-             </li>
-             <li class="selected">
-               <a href=""
-                  tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                  i18n:translate="label_groups">Groups</a>
-             </li>
-             <li>
-               <a href=""
-                  tal:attributes="href string:$portal_url/@@usergroup-controlpanel"
-                  i18n:translate="label_usergroup_settings">Settings</a>
-             </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@member-registration"
-                   i18n:translate="label_member_registration">Member Registration</a>
-              </li>
-           </ul>
-          <div class="contentActions">&nbsp;</div>
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+        Portal status message
+    </div>
+
+    <div id="content-core">
+
+      <div class="autotabs">
+        <div class="autotoc-nav">
+          <a href="${portal_url}/@@usergroup-userprefs"
+             i18n:translate="label_users">Users</a>
+          <a class="active"
+             href="${portal_url}/@@usergroup-groupprefs"
+             i18n:translate="label_groups">Groups</a>
+          <a href="${portal_url}/@@usergroup-controlpanel"
+             i18n:translate="label_usergroup_settings">Settings</a>
+          <a href="${portal_url}/@@member-registration"
+             i18n:translate="label_member_registration">Member Registration</a>
         </div>
 
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-            Portal status message
-        </div>
+        <p class="discreet">
+          <span tal:omit-tag=""
+                i18n:translate="description_groups_management">
+            Groups are logical collections of users, such as
+            departments and business units. Groups are not directly
+            related to permissions on a global level, you normally
+            use Roles for that - and let certain Groups have a
+            particular role.
+          </span>
+          <span tal:omit-tag=""
+                i18n:translate="description_groups_management2">
+            The symbol
+            <img i18n:name="image_link_icon"
+                 tal:replace="structure context/site_icon.png" />
+            indicates a role inherited from membership in another group.
+          </span>
+        </p>
 
-        <article id="content">
-            <a href=""
-               id="setup-link"
-               tal:attributes="href string:$portal_url/plone_control_panel"
-               i18n:translate="">
-              Site Setup
-            </a>
-            <h1 class="documentFirstHeading"
-                i18n:translate="heading_groups_overview">Groups Overview</h1>
+        <p i18n:translate="description_pas_group_listing"
+           tal:condition="view/show_group_listing_warning">
+            Note: Some or all of your PAS groups
+            source plugins do not allow listing of groups, so you
+            may not see the groups defined by those plugins unless
+            doing a specific search.
+        </p>
 
-            <div id="content-core">
+        <a class="pat-modal" id="add-group"
+           tal:attributes="href string:${portal_url}/@@usergroup-groupdetails">
+           <button i18n:translate="label_add_new_group">Add New Group</button>
+        </a>
 
-                <p class="discreet">
-                  <span tal:omit-tag=""
-                        i18n:translate="description_groups_management">
-                    Groups are logical collections of users, such as
-                    departments and business units. Groups are not directly
-                    related to permissions on a global level, you normally
-                    use Roles for that - and let certain Groups have a
-                    particular role.
-                  </span>
-                  <span tal:omit-tag=""
-                        i18n:translate="description_groups_management2">
-                    The symbol
-                    <img i18n:name="image_link_icon"
-                         tal:replace="structure context/site_icon.png" />
-                    indicates a role inherited from membership in another group.
-                  </span>
-                </p>
+        <form action=""
+              name="groups_search"
+              method="post"
+              tal:attributes="action string:$template_id">
 
-                <p i18n:translate="description_pas_group_listing"
-                   tal:condition="view/show_group_listing_warning">
-                    Note: Some or all of your PAS groups
-                    source plugins do not allow listing of groups, so you
-                    may not see the groups defined by those plugins unless
-                    doing a specific search.
-                </p>
+            <input type="hidden" name="form.submitted" value="1" />
 
-                <a class="pat-modal" id="add-group"
-                   tal:attributes="href string:${portal_url}/@@usergroup-groupdetails">
-                   <button i18n:translate="label_add_new_group">Add New Group</button>
-                </a>
+            <input type="hidden" value="b_start" name="b_start"
+                   tal:attributes="value b_start"/>
 
-                <form action=""
-                      name="groups_search"
-                      method="post"
-                      tal:attributes="action string:$template_id">
+            <input type="hidden" value="" name="showAll"
+                   tal:attributes="value showAll"/>
 
-                    <input type="hidden" name="form.submitted" value="1" />
+            <table class="listing"
+                   summary="Select roles for each group"
+                   i18n:attributes="summary summary_roles_for_groups;">
+                <tbody>
+                    <tr class="odd">
+                        <th colspan="6"
+                            tal:attributes="colspan python:len(portal_roles)+2">
 
-                    <input type="hidden" value="b_start" name="b_start"
-                           tal:attributes="value b_start"/>
+                            <span tal:omit-tag=""
+                                  i18n:translate="label_group_search">
+                                Group Search
+                            </span>
 
-                    <input type="hidden" value="" name="showAll"
-                           tal:attributes="value showAll"/>
+                            <input class="quickSearch"
+                                   type="text"
+                                   name="searchstring"
+                                   value=""
+                                   tal:attributes="value view/searchString;"
+                                   />
 
-                    <table class="listing"
-                           summary="Select roles for each group"
-                           i18n:attributes="summary summary_roles_for_groups;">
-                        <tbody>
-                            <tr class="odd">
-                                <th colspan="6"
-                                    tal:attributes="colspan python:len(portal_roles)+2">
+                            <input type="submit"
+                                   class="searchButton"
+                                   name="form.button.Search"
+                                   value="Search"
+                                   i18n:attributes="value label_search;"
+                                   />
 
-                                    <span tal:omit-tag=""
-                                          i18n:translate="label_group_search">
-                                        Group Search
-                                    </span>
+                            <input type="submit"
+                                   class="searchButton"
+                                   name="form.button.FindAll"
+                                   value="Show all"
+                                   i18n:attributes="value label_showall;"
+                                   tal:condition="not:site_properties/many_groups"
+                                   />
 
-                                    <input class="quickSearch"
-                                           type="text"
-                                           name="searchstring"
-                                           value=""
-                                           tal:attributes="value view/searchString;"
-                                           />
+                        </th>
+                    </tr>
 
-                                    <input type="submit"
-                                           class="searchButton"
-                                           name="form.button.Search"
-                                           value="Search"
-                                           i18n:attributes="value label_search;"
-                                           />
+                    <tal:block tal:condition="search_results">
+                    <tr class="odd">
+                        <th rowspan="2"
+                            i18n:translate="listingheader_group_name">
+                            Group Name
+                        </th>
 
-                                    <input type="submit"
-                                           class="searchButton"
-                                           name="form.button.FindAll"
-                                           value="Show all"
-                                           i18n:attributes="value label_showall;"
-                                           tal:condition="not:site_properties/many_groups"
-                                           />
+                        <th colspan="3"
+                            tal:attributes="colspan python:len(portal_roles)"
+                            i18n:translate="listingheader_roles">
+                            Roles
+                        </th>
 
-                                </th>
-                            </tr>
+                        <th rowspan="2"
+                            i18n:translate="listingheader_remove_group">
+                            Remove Group
+                        </th>
+                    </tr>
 
-                            <tal:block tal:condition="search_results">
-                            <tr class="odd">
-                                <th rowspan="2"
-                                    i18n:translate="listingheader_group_name">
-                                    Group Name
-                                </th>
+                    <tr class="odd">
+                        <tal:header repeat="portal_role portal_roles">
+                            <th tal:content="portal_role"
+                                i18n:translate="">
+                                Role
+                            </th>
+                        </tal:header>
+                    </tr>
 
-                                <th colspan="3"
-                                    tal:attributes="colspan python:len(portal_roles)"
-                                    i18n:translate="listingheader_roles">
-                                    Roles
-                                </th>
+                    <tal:block repeat="group_info batch">
+                    <tr tal:define="oddrow repeat/group_info/odd;"
+                        tal:attributes="class python:oddrow and 'odd' or 'even'">
 
-                                <th rowspan="2"
-                                    i18n:translate="listingheader_remove_group">
-                                    Remove Group
-                                </th>
-                            </tr>
+                        <td>
+                            <input type="hidden"
+                                   name=""
+                                   tal:attributes="name string:group_${group_info/groupid}:list"
+                                   value=""
+                                   />
 
-                            <tr class="odd">
-                                <tal:header repeat="portal_role portal_roles">
-                                    <th tal:content="portal_role"
-                                        i18n:translate="">
-                                        Role
-                                    </th>
-                                </tal:header>
-                            </tr>
+                            <a href="#"
+                               tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
+                                               title group_info/description|string:''">
+                               <tal:block replace="structure context/portal_url/group.png" />&nbsp;
+                               <tal:group tal:replace="group_info/title" /> <tal:groupid tal:condition="python:group_info['groupid'] != group_info['title']">(<tal:id tal:replace="group_info/groupid" />)</tal:groupid>
+                           </a>
+                        </td>
 
-                            <tal:block repeat="group_info batch">
-                            <tr tal:define="oddrow repeat/group_info/odd;"
-                                tal:attributes="class python:oddrow and 'odd' or 'even'">
+                        <td class="listingCheckbox"
+                            tal:repeat="portal_role portal_roles">
+                          <tal:block tal:define="inherited python:group_info['roles'][portal_role]['inherited'];
+                                                 explicit python:group_info['roles'][portal_role]['explicit'];
+                                                 enabled python:group_info['roles'][portal_role]['canAssign']">
+                            <input type="checkbox"
+                                   class="noborder"
+                                   name="name"
+                                   value="Manager"
+                                   tal:condition="not:inherited"
+                                   tal:attributes="name string:group_${group_info/groupid}:list;
+                                                   value portal_role;
+                                                   checked python:'checked' if explicit else nothing;
+                                                   disabled python:default if enabled else 'disabled'"
+                                   />
+                            <input type="hidden"
+                                   name="name"
+                                   value="Manager"
+                                   tal:condition="python:explicit and not enabled and not inherited"
+                                   tal:attributes="name string:group_${group_info/groupid}:list;
+                                                   value portal_role" />
+                            <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
+                          </tal:block>
+                        </td>
 
-                                <td>
-                                    <input type="hidden"
-                                           name=""
-                                           tal:attributes="name string:group_${group_info/groupid}:list"
-                                           value=""
-                                           />
-
-                                    <a href="#"
-                                       tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
-                                                       title group_info/description|string:''">
-                                       <tal:block replace="structure context/portal_url/group.png" />&nbsp;
-                                       <tal:group tal:replace="group_info/title" /> <tal:groupid tal:condition="python:group_info['groupid'] != group_info['title']">(<tal:id tal:replace="group_info/groupid" />)</tal:groupid>
-                                   </a>
-                                </td>
-
-                                <td class="listingCheckbox"
-                                    tal:repeat="portal_role portal_roles">
-                                  <tal:block tal:define="inherited python:group_info['roles'][portal_role]['inherited'];
-                                                         explicit python:group_info['roles'][portal_role]['explicit'];
-                                                         enabled python:group_info['roles'][portal_role]['canAssign']">
-                                    <input type="checkbox"
-                                           class="noborder"
-                                           name="name"
-                                           value="Manager"
-                                           tal:condition="not:inherited"
-                                           tal:attributes="name string:group_${group_info/groupid}:list;
-                                                           value portal_role;
-                                                           checked python:'checked' if explicit else nothing;
-                                                           disabled python:default if enabled else 'disabled'"
-                                           />
-                                    <input type="hidden"
-                                           name="name"
-                                           value="Manager"
-                                           tal:condition="python:explicit and not enabled and not inherited"
-                                           tal:attributes="name string:group_${group_info/groupid}:list;
-                                                           value portal_role" />
-                                    <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
-                                  </tal:block>
-                                </td>
-
-                                <td class="listingCheckbox">
-                                    <input type="checkbox"
-                                           class="noborder notify"
-                                           name="delete:list"
-                                           value="value"
-                                           tal:attributes="value group_info/groupid;
-                                                           disabled python:default if group_info['can_delete'] else 'disabled'"
-                                           />
-                                </td>
-                            </tr>
-                            </tal:block>
-
-                            </tal:block>
-
-                            <tal:block tal:condition="python:(view.searchString and not search_results)">
-                            <tr>
-                                <td i18n:translate="text_nomatches"
-                                    style="text-align:center;">
-                                    No matches
-                                </td>
-                            </tr>
-                            </tal:block>
-                        </tbody>
-                    </table>
-
-                    <tal:block tal:condition="python:(search_results)">
-
-                        <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                        <div class="showAllSearchResults"
-                             tal:condition="python:batch.next or batch.previous"
-                             tal:define="mq python:modules['ZTUtils'].make_query;
-                                         keys batchformkeys|nothing;
-                                         linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                         url batch_base_url | string:${context/absolute_url}/${template_id}">
-                            <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                               i18n:translate="description_pas_show_all_search_results">
-                                Show all search results
-                            </a>
-                        </div>
-
-                        <input class="context"
-                               type="submit"
-                               name="form.button.Modify"
-                               value="Apply Changes"
-                               i18n:attributes="value label_apply_changes;"
-                               />
+                        <td class="listingCheckbox">
+                            <input type="checkbox"
+                                   class="noborder notify"
+                                   name="delete:list"
+                                   value="value"
+                                   tal:attributes="value group_info/groupid;
+                                                   disabled python:default if group_info['can_delete'] else 'disabled'"
+                                   />
+                        </td>
+                    </tr>
                     </tal:block>
 
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
+                    </tal:block>
 
-                </form>
-            </div>
-        </article>
+                    <tal:block tal:condition="python:(view.searchString and not search_results)">
+                    <tr>
+                        <td i18n:translate="text_nomatches"
+                            style="text-align:center;">
+                            No matches
+                        </td>
+                    </tr>
+                    </tal:block>
+                </tbody>
+            </table>
+
+            <tal:block tal:condition="python:(search_results)">
+
+                <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+                <div class="showAllSearchResults"
+                     tal:condition="python:batch.next or batch.previous"
+                     tal:define="mq python:modules['ZTUtils'].make_query;
+                                 keys batchformkeys|nothing;
+                                 linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                                 url batch_base_url | string:${context/absolute_url}/${template_id}">
+                    <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                       i18n:translate="description_pas_show_all_search_results">
+                        Show all search results
+                    </a>
+                </div>
+
+                <input class="context"
+                       type="submit"
+                       name="form.button.Modify"
+                       value="Apply Changes"
+                       i18n:attributes="value label_apply_changes;"
+                       />
+            </tal:block>
+
+            <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+      </div>
     </div>
+  </article>
 
 </metal:main>
 </body>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
@@ -31,193 +31,179 @@
                  batch python:Batch(view.searchResults, b_size, int(b_start));
                  batchformkeys python:['searchstring','_authenticator', 'userid'];">
 
-    <div class="documentEditable">
-        <!-- simulating views on the groups/user pages until we have real objects. -->
-        <div id="edit-bar">
-            <ul class="contentViews" id="content-views">
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@user-information?${userquery}"
-                   i18n:translate="label_personal_information">Personal Information</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@user-preferences?${userquery}"
-                   i18n:translate="label_personal_preferences">Personal Preferences</a>
-              </li>
-              <li class="selected">
-                <a href=""
-                   tal:attributes="href string:$portal_url/${template_id}?${userquery}"
-                   i18n:translate="label_group_memberships">Group Memberships</a>
-              </li>
-            </ul>
-            <div class="contentActions">&nbsp;</div>
-        </div>
+  <article id="content" tal:define="many_groups view/many_groups">
 
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-          Portal status message
-        </div>
+    <a href=""
+       class="link-parent"
+       tal:attributes="href string:$portal_url/@@usergroup-userprefs"
+       i18n:translate="label_up_to_usersoverview">
+      Up to Users Overview
+    </a>
 
-        <article id="content" tal:define="many_groups view/many_groups">
+    <h1 class="documentFirstHeading">
+      <span tal:replace="python:member.getProperty('fullname')" />
+      (<span tal:content="python:member.getUser().getUserName()"
+            tal:omit-tag="">login name</span>)
+    </h1>
 
-            <h1 class="documentFirstHeading"
-                i18n:translate="heading_group_memberships_for_fullname">
-              Group memberships for
-              <span i18n:name="fullname"
-                    tal:replace="python:member.getProperty('fullname')" />
-              (<span tal:content="python:member.getUser().getUserName()"
-                    tal:omit-tag=""
-                    i18n:name="userid">login name</span>)
-            </h1>
-
-            <div id="content-core">
-                <a href=""
-                   class="link-parent"
-                   tal:attributes="href string:$portal_url/@@usergroup-userprefs"
-                   i18n:translate="label_up_to_usersoverview">
-                  Up to Users Overview
-                </a>
-
-                <form method="post"
-                      tal:attributes="action string:$portal_url/$template_id?userid=${userid}">
-
-                  <h2 i18n:translate="heading_memberships_current">Current group memberships</h2>
-                  <table tal:condition="groups" class="listing" summary="Group Memberships Listing">
-                    <tr>
-                      <th i18n:translate="listingheader_group_name">Group Name</th>
-                      <th i18n:translate="listingheader_group_remove">Remove</th>
-                    </tr>
-                    <tal:block repeat="group groups">
-                        <tr tal:define="oddrow repeat/group/odd;
-                                        groupId group/getId;"
-                            tal:attributes="class python:'odd' if oddrow else 'even'">
-                            <td>
-                                <a href="@@usergroup-groupdetails"
-                                   tal:attributes="href string:@@usergroup-groupdetails?groupname=${groupId}">
-                                <tal:block replace="structure portal/group.png"/>&nbsp;<span
-                                             tal:replace="group/getGroupTitleOrName">group name</span>
-                                </a>
-                            </td>
-
-
-                            <td class="listingCheckbox">
-                                <input type="checkbox"
-                                       class="noborder notify"
-                                       name="delete:list"
-                                       tal:attributes="value groupId;
-                                                       disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" />
-                            </td>
-                        </tr>
-                    </tal:block>
-                  </table>
-                  <p tal:condition="not:groups" i18n:translate="text_user_not_in_any_group">This user does not belong to any group.</p>
-                  <input class="destructive"
-                         type="submit"
-                         name="form.button.Delete"
-                         value="Remove from selected groups"
-                         i18n:attributes="value label_remove_selected_groups;"
-                         tal:condition="groups" />
-
-                  <h2 tal:condition="many_groups" i18n:translate="heading_search_groups">Search for groups</h2>
-                  <h2 tal:condition="not:many_groups" i18n:translate="heading_assign_to_groups">Assign to groups</h2>
-
-                  <table class="listing" summary="Groups">
-                    <tr>
-                      <th colspan="2" tal:condition="many_groups">
-                        <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
-                              <input class="quickSearch"
-                                     type="text"
-                                     name="searchstring"
-                                     value=""
-                                     tal:attributes="value view/searchString;"
-                                     />
-
-                              <input type="submit"
-                                     class="searchButton"
-                                     name="form.button.search"
-                                     value="Search"
-                                     i18n:attributes="value label_search;" />
-
-                      </th>
-                    </tr>
-                    <tal:block condition="python:results">
-                        <tr>
-                          <th>
-                              <input class="noborder"
-                                     type="checkbox"
-                                     src="select_all_icon.png"
-                                     name="selectButton"
-                                     title="Select all items"
-                                     onClick="toggleSelect(this, 'add:list');"
-                                     tal:attributes="src string:${context/portal_url}/select_all_icon.png"
-                                     alt="Select all items"
-                                     i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
-                          </th>
-                          <th i18n:translate="listingheader_group_name">Group Name</th>
-                        </tr>
-                        <tal:block repeat="obj batch">
-                          <tr tal:define="oddrow repeat/obj/odd"
-                              tal:attributes="class python:'odd' if oddrow else 'even'">
-
-                            <td class="listingCheckbox">
-                              <input type="checkbox"
-                                     class="noborder"
-                                     name="add:list"
-                                     value="value"
-                                         tal:define="calcId obj/getGroupId | obj/getId;
-                                                     canAddToGroup python:member.canAddToGroup(calcId) and ('Manager' not in obj.getRoles() or view.is_zope_manager)"
-                                         tal:attributes="value calcId;
-                                                         disabled python:canAddToGroup and default or 'disabled'" />
-                            </td>
-
-                            <td>
-                                <img src="group.png" alt="" />
-                                <a href="" tal:attributes="href python:'@@usergroup-groupdetails?'+mq(groupname=obj.getGroupName())"
-                                          tal:content="obj/getGroupTitleOrName | default">
-                                      <span i18n:translate="link_groupname_not_available">
-                                          groupname not available
-                                      </span>
-                                </a>
-                            </td>
-                          </tr>
-                        </tal:block>
-                    </tal:block>
-                  </table>
-
-                  <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                  <div class="showAllSearchResults"
-                       tal:condition="python:batch.next or batch.previous"
-                       tal:define="mq python:modules['ZTUtils'].make_query;
-                                   keys batchformkeys|nothing;
-                                   linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                   url batch_base_url | string:${context/absolute_url}/${template_id}">
-                      <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                         i18n:translate="description_pas_show_all_search_results">
-                          Show all search results
-                      </a>
-                  </div>
-
-                  <input type="hidden" value="b_start" name="b_start"
-                         tal:attributes="value b_start"/>
-
-                  <input type="hidden" value="" name="showAll"
-                         tal:attributes="value showAll"/>
-
-                  <input type="hidden" name="form.submitted" value="1" />
-
-                  <input class="context"
-                         type="submit"
-                         name="form.button.Add"
-                         value="Add user to selected groups"
-                         tal:condition="batch"
-                         i18n:attributes="value label_add_user_to_group;" />
-                  <input tal:replace="structure context/@@authenticator/authenticator" />
-
-                </form>
-            </div>
-        </article>
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      Portal status message
     </div>
+
+    <div id="content-core">
+
+      <div class="autotabs">
+        <nav class="autotoc-nav">
+          <a href="${portal_url}/@@user-information?${userquery}"
+             i18n:translate="title_personal_information_form">Personal Information</a>
+          <a href="${portal_url}/@@user-preferences?${userquery}"
+             i18n:translate="">Personal Preferences</a>
+          <a class="active"
+             href="${portal_url}/@@usergroup-usermembership?${userquery}"
+             i18n:translate="label_group_memberships">Group Memberships</a>
+        </nav>
+
+        <form method="post"
+              tal:attributes="action string:$portal_url/$template_id?userid=${userid}">
+
+          <h2 i18n:translate="heading_memberships_current">Current group memberships</h2>
+          <table tal:condition="groups" class="listing" summary="Group Memberships Listing">
+            <tr>
+              <th i18n:translate="listingheader_group_name">Group Name</th>
+              <th i18n:translate="listingheader_group_remove">Remove</th>
+            </tr>
+            <tal:block repeat="group groups">
+                <tr tal:define="oddrow repeat/group/odd;
+                                groupId group/getId;"
+                    tal:attributes="class python:'odd' if oddrow else 'even'">
+                    <td>
+                        <a href="@@usergroup-groupdetails"
+                           tal:attributes="href string:@@usergroup-groupdetails?groupname=${groupId}">
+                        <tal:block replace="structure portal/group.png"/>&nbsp;<span
+                                     tal:replace="group/getGroupTitleOrName">group name</span>
+                        </a>
+                    </td>
+
+
+                    <td class="listingCheckbox">
+                        <input type="checkbox"
+                               class="noborder notify"
+                               name="delete:list"
+                               tal:attributes="value groupId;
+                                               disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" />
+                    </td>
+                </tr>
+            </tal:block>
+          </table>
+          <p tal:condition="not:groups" i18n:translate="text_user_not_in_any_group">This user does not belong to any group.</p>
+          <input class="destructive"
+                 type="submit"
+                 name="form.button.Delete"
+                 value="Remove from selected groups"
+                 i18n:attributes="value label_remove_selected_groups;"
+                 tal:condition="groups" />
+
+          <h2 tal:condition="many_groups" i18n:translate="heading_search_groups">Search for groups</h2>
+          <h2 tal:condition="not:many_groups" i18n:translate="heading_assign_to_groups">Assign to groups</h2>
+
+          <table class="listing" summary="Groups">
+            <tr>
+              <th colspan="2" tal:condition="many_groups">
+                <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
+                      <input class="quickSearch"
+                             type="text"
+                             name="searchstring"
+                             value=""
+                             tal:attributes="value view/searchString;"
+                             />
+
+                      <input type="submit"
+                             class="searchButton"
+                             name="form.button.search"
+                             value="Search"
+                             i18n:attributes="value label_search;" />
+
+              </th>
+            </tr>
+            <tal:block condition="python:results">
+                <tr>
+                  <th>
+                      <input class="noborder"
+                             type="checkbox"
+                             src="select_all_icon.png"
+                             name="selectButton"
+                             title="Select all items"
+                             onClick="toggleSelect(this, 'add:list');"
+                             tal:attributes="src string:${context/portal_url}/select_all_icon.png"
+                             alt="Select all items"
+                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                  </th>
+                  <th i18n:translate="listingheader_group_name">Group Name</th>
+                </tr>
+                <tal:block repeat="obj batch">
+                  <tr tal:define="oddrow repeat/obj/odd"
+                      tal:attributes="class python:'odd' if oddrow else 'even'">
+
+                    <td class="listingCheckbox">
+                      <input type="checkbox"
+                             class="noborder"
+                             name="add:list"
+                             value="value"
+                                 tal:define="calcId obj/getGroupId | obj/getId;
+                                             canAddToGroup python:member.canAddToGroup(calcId) and ('Manager' not in obj.getRoles() or view.is_zope_manager)"
+                                 tal:attributes="value calcId;
+                                                 disabled python:canAddToGroup and default or 'disabled'" />
+                    </td>
+
+                    <td>
+                        <img src="group.png" alt="" />
+                        <a href="" tal:attributes="href python:'@@usergroup-groupdetails?'+mq(groupname=obj.getGroupName())"
+                                  tal:content="obj/getGroupTitleOrName | default">
+                              <span i18n:translate="link_groupname_not_available">
+                                  groupname not available
+                              </span>
+                        </a>
+                    </td>
+                  </tr>
+                </tal:block>
+            </tal:block>
+          </table>
+
+          <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+          <div class="showAllSearchResults"
+               tal:condition="python:batch.next or batch.previous"
+               tal:define="mq python:modules['ZTUtils'].make_query;
+                           keys batchformkeys|nothing;
+                           linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                           url batch_base_url | string:${context/absolute_url}/${template_id}">
+              <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                 i18n:translate="description_pas_show_all_search_results">
+                  Show all search results
+              </a>
+          </div>
+
+          <input type="hidden" value="b_start" name="b_start"
+                 tal:attributes="value b_start"/>
+
+          <input type="hidden" value="" name="showAll"
+                 tal:attributes="value showAll"/>
+
+          <input type="hidden" name="form.submitted" value="1" />
+
+          <input class="context"
+                 type="submit"
+                 name="form.button.Add"
+                 value="Add user to selected groups"
+                 tal:condition="batch"
+                 i18n:attributes="value label_add_user_to_group;" />
+          <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+
+      </div>
+    </div>
+  </article>
 
 </metal:main>
 

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -17,234 +17,221 @@
                 portal_roles view/portal_roles;
                 portal_url context/portal_url;">
 
-    <div class="documentEditable">
-        <div id="edit-bar">
-            <ul class="contentViews" id="content-views">
-              <li class="selected">
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@usergroup-userprefs"
-                   i18n:translate="label_users">Users</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@usergroup-groupprefs"
-                   i18n:translate="label_groups">Groups</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@usergroup-controlpanel"
-                   i18n:translate="label_usergroup_settings">Settings</a>
-              </li>
-              <li>
-                <a href=""
-                   tal:attributes="href string:$portal_url/@@member-registration"
-                   i18n:translate="label_member_registration">Member Registration</a>
-              </li>
-            </ul>
-            <div class="contentActions">&nbsp;</div>
-        </div>
+  <article id="content">
 
-        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-          Portal status message
-        </div>
+    <h1 class="documentFirstHeading"
+        i18n:translate="heading_users_overview">Users Overview</h1>
 
-        <article id="content">
-
-
-            <h1 class="documentFirstHeading"
-                i18n:translate="heading_users_overview">Users Overview</h1>
-
-            <div id="content-core">
-                <p i18n:translate="description_user_management" class="documentDescription">
-                  Click the user's name to see and change the details of a
-                  specific user. You can also add and remove users.
-                </p>
-                <p i18n:translate="user_roles_note" class="discreet">
-                  Note that roles set here apply directly to a user.
-                  The symbol <img i18n:name="image_link_icon" tal:replace="structure context/site_icon.png" />
-                  indicates a role inherited from membership in a group.
-                </p>
-                <p i18n:translate="description_pas_users_listing"
-                   tal:condition="view/show_users_listing_warning" class="portalMessage warning">
-                  <strong>Note</strong>
-                  <span>Some or all of your PAS user source
-                  plugins do not allow listing of users, so you may not see
-                  the users defined by those plugins unless doing a specific
-                  search.</span>
-                </p>
-                <p>
-                  <a class="pat-modal" id="add-user"
-                     data-pat-modal="{&quot;actionOptions&quot;: {&quot;displayInModal&quot;: false}}"
-                     tal:attributes="href string:${portal_url}/@@new-user">
-                     <button i18n:translate="label_add_new_user" id="add-new-user" class="context">Add New User</button>
-                  </a>
-                </p>
-                <form action=""
-                      class="enableAutoFocus autotabs"
-                      name="users_search"
-                      method="post"
-                      tal:attributes="action string:$portal_url/$template_id"
-                      tal:define="findAll python:'form.button.FindAll' in request.keys();
-                                  portal_users view/searchResults;
-                                  batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
-                                  batchformkeys python:['searchstring','_authenticator'];
-                                  many_users view/many_users">
-                  <input type="hidden" name="form.submitted" value="1" />
-
-                  <div class="field">
-                    <label for="quickSearch" i18n:translate="label_user_search">User Search</label>
-                                  <input class="quickSearch"
-                                         id="quickSearch"
-                                         type="text"
-                                         name="searchstring"
-                                         value=""
-                                         tal:attributes="value view/searchString;"
-                                         />
-
-                                  <input type="submit"
-                                         class="searchButton context"
-                                         name="form.button.Search"
-                                         value="Search"
-                                         i18n:attributes="value label_search;"
-                                         />
-
-                                  <input type="submit"
-                                         class="searchButton standalone"
-                                         name="form.button.FindAll"
-                                         value="Show all"
-                                         i18n:attributes="value label_showall;"
-                                         tal:condition="not:many_users"
-                                         />
-                  </div>
-                  <table class="listing" summary="User Listing">
-                      <tbody>
-                          <tal:block tal:condition="portal_users" >
-                          <tr class="odd">
-                              <th rowspan="2" i18n:translate="listingheader_user_name">User name</th>
-                              <th colspan="3" tal:attributes="colspan python:len(portal_roles)"
-                                  i18n:translate="listingheader_roles">Roles</th>
-                              <th rowspan="2" i18n:translate="listingheader_reset_password">Reset Password</th>
-                              <th rowspan="2" i18n:translate="listingheader_remove_user">Remove user</th>
-                          </tr>
-                          <tr class="odd">
-                              <th tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
-                          </tr>
-                          </tal:block>
-                          <tal:block repeat="user batch">
-                            <tr tal:define="oddrow repeat/user/odd;
-                                            userid user/userid;
-                                            userquery python:view.makeQuery(userid=userid);"
-                                tal:attributes="class python:oddrow and 'odd' or 'even'">
-
-                                <td>
-                                    <a href="@@user-information"
-                                       tal:attributes="href string:$portal_url/@@user-information?${userquery};
-                                                       title userid">
-                                        <span tal:replace="user/fullname">Full Name</span>
-                                        <em> – <em tal:replace="user/login">login name</em></em>
-                                    </a>
-                                    <input type="hidden" name="users.id:records" tal:attributes="value userid" />
-                                </td>
-
-                                <td class="listingCheckbox"
-                                    tal:repeat="portal_role portal_roles">
-                                  <tal:block tal:define="inherited python:user['roles'][portal_role]['inherited'];
-                                                         explicit python:user['roles'][portal_role]['explicit'];
-                                                         enabled python:user['roles'][portal_role]['canAssign']">
-                                    <input type="checkbox"
-                                       class="noborder"
-                                       name="users.roles:list:records"
-                                       value="Manager"
-                                       tal:condition="not:inherited"
-                                       tal:attributes="value portal_role;
-                                           checked python:'checked' if explicit else nothing;
-                                           disabled python:default if enabled else 'disabled'" />
-                                    <input type="hidden"
-                                        name="users.roles:list:records"
-                                        value="Manager"
-                                        tal:condition="python:explicit and not enabled and not inherited"
-                                        tal:attributes="value portal_role" />
-                                    <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
-                                  </tal:block>
-
-                                </td>
-
-                                <td class="listingCheckbox">
-                                  <input type="checkbox"
-                                     class="noborder"
-                                     name="users.resetpassword:records"
-                                                 value=""
-                                                 tal:attributes="value userid;
-                                                                 disabled python:user['can_set_password'] and default or 'disabled'" />
-                                </td>
-
-                                <td class="listingCheckbox">
-                                  <input type="checkbox"
-                                                 class="noborder notify"
-                                                 name="delete:list"
-                                                 value=""
-                                                 tal:attributes="value userid;
-                                                                 disabled python:user['can_delete'] and default or 'disabled'" />
-                                </td>
-                            </tr>
-                          </tal:block>
-                          <tr tal:condition="not:batch">
-                              <td tal:condition="view/searchString"
-                                  i18n:translate="text_nomatches"
-                                  style="text-align:center;">No matches</td>
-                              <tal:block tal:condition="not:view/searchString">
-                                <td tal:condition="many_users"
-                                    class="discreet"
-                                    i18n:translate="text_no_user_searchstring"
-                                    style="text-align:center; font-size: 100%;">
-                                    Enter a username to search for
-                                </td>
-                                <td tal:condition="not:many_users"
-                                    class="discreet"
-                                    i18n:translate="text_no_user_searchstring_largesite"
-                                    style="text-align:center; font-size: 100%;">
-                                    Enter a username to search for, or click 'Show All'
-                                </td>
-                              </tal:block>
-                          </tr>
-                      </tbody>
-                  </table>
-
-                  <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                  <div class="showAllSearchResults"
-                       tal:condition="python:batch.next or batch.previous"
-                       tal:define="mq python:modules['ZTUtils'].make_query;
-                                   keys batchformkeys|nothing;
-                                   linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                   url batch_base_url | string:${context/absolute_url}/${template_id}">
-                      <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                         i18n:translate="description_pas_show_all_search_results">
-                          Show all search results
-                      </a>
-                  </div>
-
-                  <input type="hidden" value="b_start" name="b_start"
-                         tal:attributes="value b_start"/>
-
-                  <input type="hidden" value="" name="showAll"
-                         tal:attributes="value showAll"/>
-
-                  <div class="formControls" tal:condition="batch">
-                  <input class="context"
-                     type="submit"
-                     name="form.button.Modify"
-                     value="Apply Changes"
-                     i18n:attributes="value label_apply_changes;"
-                     />
-                   </div>
-
-                  <input tal:replace="structure context/@@authenticator/authenticator" />
-
-                </form>
-            </div>
-        </article>
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      Portal status message
     </div>
+
+    <div id="content-core">
+
+      <div class="autotabs">
+        <div class="autotoc-nav">
+          <a class="active"
+             href="${portal_url}/@@usergroup-userprefs"
+             i18n:translate="label_users">Users</a>
+          <a href="${portal_url}/@@usergroup-groupprefs"
+             i18n:translate="label_groups">Groups</a>
+          <a href="${portal_url}/@@usergroup-controlpanel"
+             i18n:translate="label_usergroup_settings">Settings</a>
+          <a href="${portal_url}/@@member-registration"
+             i18n:translate="label_member_registration">Member Registration</a>
+        </div>
+
+        <p i18n:translate="description_user_management" class="documentDescription">
+          Click the user's name to see and change the details of a
+          specific user. You can also add and remove users.
+        </p>
+        <p i18n:translate="user_roles_note" class="discreet">
+          Note that roles set here apply directly to a user.
+          The symbol <img i18n:name="image_link_icon" tal:replace="structure context/site_icon.png" />
+          indicates a role inherited from membership in a group.
+        </p>
+        <p i18n:translate="description_pas_users_listing"
+           tal:condition="view/show_users_listing_warning" class="portalMessage warning">
+          <strong>Note</strong>
+          <span>Some or all of your PAS user source
+          plugins do not allow listing of users, so you may not see
+          the users defined by those plugins unless doing a specific
+          search.</span>
+        </p>
+        <p>
+          <a class="pat-modal" id="add-user"
+             data-pat-modal="{&quot;actionOptions&quot;: {&quot;displayInModal&quot;: false}}"
+             tal:attributes="href string:${portal_url}/@@new-user">
+             <button i18n:translate="label_add_new_user" id="add-new-user" class="context">Add New User</button>
+          </a>
+        </p>
+        <form action=""
+              class="enableAutoFocus autotabs"
+              name="users_search"
+              method="post"
+              tal:attributes="action string:$portal_url/$template_id"
+              tal:define="findAll python:'form.button.FindAll' in request.keys();
+                          portal_users view/searchResults;
+                          batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
+                          batchformkeys python:['searchstring','_authenticator'];
+                          many_users view/many_users">
+          <input type="hidden" name="form.submitted" value="1" />
+
+          <div class="field">
+            <label for="quickSearch" i18n:translate="label_user_search">User Search</label>
+                          <input class="quickSearch"
+                                 id="quickSearch"
+                                 type="text"
+                                 name="searchstring"
+                                 value=""
+                                 tal:attributes="value view/searchString;"
+                                 />
+
+                          <input type="submit"
+                                 class="searchButton context"
+                                 name="form.button.Search"
+                                 value="Search"
+                                 i18n:attributes="value label_search;"
+                                 />
+
+                          <input type="submit"
+                                 class="searchButton standalone"
+                                 name="form.button.FindAll"
+                                 value="Show all"
+                                 i18n:attributes="value label_showall;"
+                                 tal:condition="not:many_users"
+                                 />
+          </div>
+          <table class="listing" summary="User Listing">
+              <tbody>
+                  <tal:block tal:condition="portal_users" >
+                  <tr class="odd">
+                      <th rowspan="2" i18n:translate="listingheader_user_name">User name</th>
+                      <th colspan="3" tal:attributes="colspan python:len(portal_roles)"
+                          i18n:translate="listingheader_roles">Roles</th>
+                      <th rowspan="2" i18n:translate="listingheader_reset_password">Reset Password</th>
+                      <th rowspan="2" i18n:translate="listingheader_remove_user">Remove user</th>
+                  </tr>
+                  <tr class="odd">
+                      <th tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
+                  </tr>
+                  </tal:block>
+                  <tal:block repeat="user batch">
+                    <tr tal:define="oddrow repeat/user/odd;
+                                    userid user/userid;
+                                    userquery python:view.makeQuery(userid=userid);"
+                        tal:attributes="class python:oddrow and 'odd' or 'even'">
+
+                        <td>
+                            <a href="@@user-information"
+                               tal:attributes="href string:$portal_url/@@user-information?${userquery};
+                                               title userid">
+                                <span tal:replace="user/fullname">Full Name</span>
+                                <em> – <em tal:replace="user/login">login name</em></em>
+                            </a>
+                            <input type="hidden" name="users.id:records" tal:attributes="value userid" />
+                        </td>
+
+                        <td class="listingCheckbox"
+                            tal:repeat="portal_role portal_roles">
+                          <tal:block tal:define="inherited python:user['roles'][portal_role]['inherited'];
+                                                 explicit python:user['roles'][portal_role]['explicit'];
+                                                 enabled python:user['roles'][portal_role]['canAssign']">
+                            <input type="checkbox"
+                               class="noborder"
+                               name="users.roles:list:records"
+                               value="Manager"
+                               tal:condition="not:inherited"
+                               tal:attributes="value portal_role;
+                                   checked python:'checked' if explicit else nothing;
+                                   disabled python:default if enabled else 'disabled'" />
+                            <input type="hidden"
+                                name="users.roles:list:records"
+                                value="Manager"
+                                tal:condition="python:explicit and not enabled and not inherited"
+                                tal:attributes="value portal_role" />
+                            <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
+                          </tal:block>
+
+                        </td>
+
+                        <td class="listingCheckbox">
+                          <input type="checkbox"
+                             class="noborder"
+                             name="users.resetpassword:records"
+                                         value=""
+                                         tal:attributes="value userid;
+                                                         disabled python:user['can_set_password'] and default or 'disabled'" />
+                        </td>
+
+                        <td class="listingCheckbox">
+                          <input type="checkbox"
+                                         class="noborder notify"
+                                         name="delete:list"
+                                         value=""
+                                         tal:attributes="value userid;
+                                                         disabled python:user['can_delete'] and default or 'disabled'" />
+                        </td>
+                    </tr>
+                  </tal:block>
+                  <tr tal:condition="not:batch">
+                      <td tal:condition="view/searchString"
+                          i18n:translate="text_nomatches"
+                          style="text-align:center;">No matches</td>
+                      <tal:block tal:condition="not:view/searchString">
+                        <td tal:condition="many_users"
+                            class="discreet"
+                            i18n:translate="text_no_user_searchstring"
+                            style="text-align:center; font-size: 100%;">
+                            Enter a username to search for
+                        </td>
+                        <td tal:condition="not:many_users"
+                            class="discreet"
+                            i18n:translate="text_no_user_searchstring_largesite"
+                            style="text-align:center; font-size: 100%;">
+                            Enter a username to search for, or click 'Show All'
+                        </td>
+                      </tal:block>
+                  </tr>
+              </tbody>
+          </table>
+
+          <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+          <div class="showAllSearchResults"
+               tal:condition="python:batch.next or batch.previous"
+               tal:define="mq python:modules['ZTUtils'].make_query;
+                           keys batchformkeys|nothing;
+                           linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                           url batch_base_url | string:${context/absolute_url}/${template_id}">
+              <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                 i18n:translate="description_pas_show_all_search_results">
+                  Show all search results
+              </a>
+          </div>
+
+          <input type="hidden" value="b_start" name="b_start"
+                 tal:attributes="value b_start"/>
+
+          <input type="hidden" value="" name="showAll"
+                 tal:attributes="value showAll"/>
+
+          <div class="formControls" tal:condition="batch">
+          <input class="context"
+             type="submit"
+             name="form.button.Modify"
+             value="Apply Changes"
+             i18n:attributes="value label_apply_changes;"
+             />
+           </div>
+
+          <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+      </div>
+    </div>
+
+  </article>
 
 </metal:main>
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0a1 (unreleased)
 ------------------
 
+- Fix user/group control panel markup for Plone 5.
+  [davisagli]
+
 - folder_position script: make position and id optional.  Default
   position to 'ordered' and id to None, which means: do nothing.
   plone.folder 1.0.5 allows this, making it possible to simply reverse


### PR DESCRIPTION
Use tabs in the content area for navigation within the user and group control panels, instead of hijacking the edit bar.

(This looks like more changed than actually did -- the actual control panel markup is unchanged, but it got wrapped in a new div for the tabs.)