### PR TITLE
Revert removal of portal_quickinstaller.installProducts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 5.0b4 (unreleased)
 ----------------
 
+- Fix add-ons to be installed using CMFQuickInstaller (restore support
+  for Extensions/Install.py)
+  [datakurre]
+
 - Rename showEditableBorder to showToolbar and deprecate using
   disable_border and enable_border for enable_toolbar and disable_toolbar
   [vangheem]

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -131,7 +131,7 @@
                 <form action="install_products" method="post" class="pull-right">
                    <input type="hidden"
                            name="install_products:list"
-                           tal:attributes="value string:profile-${product/install_profile/id};" />
+                           tal:attributes="value pid;" />
                    <span i18n:translate="label_product_install_action">
                       <span i18n:name="install_button">
                          <input class="context"

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.py
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.py
@@ -203,20 +203,14 @@ class UpgradeProductsView(BrowserView):
 class InstallProductsView(BrowserView):
 
     def __call__(self):
-        """
-        Install products by running the default import steps
-        XXX: is this running all profiles?
-        """
-        setupTool = getToolByName(self.context, 'portal_setup')
-        profiles = self.request.get('install_products')
+        qi = getToolByName(self.context, 'portal_quickinstaller')
+        products = self.request.get('install_products')
         msg_type = 'info'
-        if profiles:
+        if products:
             messages = IStatusMessage(self.request)
-            for profile in profiles:
-                # TODO: find out where this is and don't run already
-                # activated profiles
-                setupTool.runAllImportStepsFromProfile(profile)
-                msg = _(u'Installed ${product}!', mapping={'product': profile})
+            for product in products:
+                qi.installProducts(products=[product, ])
+                msg = _(u'Installed ${product}!', mapping={'product': product})
                 messages.addStatusMessage(msg, type=msg_type)
 
         purl = getToolByName(self.context, 'portal_url')()
@@ -225,7 +219,6 @@ class InstallProductsView(BrowserView):
 
 class UninstallProductsView(BrowserView):
     def __call__(self):
-        # XXX: Need to call the uninstall profile
         qi = getToolByName(self.context, 'portal_quickinstaller')
         products = self.request.get('uninstall_products')
         msg_type = 'info'


### PR DESCRIPTION
Fixes #443 

It seems that the goal was to drop support for QuickInstaller in favor of GS' "default"-profile for install, upgradeSteps for upgrade and "uninstall" profile for uninstall. Yet, this seem to be much for existing add-ons (especially, because "uninstall" profile has never been even as "official" as default profile and there's no way beyond portal_setup to import uninstall-profiles in Plone 4).

Also, QI has historically provided magical uninstall for simple products, which many have used to rely on, and for which there's not yet any replacement. (Although, it might not have support for p.a.registry yet.)
