### PR TITLE
Rework timezone selector.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,15 @@ Changelog
 
 - Fix link to documentation
 
+- Rework timezone selection in @@plone-addsite.
+  [jaroel]
+
+- Rework language selection in @@plone-addsite.
+  [jaroel]
+
 
 5.0b3 (2015-07-20)
 ------------------
-- Rework language selection in @@plone-addsite.
-  [jaroel]
 
 - show toolbar buttons on sitemap, accessibility and search pages
   [vangheem]

--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -190,12 +190,7 @@ class AddPloneSite(BrowserView):
         # Group country specific versions by language
         grouped = OrderedDict()
         for langcode, data in available.items():
-            splitted = langcode.split('-')
-            lang = splitted.pop(0)
-            try:
-                locale = splitted.pop(0)
-            except IndexError:
-                locale = None
+            lang = langcode.split('-')[0]
             language = languages.get(lang, lang)  # Label
 
             struct = grouped.get(lang, {'label': language, 'languages': []})
@@ -219,8 +214,19 @@ class AddPloneSite(BrowserView):
             IVocabularyFactory,
             'plone.app.vocabularies.CommonTimezones'
         )(self.context)
-        tz_list = [it.value for it in tz_vocab]
-        return tz_list
+
+        grouped = OrderedDict()
+        tz_values = [it.value for it in tz_vocab]
+        for value in tz_values:
+            splitted = value.split('/')
+            group = splitted.pop(0)
+            label = u'/'.join(splitted)
+
+            entries = grouped.get(group, [])
+            entries.append({'label': label or group, 'value': value})
+            grouped[group] = entries
+
+        return grouped
 
     def __call__(self):
         context = self.context

--- a/Products/CMFPlone/browser/templates/plone-addsite.pt
+++ b/Products/CMFPlone/browser/templates/plone-addsite.pt
@@ -131,12 +131,14 @@
         <select id="portal_timezone"
           name="portal_timezone"
           tal:define="tz_list view/timezones">
+          <optgroup tal:repeat="group tz_list" tal:attributes="label group">
           <option value="UTC"
-                  tal:repeat="tz tz_list"
-                  tal:attributes="value tz"
-                  tal:content="tz">
+                  tal:repeat="tz python:tz_list[group]"
+                  tal:attributes="value tz/value"
+                  tal:content="tz/label">
               UTC
           </option>
+          </optgroup>
         </select>
       </div>
 


### PR DESCRIPTION
Group language in the timezone selector by 'continent'.
This allows us to type 'Amsterdam' instead of 'Europe/Amsterdam'

![screen shot 2015-07-23 at 10 53 19](https://cloud.githubusercontent.com/assets/70700/8846636/1850b172-3129-11e5-83e3-a4dc9b9e2289.png)
