### PR TITLE
Prevent patterns from being scanned/initialized multiple times.

### DIFF
--- a/Products/CMFPlone/static/plone.js
+++ b/Products/CMFPlone/static/plone.js
@@ -30,7 +30,7 @@ if (window.jQuery) {
 
 require([
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-base',
 
   'mockup-patterns-select2',
@@ -48,12 +48,16 @@ require([
   'bootstrap-dropdown',
   'bootstrap-collapse',
   'bootstrap-tooltip'
-], function($, Registry) {
+], function($, registry, Base) {
   'use strict';
 
   // initialize only if we are in top frame
   if (window.parent === window) {
-    Registry.init();
+    $(document).ready(function() {
+      $('body').addClass('pat-plone');
+      if (!registry.initialized) {
+        registry.init();
+      }
+    });
   }
-
 });

--- a/Products/CMFPlone/static/resourceregistry.js
+++ b/Products/CMFPlone/static/resourceregistry.js
@@ -2,7 +2,6 @@
 
 (function() {
   'use strict';
-
   require(['jquery'], function($){
     $(document).ready(function() {
       requirejs.config({
@@ -10,8 +9,10 @@
           'mockup-patterns-resourceregistry-url': '++resource++mockup/resourceregistry'
         }
       });
-      require(['++resource++mockup/resourceregistry/pattern.js', 'mockup-registry'], function(ResourceRegistry, Registry){
-        Registry.scan($('.pat-resourceregistry'));
+      require(['++resource++mockup/resourceregistry/pattern.js', 'pat-registry'], function(resourceRegistry, registry){
+        if (!registry.initialized) {
+          registry.init();
+        }
       });
     });
   });


### PR DESCRIPTION
For reference, see my comment here:
https://github.com/Patternslib/Patterns/issues/396#issuecomment-73722048

This commit is also relate to https://github.com/plone/mockup/pull/462

*Here follow the same explanation as in that pull request:*

If we have multiple bundles that all pull in pat-registry and then call registry.scan, then patterns will be scanned and initialized multiple times.

Instead, we need to call registry.init if it's not been called before. If it's been called before, we don't need to do anything because the patterns will automatically be registered as soon as they are loaded by require.js and evaluated by the JS engine and then automatically scanned by the registry.

*Note:* this change relies on the Patternslib registry and won't work with the fork @vangheem made of pat-registry. Hopefully that fork can now be discarded.