### PR TITLE
@@tinymce-controlpanel content_css attribute must be a list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,11 @@ Changelog
 - Rework language selection in @@plone-addsite.
   [jaroel]
 
+- Turn @@tinymce-controlpanel ``content_css`` field into a list, so we can add
+  several CSS URLs (useful when add-ons need to provide extra TinyMCE styles),
+  and fix TinyMCE config getter so it considers the ``content_css`` value.
+  [ebrehault]
+
 
 5.0b3 (2015-07-20)
 ------------------

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -397,7 +397,7 @@ class ITinyMCELayoutSchema(Interface):
         default=None,
         required=False)
 
-    content_css = schema.TextLine(
+    content_css = schema.List(
         title=_(u"Choose the CSS used in WYSIWYG Editor Area"),
         description=_(u"This option enables you to specify a custom CSS file "
                       "that provides content CSS. "
@@ -405,7 +405,10 @@ class ITinyMCELayoutSchema(Interface):
                       "(the editable area). In addition to what is listed here, "
                       "the plone bundle CSS and diazo themes using the "
                       "tinymce-content-css setting are also added."),
-        default=u'++plone++static/components/tinymce/skins/lightgray/content.min.css',
+        value_type=schema.TextLine(),
+        default=[
+            u'++plone++static/components/tinymce/skins/lightgray/content.min.css',
+        ],
         required=False)
 
     header_styles = schema.List(

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -34,6 +34,8 @@ class TinyMCESettingsGenerator(object):
             '%s/++plone++static/plone-compiled.css' % self.portal_url,
             '%s/++plone++static/tinymce-styles.css' % self.portal_url
         ]
+        for url in self.settings.content_css:
+            files.append('%s/%s' % (self.portal_url, url))
         theme = self.get_theme()
         if (theme and hasattr(theme, 'tinymce_content_css') and
                 theme.tinymce_content_css):

--- a/Products/CMFPlone/profiles/default/metadata.xml
+++ b/Products/CMFPlone/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>5006</version>
+  <version>5007</version>
 </metadata>

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -88,7 +88,9 @@
   <records interface="Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings" />
   <records interface="Products.CMFPlone.interfaces.ITinyMCESchema"
            prefix="plone">
-    <value key="content_css">++plone++static/components/tinymce-builded/js/tinymce/skins/lightgray/content.min.css</value>
+    <value key="content_css">
+      <element>++plone++static/components/tinymce-builded/js/tinymce/skins/lightgray/content.min.css</element>
+    </value>
   </records>
   <record name="plone.resources.development">
     <field type="plone.registry.field.Bool">


### PR DESCRIPTION
- Turn @@tinymce-controlpanel `content_css` field into a list, so we can add several CSS URLs (useful when add-ons need to provide extra TinyMCE styles),
- fix TinyMCE config getter so it considers the ``content_css`` value.