### PR TITLE
Require POST for several mail scripts

### DIFF
--- a/Products/CMFPlone/skins/plone_form_scripts/discussion_reply.cpy
+++ b/Products/CMFPlone/skins/plone_form_scripts/discussion_reply.cpy
@@ -14,6 +14,9 @@ from Products.CMFPlone import PloneMessageFactory as _
 mtool = getToolByName(context, 'portal_membership')
 dtool = getToolByName(context, 'portal_discussion')
 req = context.REQUEST
+if req.get('REQUEST_METHOD', '').upper() != 'POST':
+    from zExceptions import Forbidden
+    raise Forbidden('Use POST please.')
 
 if username or password:
     # The user username/password inputs on on the comment form were used,

--- a/Products/CMFPlone/skins/plone_form_scripts/send_feedback.cpy
+++ b/Products/CMFPlone/skins/plone_form_scripts/send_feedback.cpy
@@ -9,6 +9,9 @@
 ##title=Send feedback to an author
 
 REQUEST = context.REQUEST
+if REQUEST.get('REQUEST_METHOD', '').upper() != 'POST':
+    from zExceptions import Forbidden
+    raise Forbidden('Use POST please.')
 
 from Products.CMFPlone.utils import transaction_note
 from Products.CMFCore.utils import getToolByName

--- a/Products/CMFPlone/skins/plone_form_scripts/send_feedback_site.cpy
+++ b/Products/CMFPlone/skins/plone_form_scripts/send_feedback_site.cpy
@@ -9,6 +9,9 @@
 ##title=Send feedback to portal administrator
 
 REQUEST = context.REQUEST
+if REQUEST.get('REQUEST_METHOD', '').upper() != 'POST':
+    from zExceptions import Forbidden
+    raise Forbidden('Use POST please.')
 
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _

--- a/Products/CMFPlone/skins/plone_form_scripts/sendto.cpy
+++ b/Products/CMFPlone/skins/plone_form_scripts/sendto.cpy
@@ -9,6 +9,9 @@
 ##title=Send an URL to a friend
 
 REQUEST = context.REQUEST
+if REQUEST.get('REQUEST_METHOD', '').upper() != 'POST':
+    from zExceptions import Forbidden
+    raise Forbidden('Use POST please.')
 
 from Products.CMFPlone.utils import transaction_note
 from Products.CMFPlone.PloneTool import AllowSendto

--- a/Products/CMFPlone/tests/testSecurityDeclarations.py
+++ b/Products/CMFPlone/tests/testSecurityDeclarations.py
@@ -407,6 +407,11 @@ class TestAllowSendtoSecurity(PloneTestCase.PloneTestCase):
         from Products.statusmessages.interfaces import IStatusMessage
         # Clean out any current status messages.
         IStatusMessage(request).show()
+        # First, a GET request will fail.
+        from zExceptions import Forbidden
+        self.assertRaises(Forbidden, sendto)
+        # So use a POST.
+        request['REQUEST_METHOD'] = 'POST'
         # Should fail with the not allowed msg as status message.
         sendto()
         status_messages = IStatusMessage(request).show()

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 4.3.7 (unreleased)
 ------------------
 
+- Require ``POST`` request for various forms that send email.
+  [maurits]
+
 - Properly hide ``plone.app.jquery`` and ``plone.app.jquerytools``
   from products.
   [maurits]


### PR DESCRIPTION
Otherwise someone could be tricked by a spammer into clicking a normal link and this could already send an email.

See https://pypi.python.org/pypi/collective.honeypot for background and for more radical fixes. I am looking into getting some of that into Plone 5. But these POSTs are the simple fixes that may already help a bit. Good for 4.3 I would say.