### PR TITLE
Fix broken 'Installing a third party add-on' link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0b2 (unreleased)
 ------------------
 
+- Fix broken "Installing a third party add-on" link
+  [cedricmessiant]
+
 - Fix folder contents button disappeared act
   [vangheem]
 

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -26,7 +26,7 @@
           configuration, run buildout, and restart the server process.
           For detailed instructions see
           <span i18n:name="third_party_product">
-          <a i18n:translate="" href="http://plone.org/documentation/tutorial/buildout/installing-a-third-party-product">
+          <a i18n:translate="" href="http://docs.plone.org/old-reference-manuals/buildout/thirdparty.html">
             Installing a third party add-on
           </a>
           </span>.


### PR DESCRIPTION
I'm not sure if it should be fixed here or in the documentation.