### PR TITLE
Fix email validation of long domain names.

### DIFF
--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -69,7 +69,8 @@ CEILING_DATE = DefaultDublinCoreImpl._DefaultDublinCoreImpl__CEILING_DATE
 FLOOR_DATE = DefaultDublinCoreImpl._DefaultDublinCoreImpl__FLOOR_DATE
 BAD_CHARS = bad_id.__self__.findall
 
-EMAIL_RE = re.compile(r"^(\w&.%#$&'\*+-/=?^_`{}|~]+!)*[\w&.%#$&'\*+-/=?^_`{}|~]+@(([0-9a-z]([0-9a-z-]*[0-9a-z])?\.)+[a-z]{2,6}|([0-9]{1,3}\.){3}[0-9]{1,3})$", re.IGNORECASE)
+# max 63 chars per label in domains, see RFC1035
+EMAIL_RE = re.compile(r"^(\w&.%#$&'\*+-/=?^_`{}|~]+!)*[\w&.%#$&'\*+-/=?^_`{}|~]+@(([0-9a-z]([0-9a-z-]*[0-9a-z])?\.)+[a-z]{2,63}|([0-9]{1,3}\.){3}[0-9]{1,3})$", re.IGNORECASE)
 # used to find double new line (in any variant)
 EMAIL_CUTOFF_RE = re.compile(r".*[\n\r][\n\r]")
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,7 +8,8 @@ Changelog
 4.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix email validation of long domain names.
+  [gotcha]
 
 
 4.3.6 (2015-06-02)


### PR DESCRIPTION
Email regexp sits in two places :-(

Products.validation has already been fixed.