### PR TITLE
fix bad test

### DIFF
--- a/Products/CMFPlone/tests/testSecurityDeclarations.py
+++ b/Products/CMFPlone/tests/testSecurityDeclarations.py
@@ -115,7 +115,7 @@ class TestSecurityDeclarations(RestrictedPythonTest):
 
     def testUse_Batch(self):
         self.check('from Products.CMFPlone import Batch;'
-                   'print Batch([], 0).nexturls')
+                   'print Batch([], 10).nexturls')
 
     # utils
 


### PR DESCRIPTION
The test creates a batch with a batch size of 0
which implicitly adds a orphansize of 0.
This is nonsense configuration and an assertion in a pending PR checks
for such nonsense.
@saily