### PR TITLE
Provide information about broken packages in add-ons control panel

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -196,6 +196,28 @@
           </section>
         </section>
 
+        <section tal:define="products view/get_broken;
+                             num_products python:len(products);"
+                 tal:condition="num_products"
+                 id="broken-products" class="portlet">
+          <header class="portletHeader" i18n:translate="">Broken add-ons</header>
+          <section class="portletContent">
+            <ul class="configlets">
+              <li tal:repeat="product products">
+                <h3>
+                  <span tal:replace="product/productname">
+                    Add-on Name
+                  </span>
+                </h3>
+                <p class="configletDescription discreet">
+                  <span tal:content="product/type">Error Type</span>
+                  <em class="discreet"> - <tal:span tal:content="product/value">Error Reason</tal:span></em>
+                </p>
+              </li>
+            </ul>
+          </section>
+        </section>
+
     </div>
 </metal:main>
 


### PR DESCRIPTION
This pull request provides a listing of add-on packages that are broken and therefore not installable in the add-ons control panel.

The purpose is to assist product developers in diagnosing the reason for their package not appearing in the list of available packages.  It would also be of use to site managers who attempt to add an add-on that does not properly declare package dependencies.  

A [related pull request](https://github.com/plone/plonetheme.barceloneta/pull/13) to plonetheme.barceloneta provides the css styles required to keep the styling of this new listing in accordance with those for the existing listings.

Addresses issue #419 