### PR TITLE
Fix search page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 5.0b3 (unreleased)
 ------------------
 
+- use ajax_load in @@search when loading results dynamically, and add missing
+  closing tag
+  [ebrehault]
+
 - better formatting of config.js
   [vangheem]
 

--- a/Products/CMFPlone/browser/static/search.js
+++ b/Products/CMFPlone/browser/static/search.js
@@ -50,7 +50,7 @@ require([
     $loader.show();
     pushHistory();
     $.ajax({
-      url: window.location.origin + window.location.pathname,
+      url: window.location.origin + window.location.pathname + '?ajax_load=1',
       data: $('#searchform').serialize()
     }).done(function(html){
       var $html = $(html);

--- a/Products/CMFPlone/browser/templates/search.pt
+++ b/Products/CMFPlone/browser/templates/search.pt
@@ -190,11 +190,12 @@
                   <strong i18n:name="number" id="search-results-number"
                           tal:content="batch/sequence_length|string:0">234</strong>
                     items matching your search terms.
-                  </span>
+                </span>
+              </div>
 
                   
 
-                <metal:searchresults define-macro="search_results">
+              <metal:searchresults define-macro="search_results">
                 <div class="autotabs">
                   <nav class="autotoc-nav" id="searchResultsSort">
                     <span i18n:translate="sort_by" class="autotab-heading">Sort by</span>


### PR DESCRIPTION
- add a missing closing tag
- use `ajax_load` when loading results for performances sakes and to avoid funky side effects in Diazo