### PR TITLE
let plone.app.theming manage it's own cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0b3 (unreleased)
 ------------------
 
+- Use new plone.app.theming policy API and delegate theme cache to plone.app.theming
+  [gyst]
+
 - Fix issue where site root syndication was giving 404s
   [vangheem]
 

--- a/Products/CMFPlone/resources/__init__.py
+++ b/Products/CMFPlone/resources/__init__.py
@@ -1,20 +1,9 @@
-from zope.component import adapter
-from plone.app.theming.interfaces import IThemeAppliedEvent
 import os
-from zope.component.hooks import getSite
 
 
 RESOURCE_DEVELOPMENT_MODE = False
 if os.getenv('FEDEV', '').lower() == 'true':
     RESOURCE_DEVELOPMENT_MODE = True
-
-
-@adapter(IThemeAppliedEvent)
-def onThemeApplied(event):
-    # change current theme on the _v_ variable
-    theme = event.theme
-    portal = getSite()
-    portal._v_currentTheme = theme
 
 
 def add_resource_on_request(request, resource):

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -5,9 +5,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IBundleRegistry
 from Products.CMFPlone.interfaces import IResourceRegistry
 from plone.app.layout.viewlets.common import ViewletBase
-from plone.app.theming.utils import getCurrentTheme
-from plone.app.theming.utils import getTheme
-from plone.app.theming.utils import isThemeEnabled
+from plone.app.theming.utils import theming_policy
 from plone.registry.interfaces import IRegistry
 from zope import component
 from zope.component import getMultiAdapter
@@ -99,16 +97,10 @@ class ResourceView(ViewletBase):
         """
         cache = component.queryUtility(ram.IRAMCache)
         bundles = self.get_bundles()
+        policy = theming_policy(self.request)
         # Check if its Diazo enabled
-        if isThemeEnabled(self.request):
-            portal = self.portal_state.portal()
-            # Volatile attribute to cache the current theme
-            if hasattr(portal, '_v_currentTheme'):
-                themeObj = portal._v_currentTheme
-            else:
-                theme = getCurrentTheme()
-                themeObj = getTheme(theme)
-                portal._v_currentTheme = themeObj
+        if policy.isThemeEnabled():
+            themeObj = policy.get_theme()
             enabled_diazo_bundles = themeObj.enabled_bundles
             disabled_diazo_bundles = themeObj.disabled_bundles
             if hasattr(themeObj, 'production_css'):

--- a/Products/CMFPlone/resources/configure.zcml
+++ b/Products/CMFPlone/resources/configure.zcml
@@ -2,10 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="plone.registry">
 
-    <!-- subscribe to event when theme is applied so we can
-         check for bundles enabled or disabled -->
-    <subscriber handler=".onThemeApplied" />
-
     <include package=".browser" />
     <include package=".exportimport" />
 


### PR DESCRIPTION
Following the merge of the new plone.app.theming policy API
https://github.com/plone/plone.app.theming/commit/3756dbd45db394f112fae9ff25a532934013e1b5

This pull:
- Uses the new theming policy API
- Removes the event-driven theme cache from CMFPlone and instead delegates all theme caching to plone.app.theming, where it has been re-implemented.

Merging this, in combination with the plone.app.theming change which has been merged already, makes it possible for integrators to implement theme switching in Plone 5 as documented here:
http://docs.ploneintranet.org/development/components/themeswitcher.html