### PR TITLE
custom bundle fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ Changelog
 5.0b1 (unreleased)
 ------------------
 
+- Fix the resource registry to save the automatically generated filepath to the
+  compiled resource on the bundle object after compilation. The filepath is
+  always in the '++plone++static/' namespace. This fix makes custom bundles
+  actually includable.
+  [thet]
+
 - Get icon from layout_view instead of plone_view.
   [pbauer]
 

--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -240,6 +240,7 @@ class ResourceRegistryControlPanelView(RequireJsView):
         bundle = self.get_bundles().get(req.form['bundle'])
         if bundle:
             bundle.last_compilation = datetime.now()
+            bundle.jscompilation = '++plone++{}'.format(filepath)
         return json.dumps({
             'success': True,
             'filepath': '++plone++' + filepath
@@ -255,6 +256,7 @@ class ResourceRegistryControlPanelView(RequireJsView):
         bundle = self.get_bundles().get(req.form['bundle'])
         if bundle:
             bundle.last_compilation = datetime.now()
+            bundle.csscompilation = '++plone++{}'.format(filepath)
         return json.dumps({
             'success': True,
             'filepath': '++plone++' + filepath

--- a/Products/CMFPlone/resources/viewlets/__init__.py
+++ b/Products/CMFPlone/resources/viewlets/__init__.py
@@ -1,4 +1,3 @@
-
 from Products.ResourceRegistries.interfaces.registries import IResourceRegistry
 from Products.ResourceRegistries.interfaces.registries import ICSSRegistry
 from Products.ResourceRegistries.interfaces.registries import IKSSRegistry


### PR DESCRIPTION
Fix the resource registry to save the automatically generated filepath to the
compiled resource on the bundle object after compilation. The filepath is
always in the '++plone++static/' namespace. This fix makes custom bundles
actually includable.

@vangheem @bloodbare 

There are no tests yet. I'll have to finish something first...

@keul @zopyx this propably sovle some of your issues too!
by the way, the cause of the issue came obvious to me, after looking at the bundle compilation metadata via this fix: https://github.com/plone/mockup/pull/457

Maybe fixes #323
