### PR TITLE
Remove Zope branding

### DIFF
--- a/Products/CMFPlone/browser/templates/plone-overview.pt
+++ b/Products/CMFPlone/browser/templates/plone-overview.pt
@@ -133,7 +133,7 @@
         tal:attributes="href string:${context/absolute_url}/manage_main"
         title="Go to the ZMI"
         i18n:attributes="title;"
-        i18n:translate="label_zmi_link">Zope Management Interface</a>
+        i18n:translate="label_zmi_link">Advanced Management Interface</a>
       <span i18n:translate="label_zmi_link_description"> &#151; low-level technical configuration.</span>
     </p>
     <p>

--- a/Products/CMFPlone/profiles/default/controlpanel.xml
+++ b/Products/CMFPlone/profiles/default/controlpanel.xml
@@ -98,7 +98,7 @@
     i18n:attributes="title">
   <permission>Plone Site Setup: Security</permission>
  </configlet>
- <configlet title="Zope Management Interface" action_id="ZMI" appId="ZMI"
+ <configlet title="Advanced Management Interface" action_id="ZMI" appId="ZMI"
     category="Plone" condition_expr=""
     icon_expr="string:$portal_url/zope_icon.png"
     url_expr="string:${portal_url}/manage_main" visible="True"

--- a/Products/CMFPlone/skins/plone_login/logged_out.cpt
+++ b/Products/CMFPlone/skins/plone_login/logged_out.cpt
@@ -31,7 +31,7 @@
 
 <tal:notloggedoutafterall tal:condition="not: isAnon">
     <h1 class="documentFirstHeading"
-        i18n:translate="heading_quit_to_log_out">Still logged in as a Zope user</h1>
+        i18n:translate="heading_quit_to_log_out">Still logged in to the Advanced Management Interface</h1>
 
     <div class="documentDescription" i18n:translate="description_quit_to_log_out">
         You are logged in via HTTP authentication (i.e. the Zope Management


### PR DESCRIPTION
This is absolutely, positively **not** to be interpreted as anti-Zope sentiment, rather it's a pro-consistent-Plone-marketing statement. We no longer need to associate Plone with Zope technologies in any public-facing way **inside** the Plone product nor should we. Strategic alignment with Zope on websites, social media, etc is still absolutely fine and should still be encouraged (e.g. I still <3 Zope!) But the Plone product itself should scream "I am Plone!" not "I am a mixture of Plone and Zope!" The latter serves no purpose anymore but to confuse people and hinder Plone's mission to be the leading open source enterprise CMS.