### PR TITLE
site_logo in controlpanel + @@sitelogo view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Changelog
 5.0b1 (unreleased)
 ------------------
 
+- Caching for ``@@site-logo``.
+  [thet]
+
+- Support for portal site logos stored in the portal registry by uploading via
+  the site control panel. Add a ``@@site-logo`` view for downloading the logo.
+  [thet]
+
 - Fix the resource registry to save the automatically generated filepath to the
   compiled resource on the bundle object after compilation. The filepath is
   always in the '++plone++static/' namespace. This fix makes custom bundles

--- a/Products/CMFPlone/browser/admin.zcml
+++ b/Products/CMFPlone/browser/admin.zcml
@@ -57,11 +57,6 @@
   <adapter factory=".admin.AppTraverser" />
 
   <browser:resource
-      file="plone-logo.png"
-      name="plone-logo.png"
-      />
-
-  <browser:resource
       file="plone-admin-ui.css"
       name="plone-admin-ui.css"
       />

--- a/Products/CMFPlone/browser/caching.zcml
+++ b/Products/CMFPlone/browser/caching.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    i18n_domain="plone">
+
+    <include package="z3c.caching" />
+    <include package="z3c.caching" file="meta.zcml" />
+
+    <cache:ruleset
+        for=".sitelogo.SiteLogo"
+        ruleset="plone.stableResource"
+        />
+
+</configure>

--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -1,8 +1,11 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:browser="http://namespaces.zope.org/browser"
-           xmlns:five="http://namespaces.zope.org/five">
+           xmlns:i18n="http://namespaces.zope.org/i18n"
+           xmlns:zcml="http://namespaces.zope.org/zcml"
+           i18n_domain="plone">
 
   <include file="admin.zcml" />
+  <include file="caching.zcml" zcml:condition="installed z3c.caching"/>
 
   <class class="Products.CMFPlone.Portal.PloneSite">
     <implements interface="plone.app.layout.navigation.interfaces.INavigationRoot" />
@@ -15,6 +18,18 @@
   <permission
     id="Products.CMFPlone.AllowSendto"
     title="Allow sendto" />
+
+  <browser:resource
+      file="plone-logo.png"
+      name="plone-logo.png"
+      />
+
+  <browser:page
+      for="*"
+      name="site-logo"
+      class=".sitelogo.SiteLogo"
+      permission="zope.Public"
+      />
 
   <browser:page
       for="*"

--- a/Products/CMFPlone/browser/sitelogo.py
+++ b/Products/CMFPlone/browser/sitelogo.py
@@ -1,0 +1,26 @@
+from Products.CMFPlone.interfaces import ISiteSchema
+from plone.formwidget.namedfile.converter import b64decode_file
+from plone.namedfile.browser import Download
+from plone.namedfile.file import NamedImage
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+
+class SiteLogo(Download):
+
+    def __init__(self, context, request):
+        super(SiteLogo, self).__init__(context, request)
+        self.filename = None
+        self.data = None
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISiteSchema, prefix="plone")
+        if getattr(settings, 'site_logo', False):
+            filename, data = b64decode_file(settings.site_logo)
+            data = NamedImage(data=data, filename=filename)
+            self.data = data
+            self.filename = filename
+            # self.width, self.height = self.data.getImageSize()
+
+    def _getFile(self):
+        return self.data

--- a/Products/CMFPlone/controlpanel/bbb/site.py
+++ b/Products/CMFPlone/controlpanel/bbb/site.py
@@ -36,5 +36,6 @@ class SiteControlPanelAdapter(object):
     site_title = property(get_site_title, set_site_title)
     webstats_js = property(get_webstats_js, set_webstats_js)
 
+    site_logo = ProxyFieldProperty(ISiteSchema['site_logo'])
     enable_sitemap = ProxyFieldProperty(ISiteSchema['enable_sitemap'])
     exposeDCMetaTags = ProxyFieldProperty(ISiteSchema['exposeDCMetaTags'])

--- a/Products/CMFPlone/controlpanel/browser/site.py
+++ b/Products/CMFPlone/controlpanel/browser/site.py
@@ -2,6 +2,7 @@
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.interfaces import ISiteSchema
 from plone.app.registry.browser import controlpanel
+from plone.formwidget.namedfile.widget import NamedImageFieldWidget
 
 
 class SiteControlPanelForm(controlpanel.RegistryEditForm):
@@ -11,6 +12,10 @@ class SiteControlPanelForm(controlpanel.RegistryEditForm):
     description = _("Site-wide settings.")
     schema = ISiteSchema
     schema_prefix = "plone"
+
+    def updateFields(self):
+        super(SiteControlPanelForm, self).updateFields()
+        self.fields['site_logo'].widgetFactory = NamedImageFieldWidget
 
 
 class SiteControlPanel(controlpanel.ControlPanelFormWrapper):

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_site.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_site.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
 from Products.CMFPlone.interfaces import ISiteSchema
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
+from StringIO import StringIO
 from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 import unittest2 as unittest
+
+# Red pixel with filename pixel.png
+SITE_LOGO_BASE64 = 'filenameb64:cGl4ZWwucG5n;datab64:iVBORw0KGgoAAAANSUhEUgAA'\
+                   'AAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4z8AAAAMBAQAY3Y2wAAAAA'\
+                   'ElFTkSuQmCC'
+SITE_LOGO_HEX = '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00'\
+                '\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDAT'\
+                '\x08\xd7c\xf8\xcf\xc0\x00\x00\x03\x01\x01\x00\x18\xdd\x8d'\
+                '\xb0\x00\x00\x00\x00IEND\xaeB`\x82'
 
 
 class SiteControlPanelFunctionalTest(unittest.TestCase):
@@ -83,6 +93,17 @@ class SiteControlPanelFunctionalTest(unittest.TestCase):
 
         self.assertEqual(self.portal.title, u'My Site')
         self.assertEqual(self.portal.Title(), u'My Site')
+
+    def test_site_logo_is_stored_in_registry(self):
+        self.browser.open(
+            "%s/@@site-controlpanel" % self.portal_url)
+        ctrl = self.browser.getControl(name="form.widgets.site_logo")
+        ctrl.add_file(StringIO(SITE_LOGO_HEX), 'image/png', 'pixel.png')
+        self.browser.getControl('Save').click()
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISiteSchema, prefix='plone')
+        self.assertEqual(settings.site_logo, SITE_LOGO_BASE64)
 
     def test_exposeDCMetaTags(self):
         self.browser.open(

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_site.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_site.py
@@ -38,6 +38,9 @@ class SiteRegistryIntegrationTest(unittest.TestCase):
     def test_site_title_setting(self):
         self.assertTrue(hasattr(self.settings, 'site_title'))
 
+    def test_site_logo_setting(self):
+        self.assertTrue(hasattr(self.settings, 'site_logo'))
+
     def test_exposeDCMetaTags_setting(self):
         self.assertTrue(hasattr(self.settings, 'exposeDCMetaTags'))
 

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -3,10 +3,10 @@ from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.utils import validate_json
 from basetool import IPloneBaseTool
 from plone.locking.interfaces import ILockSettings
+from zope import schema
 from zope.interface import Interface
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-from zope import schema
 
 
 class IControlPanel(IPloneBaseTool):
@@ -865,6 +865,12 @@ class ISiteSchema(ILockSettings):
             u"This shows up in the title bar of "
             u"browsers and in syndication feeds."),
         default=u'Plone site')
+
+    site_logo = schema.ASCII(
+        title=_(u"Site Logo"),
+        description=_(u"This shows a custom Logo on your Site."),
+        required=False,
+    )
 
     exposeDCMetaTags = schema.Bool(
         title=_(u"Expose Dublin Core metadata"),

--- a/Products/CMFPlone/tests/test_sitelogo.py
+++ b/Products/CMFPlone/tests/test_sitelogo.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from Products.CMFPlone.interfaces import ISiteSchema
+from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+import unittest2 as unittest
+
+# Red pixel with filename pixel.png
+SITE_LOGO_BASE64 = 'filenameb64:cGl4ZWwucG5n;datab64:iVBORw0KGgoAAAANSUhEUgAA'\
+                   'AAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4z8AAAAMBAQAY3Y2wAAAAA'\
+                   'ElFTkSuQmCC'
+SITE_LOGO_HEX = '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00'\
+                '\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDAT'\
+                '\x08\xd7c\xf8\xcf\xc0\x00\x00\x03\x01\x01\x00\x18\xdd\x8d'\
+                '\xb0\x00\x00\x00\x00IEND\xaeB`\x82'
+
+
+class SiteLogoFunctionalTest(unittest.TestCase):
+    """Test the site logo view.
+    """
+    layer = PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_sitelogo_view(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISiteSchema, prefix='plone')
+        settings.site_logo = SITE_LOGO_BASE64
+        view = self.portal.restrictedTraverse('@@site-logo')
+        self.assertTrue(view(), SITE_LOGO_HEX)
+        view.request.response
+        headers = view.request.response
+        self.assertTrue(headers['content-type'], 'image/png')
+        self.assertTrue(headers['content-length'], '69')
+        self.assertTrue(
+            headers['content-disposition'],
+            "attachment; filename*=UTF-8''pixel.png"
+        )


### PR DESCRIPTION
- Caching for ``@@site-logo``.

- Support for portal site logos stored in the portal registry by uploading via
  the site control panel. Add a ``@@site-logo`` view for downloading the logo.

Needs:
- https://github.com/plone/plone.formwidget.namedfile/pull/15
- https://github.com/plone/plone.app.layout/pull/38