### PR TITLE
Remove Products.ExternalEditor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Products.CMFUid',
         'Products.DCWorkflow',
         'Products.ExtendedPathIndex',
-        'Products.ExternalEditor',
         'Products.GenericSetup >=1.4',
         'Products.MimetypesRegistry',
         'Products.PasswordResetTool',


### PR DESCRIPTION
Seems to not be used anywhere...

There should fail only the tests in CMFPlone itself that test that it works... should that code be moved to P.ExternalEditor itself?

Actually the point of this pull request is to get rid of the last svn dependencies that we still have...