### PR TITLE
Connect Users & Groups control panel settings to their registry entries

### DIFF
--- a/Products/CMFPlone/controlpanel/bbb/usergroups.py
+++ b/Products/CMFPlone/controlpanel/bbb/usergroups.py
@@ -1,8 +1,8 @@
-from zope.component import getAdapter
-from zope.site.hooks import getSite
 from zope.component import adapts
+from zope.component import getUtility
 from zope.interface import implements
-from Products.CMFCore.utils import getToolByName
+from zope.site.hooks import getSite
+from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 
@@ -15,21 +15,28 @@ class UserGroupsSettingsControlPanelAdapter(object):
     def __init__(self, context):
         self.context = context
         self.portal = getSite()
-        pprop = getToolByName(context, 'portal_properties')
-        self.context = pprop.site_properties
+        registry = getUtility(IRegistry)
+        self.usergroups_settings = registry.forInterface(
+            IUserGroupsSettingsSchema, prefix="plone")
 
     def get_many_groups(self):
-        return self.context.many_groups
+        return self.usergroups_settings.many_groups
 
     def set_many_groups(self, value):
-        self.context.many_groups = value
+        if value:
+            self.usergroups_settings.many_groups = True
+        else:
+            self.usergroups_settings.many_groups = False
 
     many_groups = property(get_many_groups, set_many_groups)
 
     def get_many_users(self):
-        return self.context.many_users
+        return self.usergroups_settings.many_users
 
     def set_many_users(self, value):
-        self.context.many_users = value
+        if value:
+            self.usergroups_settings.many_users = True
+        else:
+            self.usergroups_settings.many_users = False
 
     many_users = property(get_many_users, set_many_users)

--- a/Products/CMFPlone/controlpanel/browser/usergroups.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups.py
@@ -59,13 +59,11 @@ class UsersGroupsControlPanelView(BrowserView):
 
     @property
     def many_users(self):
-        pprop = getToolByName(aq_inner(self.context), 'portal_properties')
-        return pprop.site_properties.many_users
+        return getAdapter(aq_inner(self.context), IUserGroupsSettingsSchema).many_users
 
     @property
     def many_groups(self):
-        pprop = getToolByName(aq_inner(self.context), 'portal_properties')
-        return pprop.site_properties.many_groups
+        return getAdapter(aq_inner(self.context), IUserGroupsSettingsSchema).many_groups
 
     @property
     def email_as_username(self):


### PR DESCRIPTION
Use the configuration registry for storing the many_users/many_groups properties.

See also https://github.com/plone/plone.app.upgrade/pull/44