### PR TITLE
Upgrade core addons at end of Plone migration

### DIFF
--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -26,6 +26,84 @@ logger = logging.getLogger('plone.app.upgrade')
 _upgradePaths = {}
 
 
+class Addon(object):
+    """A profile or product.
+
+    This is meant for core Plone packages, especially packages that
+    are marked as not installable (INonInstallable from
+    CMFQuickInstallerTool).  These are packages that an admin should
+    not activate, deactivate or upgrade manually, but that should be
+    handled by Plone.
+
+    Most of this is already handled in plone.app.upgrade.  But when
+    you have added an upgrade step to such a package, it can be hard
+    to remember that you should also arrange that plone.app.upgrade
+    applies this upgrade step.  This leads to an upgraded Plone Site
+    where some core packages are not updated.  Or the upgrade handlers
+    are run, but the version of the profile is not upgraded in the
+    GenericSetup tool.
+    """
+
+    def __init__(self, profile_id=None, check_module=None):
+        self.profile_id = profile_id
+        self.check_module = check_module
+
+    def __repr__(self):
+        return u'<{0} profile {1}>'.format(
+            self.__class__.__name__, self.profile_id)
+
+    def safe(self):
+        """Is this addon safe to upgrade?
+
+        Is it safe to pass its profile id to
+        portal_setup.upgradeProfile?  That method checks if the
+        profile is 'unknown' and in this case does nothing.
+
+        But in some cases the profile may have been applied, but the
+        package is gone.  For that case, you can set
+        self.check_module.
+        """
+        if self.check_module:
+            # Can we import a module, as evidence that the code is
+            # available?  Note that some modules may have been faked,
+            # to avoid breakage.  For example on Plone 5.0 the
+            # Products.TinyMCE module is faked by plone.app.upgrade.
+            try:
+                __import__(self.check_module)
+            except ImportError:
+                logger.info('Cannot import module %s. Ignoring %s',
+                            self.check_module, self)
+                return False
+        return True
+
+
+class AddonList(list):
+
+    def upgrade_all(self, context):
+        setup = getToolByName(context, 'portal_setup')
+        for addon in self:
+            if addon.safe():
+                setup.upgradeProfile(addon.profile_id)
+
+
+# List of upgradeable packages.  Obvious items to add here, are all
+# core packages that actually have upgrade steps.
+# Good start is portal_setup.listProfilesWithUpgrades()
+ADDON_LIST = AddonList([
+    Addon(profile_id=u'Products.CMFEditions:CMFEditions'),
+    Addon(profile_id=u'Products.TinyMCE:TinyMCE',
+        check_module='Products.TinyMCE.upgrades'),
+    Addon(profile_id=u'plone.app.dexterity:default'),
+    Addon(profile_id=u'plone.app.discussion:default'),
+    Addon(profile_id=u'plone.app.iterate:plone.app.iterate'),
+    Addon(profile_id=u'plone.app.jquery:default'),
+    Addon(profile_id=u'plone.app.jquerytools:default'),
+    Addon(profile_id=u'plone.app.querystring:default'),
+    Addon(profile_id=u'plone.app.theming:default'),
+    Addon(profile_id=u'plonetheme.sunburst:default'),
+    ])
+
+
 class MigrationTool(PloneBaseTool, UniqueObject, SimpleItem):
     """Handles migrations between Plone releases"""
 
@@ -192,6 +270,10 @@ class MigrationTool(PloneBaseTool, UniqueObject, SimpleItem):
                         # abort transaction to safe the zodb
                         transaction.abort()
                         break
+
+            logger.info("Starting upgrade of core addons.")
+            ADDON_LIST.upgrade_all(self)
+            logger.info("Done upgrading core addons.")
 
             logger.info("End of upgrade path, migration has finished")
 

--- a/Products/CMFPlone/tests/testMigrationTool.py
+++ b/Products/CMFPlone/tests/testMigrationTool.py
@@ -76,3 +76,124 @@ class TestMigrationTool(PloneTestCase.PloneTestCase):
         # There are no more upgrade steps available
         upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
         self.assertTrue(len(upgrades) == 0)
+
+
+class TestAddonList(PloneTestCase.PloneTestCase):
+
+    def test_addon_safe(self):
+        from Products.CMFPlone.MigrationTool import Addon
+        addon = Addon(profile_id=_DEFAULT_PROFILE)
+        self.assertTrue(addon.safe())
+        addon = Addon(profile_id=_DEFAULT_PROFILE,
+                      check_module='Products.CMFPlone')
+        self.assertTrue(addon.safe())
+        addon = Addon(profile_id=_DEFAULT_PROFILE,
+                      check_module='Products.CMFPlone.foobarbaz')
+        self.assertFalse(addon.safe())
+
+    def test_addon_repr(self):
+        from Products.CMFPlone.MigrationTool import Addon
+        addon = Addon(profile_id='foo')
+        self.assertEqual(repr(addon), u'<Addon profile foo>')
+        self.assertEqual(str(addon), '<Addon profile foo>')
+
+    def test_upgrade_all(self):
+        from Products.CMFPlone.MigrationTool import Addon
+        from Products.CMFPlone.MigrationTool import AddonList
+        # real ones:
+        cmfeditions = Addon(profile_id=u'Products.CMFEditions:CMFEditions')
+        discussion = Addon(profile_id=u'plone.app.discussion:default')
+        # real one with failing check_module:
+        dexterity = Addon(profile_id=u'plone.app.dexterity:default',
+                          check_module='no.such.module')
+        # non-existing one:
+        foo = Addon(profile_id='foo')
+        addonlist = AddonList([
+            cmfeditions,
+            discussion,
+            dexterity,
+            foo
+            ])
+        # Calling it should give no errors.
+        addonlist.upgrade_all(self.portal)
+
+        # Get the last CMFEditions profile version, as that will be
+        # the only one that gets upgraded during the second upgrade.
+        setup = getToolByName(self.portal, "portal_setup")
+        cmfeditions_version = setup.getLastVersionForProfile(
+            cmfeditions.profile_id)
+
+        # Now mess with the profile versions.
+        setup.setLastVersionForProfile(cmfeditions.profile_id, '2.0')
+        setup.setLastVersionForProfile(dexterity.profile_id, '0.1')
+        # 'unknown' needs special handling, otherwise the version will
+        # become a tuple ('unknown',):
+        setup._profile_upgrade_versions[discussion.profile_id] = 'unknown'
+
+        # Run the upgrade again.
+        addonlist.upgrade_all(self.portal)
+
+        # Check the profile versions.
+        # CMFEditions should be the last one:
+        self.assertEqual(
+            setup.getLastVersionForProfile(cmfeditions.profile_id),
+            cmfeditions_version)
+        # We had set discussion to unknown, so it will not have been
+        # upgraded:
+        self.assertEqual(
+            setup.getLastVersionForProfile(discussion.profile_id),
+            'unknown')
+        # We had given dexterity a failing check_module, so it will
+        # not have been upgraded:
+        self.assertEqual(
+            setup.getLastVersionForProfile(dexterity.profile_id),
+            ('0', '1'))
+        # The foo profile never existed:
+        self.assertEqual(
+            setup.getLastVersionForProfile(foo.profile_id),
+            'unknown')
+
+    def test_plone_addonlist_upgrade_all(self):
+        # Test the actual filled addon list.
+        from Products.CMFPlone.MigrationTool import ADDON_LIST
+        # Several addons did not get fully upgraded in the past, which
+        # is why this list was created.
+        cmfeditions_id = 'Products.CMFEditions:CMFEditions'
+        discussion_id = 'plone.app.discussion:default'
+        jq_id = 'plone.app.jquery:default'
+        jqtools_id = 'plone.app.jquerytools:default'
+        sunburst_id = 'plonetheme.sunburst:default'
+        # Note the current versions.
+        setup = getToolByName(self.portal, "portal_setup")
+        getversion = setup.getLastVersionForProfile
+        cmfeditions_version = getversion(cmfeditions_id)
+        discussion_version = getversion(discussion_id)
+        jq_version = getversion(jq_id)
+        jqtools_version = getversion(jqtools_id)
+        sunburst_version = getversion(sunburst_id)
+        # So let's mess with some profile versions.  We get some older
+        # versions that really exist.
+        setversion = setup.setLastVersionForProfile
+        setversion(cmfeditions_id, '2.0')
+        setversion(discussion_id, '100')
+        setversion(jq_id, '2')
+        setversion(jqtools_id, '1.0rc2')
+        setversion(sunburst_id, '2')
+        # Check that it worked, that the profile versions really are
+        # different.
+        self.assertNotEqual(cmfeditions_version, getversion(cmfeditions_id))
+        self.assertNotEqual(discussion_version, getversion(discussion_id))
+        self.assertNotEqual(jq_version, getversion(jq_id))
+        self.assertNotEqual(jqtools_version, getversion(jqtools_id))
+        self.assertNotEqual(sunburst_version, getversion(sunburst_id))
+
+        # Run the upgrade.
+        ADDON_LIST.upgrade_all(self.portal)
+
+        # Check that it worked, that the profiles are now at their
+        # original versions.
+        self.assertEqual(cmfeditions_version, getversion(cmfeditions_id))
+        self.assertEqual(discussion_version, getversion(discussion_id))
+        self.assertEqual(jq_version, getversion(jq_id))
+        self.assertEqual(jqtools_version, getversion(jqtools_id))
+        self.assertEqual(sunburst_version, getversion(sunburst_id))

--- a/Products/CMFPlone/tests/testMigrationTool.py
+++ b/Products/CMFPlone/tests/testMigrationTool.py
@@ -56,7 +56,22 @@ class TestMigrationTool(PloneTestCase.PloneTestCase):
         current = self.setup.getVersionForProfile(_DEFAULT_PROFILE)
         current = tuple(current.split('.'))
         last = self.setup.getLastVersionForProfile(_DEFAULT_PROFILE)
-        self.assertEquals(last, current)
+        self.assertEqual(last, current)
+
+        # There are no more upgrade steps available
+        upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
+        self.assertTrue(len(upgrades) == 0)
+
+    def testUpgrade(self):
+        self.setRoles(['Manager'])
+        self.setup.setLastVersionForProfile(_DEFAULT_PROFILE, '2.5')
+        self.migration.upgrade()
+
+        # And we have reached our current profile version
+        current = self.setup.getVersionForProfile(_DEFAULT_PROFILE)
+        current = tuple(current.split('.'))
+        last = self.setup.getLastVersionForProfile(_DEFAULT_PROFILE)
+        self.assertEqual(last, current)
 
         # There are no more upgrade steps available
         upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 4.3.7 (unreleased)
 ------------------
 
+- Upgrade known core packages at the end of the Plone migration.
+  [maurits]
+
 - Require ``POST`` request for various forms that send email.
   [maurits]
 
@@ -44,9 +47,9 @@ Changelog
   emails.
   [davidjb]
 
-- Fix: If a user "deletes" the same item twice (ex.: having two different tabs 
-  open and not realising it's already been deleted) any higher level item with 
-  the same short name will be deleted without trace. 
+- Fix: If a user "deletes" the same item twice (ex.: having two different tabs
+  open and not realising it's already been deleted) any higher level item with
+  the same short name will be deleted without trace.
   [gotcha]
 
 - Extended ulocalized_time for target_language


### PR DESCRIPTION
Note: this *might* need to be a PLIP, but I think not. I want it in 4.3.

I have been noticing too many cases where at the end of a Plone migration not all core addons had been upgraded.

In some cases, for example sunburst, the upgrade steps *were* applied but the upgrades tab of portal_setup still showed those steps as to do, because the profile version was not updated.

In other cases, for example TinyMCE, the upgrade steps were not applied at all.

For more detailed examples, see issue #812.

Most of these are details that can be fixed in various places in plone.app.upgrade, which I am doing too in https://github.com/plone/plone.app.upgrade/pull/42, but it is a bit of a hassle. Also, after adding an upgrade step to a package, it is easy to forget to arrange in plone.app.upgrade that this step is actually applied.

Solution proposed in this pull request: at the end of the Plone migration go through a list of known core profiles, see if there are still upgrade steps, and apply them.

This uses the `portal_setup.upgradeProfile` method that I added in Products.GenericSetup 1.7.7, which coredev 4.3 and 5.0 are now using.