### PR TITLE
Fix link to docs.plone.org

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 5.0b4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix link to documentation
 
 
 5.0b3 (2015-07-20)

--- a/Products/CMFPlone/browser/templates/plone-frontpage.pt
+++ b/Products/CMFPlone/browser/templates/plone-frontpage.pt
@@ -32,7 +32,7 @@ Before you start exploring your newly created Plone site, please do the followin
 
 <ul>
     <li>Find out <a class="link-plain" href="http://plone.com/features/" target="_blank">What's new in Plone</a>.</li>
-    <li>Read the <a class="link-plain" href="http://plone.org/documentation/" target="_blank">documentation</a>.
+    <li>Read the <a class="link-plain" href="http://docs.plone.org" target="_blank">documentation</a>.
     </li>
     <li>Explore the <a class="link-plain" href="http://plone.org/products" target="_blank">available add-ons</a> for Plone.</li>
     <li>Read and/or subscribe to the <a class="link-plain" href="http://plone.org/support" target="_blank">support channels</a>.</li>


### PR DESCRIPTION
Fixes link on plone-frontpage to link to docs.plone.org 