### PR TITLE
Implement resource blacklist to avoid importing known bad legacy resources.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Changelog
 5.0b2 (unreleased)
 ------------------
 
+- Add `resource_blacklist` attribute to resource registry importer, to
+  allow filtering of known bad legacy resource imports.  Filter js from
+  plone.app.jquery.
+  [alecm]
+
 - Fix broken "Installing a third party add-on" link
   [cedricmessiant]
 
@@ -16,7 +21,6 @@ Changelog
 
 - Fix resource registry javascript build
   [vangheem]
-
 
 - Move `plone.htmlhead.links` viewlet manager after `plone.scripts`,
   because the former is sometimes used to include scripts that depend on

--- a/Products/CMFPlone/resources/exportimport/jsregistry.py
+++ b/Products/CMFPlone/resources/exportimport/jsregistry.py
@@ -25,5 +25,5 @@ class JSRegistryNodeAdapter(ResourceRegistryNodeAdapter):
 
     # We already have jQuery, blacklist legacy installs of plone.app.jquery js
     resource_blacklist = set((
-        "++resource++/plone.app.jquery.js",
+        "++resource++plone.app.jquery.js",
     ))

--- a/Products/CMFPlone/resources/exportimport/jsregistry.py
+++ b/Products/CMFPlone/resources/exportimport/jsregistry.py
@@ -22,3 +22,8 @@ class JSRegistryNodeAdapter(ResourceRegistryNodeAdapter):
     resource_type = 'javascript'
     register_method = 'registerScript'
     update_method = 'updateScript'
+
+    # We already have jQuery, blacklist legacy installs of plone.app.jquery js
+    resource_blacklist = set((
+        "++resource++/plone.app.jquery.js",
+    ))

--- a/Products/CMFPlone/resources/exportimport/resourceregistry.py
+++ b/Products/CMFPlone/resources/exportimport/resourceregistry.py
@@ -36,6 +36,8 @@ def importResRegistry(context, reg_id, reg_title, filename):
 
 class ResourceRegistryNodeAdapter(XMLAdapterBase):
 
+    resource_blacklist = set()
+
     def _importNode(self, node):
         """Import the object from the DOM node.
         """
@@ -83,6 +85,10 @@ class ResourceRegistryNodeAdapter(XMLAdapterBase):
                     position = ('',)
                     continue
                 if key == 'id':
+                    if value in self.resource_blacklist:
+                        add = False
+                        data.clear()
+                        break
                     res_id = queryUtility(IIDNormalizer).normalize(str(value))
                     data['url'] = str(value)
                 elif value.lower() == 'false':


### PR DESCRIPTION
This pull request implements an attribute on the legacy js/css resource node adapters that can be used to list resources which are known to be incompatible with Plone 5.0 and ensure they are not imported.  Specifically, the plone.app.jquery.js resource is blacklisted from inclusion by addons, because Plone 5.0 already includes jQuery.