### PR TITLE
Remove no-longer-used properties from portal_properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0b5 (unreleased)
 ------------------
 
+- Remove no-longer-used properties from portal_properties
+  [esteele]
+
 - pre-cook resources so we do not write on read for resources generation
   [vangheem]
 

--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -963,7 +963,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
         mt = getToolByName(self, 'portal_membership')
 
         registry = getUtility(IRegistry)
-        site_settings = registry.forInterface(ISiteSchema, prefix="plone")
+        site_settings = registry.forInterface(ISiteSchema, prefix="plone", check=False)
         use_all = site_settings.exposeDCMetaTags
 
         security_settings = registry.forInterface(

--- a/Products/CMFPlone/browser/navigation.py
+++ b/Products/CMFPlone/browser/navigation.py
@@ -154,9 +154,8 @@ class CatalogNavigationTabs(BrowserView):
             if sortOrder is not None:
                 query['sort_order'] = sortOrder
 
-        if navtree_properties.getProperty('enable_wf_state_filtering', False):
-            query['review_state'] = navtree_properties.getProperty(
-                                                    'wf_states_to_show', [])
+        if navigation_settings.filter_on_workflow:
+            query['review_state'] = navigation_settings.workflow_states_to_show
 
         query['is_default_page'] = False
 

--- a/Products/CMFPlone/browser/navigation.py
+++ b/Products/CMFPlone/browser/navigation.py
@@ -160,8 +160,7 @@ class CatalogNavigationTabs(BrowserView):
 
         query['is_default_page'] = False
 
-        if self.site_properties.getProperty('disable_nonfolderish_sections',
-                                            False):
+        if not navigation_settings.nonfolderish_tabs:
             query['is_folderish'] = True
 
         return query

--- a/Products/CMFPlone/browser/navtree.py
+++ b/Products/CMFPlone/browser/navtree.py
@@ -5,6 +5,7 @@
 
 from zope.interface import implements
 from zope.component import getMultiAdapter, queryUtility
+from zope.component import getUtility
 
 from plone.app.layout.navigation.interfaces import INavigationQueryBuilder
 from plone.app.layout.navigation.interfaces import INavtreeStrategy
@@ -13,11 +14,13 @@ from plone.app.layout.navigation.navtree import NavtreeStrategyBase
 from plone.app.layout.navigation.root import getNavigationRoot
 
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.registry.interfaces import IRegistry
 
 from AccessControl import ModuleSecurityInfo
 from Acquisition import aq_inner
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
+from Products.CMFPlone.interfaces import INavigationSchema
 
 # Strategy objects for the navtree creation code. You can subclass these
 # to expand the default navtree behaviour, and pass instances of your
@@ -76,9 +79,12 @@ class NavtreeQueryBuilder(object):
                 query['sort_order'] = sortOrder
 
         # Filter on workflow states, if enabled
-        if navtree_properties.getProperty('enable_wf_state_filtering', False):
-            query['review_state'] = \
-                navtree_properties.getProperty('wf_states_to_show', ())
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(INavigationSchema,
+                                                    prefix="plone")
+
+        if navigation_settings.filter_on_workflow:
+            query['review_state'] = navigation_settings.workflow_states_to_show
 
         self.query = query
 

--- a/Products/CMFPlone/browser/ploneview.py
+++ b/Products/CMFPlone/browser/ploneview.py
@@ -6,6 +6,9 @@ from Products.CMFPlone import utils
 from Products.CMFPlone.browser.interfaces import IPlone
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import IEditingSchema
 from zope.deprecation import deprecate
 from zope.i18n import translate
 from zope.interface import implementer
@@ -43,8 +46,9 @@ class Plone(BrowserView):
         """Determine if visible ids are enabled
         """
         context = aq_inner(self.context)
-        props = getToolByName(context, "portal_properties").site_properties
-        if not props.getProperty('visible_ids', False):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IEditingSchema, prefix="plone")
+        if not settings.visible_ids:
             return False
 
         pm = getToolByName(context, "portal_membership")

--- a/Products/CMFPlone/browser/ploneview.py
+++ b/Products/CMFPlone/browser/ploneview.py
@@ -281,8 +281,8 @@ class Plone(BrowserView):
         """Returns an object which implements the IContentIcon interface and
         provides the informations necessary to render an icon. The item
         parameter needs to be adaptable to IContentIcon. Icons can be disabled
-        globally or just for anonymous users with the icon_visibility property
-        in site_properties.
+        globally or just for anonymous users with the icon_visibility site 
+        setting.
         """
         context = aq_inner(self.context)
         layout = getMultiAdapter((context, self.request), name=u'plone_layout')

--- a/Products/CMFPlone/controlpanel/bbb/usergroups.py
+++ b/Products/CMFPlone/controlpanel/bbb/usergroups.py
@@ -1,8 +1,8 @@
-from zope.component import getAdapter
-from zope.site.hooks import getSite
 from zope.component import adapts
+from zope.component import getUtility
 from zope.interface import implements
-from Products.CMFCore.utils import getToolByName
+from zope.site.hooks import getSite
+from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 
@@ -15,21 +15,28 @@ class UserGroupsSettingsControlPanelAdapter(object):
     def __init__(self, context):
         self.context = context
         self.portal = getSite()
-        pprop = getToolByName(context, 'portal_properties')
-        self.context = pprop.site_properties
+        registry = getUtility(IRegistry)
+        self.usergroups_settings = registry.forInterface(
+            IUserGroupsSettingsSchema, prefix="plone")
 
     def get_many_groups(self):
-        return self.context.many_groups
+        return self.usergroups_settings.many_groups
 
     def set_many_groups(self, value):
-        self.context.many_groups = value
+        if value:
+            self.usergroups_settings.many_groups = True
+        else:
+            self.usergroups_settings.many_groups = False
 
     many_groups = property(get_many_groups, set_many_groups)
 
     def get_many_users(self):
-        return self.context.many_users
+        return self.usergroups_settings.many_users
 
     def set_many_users(self, value):
-        self.context.many_users = value
+        if value:
+            self.usergroups_settings.many_users = True
+        else:
+            self.usergroups_settings.many_users = False
 
     many_users = property(get_many_users, set_many_users)

--- a/Products/CMFPlone/controlpanel/browser/usergroups.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups.py
@@ -59,13 +59,11 @@ class UsersGroupsControlPanelView(BrowserView):
 
     @property
     def many_users(self):
-        pprop = getToolByName(aq_inner(self.context), 'portal_properties')
-        return pprop.site_properties.many_users
+        return getAdapter(aq_inner(self.context), IUserGroupsSettingsSchema).many_users
 
     @property
     def many_groups(self):
-        pprop = getToolByName(aq_inner(self.context), 'portal_properties')
-        return pprop.site_properties.many_groups
+        return getAdapter(aq_inner(self.context), IUserGroupsSettingsSchema).many_groups
 
     @property
     def email_as_username(self):

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -264,13 +264,13 @@
                       style="text-align:center;">No matches</td>
 
                     <tal:block tal:condition="not:view/searchString">
-                      <td tal:condition="site_properties/many_users"
+                      <td tal:condition="view/many_users"
                         class="discreet"
                         i18n:translate="text_no_searchstring_large"
                         style="text-align:center; font-size: 100%;">
                         Enter a group or user name to search for.
                       </td>
-                      <td tal:condition="not:site_properties/many_users"
+                      <td tal:condition="not:view/many_users"
                         class="discreet"
                         i18n:translate="text_no_searchstring"
                         style="text-align:center; font-size: 100%;">

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
@@ -124,7 +124,7 @@
                        name="form.button.FindAll"
                        value="Show all"
                        i18n:attributes="value label_showall;"
-                       tal:condition="not:site_properties/many_groups"
+                       tal:condition="view/many_groups"
                        />
 
             </div>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
@@ -124,7 +124,7 @@
                        name="form.button.FindAll"
                        value="Show all"
                        i18n:attributes="value label_showall;"
-                       tal:condition="view/many_groups"
+                       tal:condition="not:view/many_groups"
                        />
 
             </div>

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -76,7 +76,7 @@ class IEditingSchema(Interface):
     available_editors = schema.List(
         title=_(u'Available editors'),
         description=_(u"Available editors in the portal."),
-        default=['TinyMCE'],
+        default=['TinyMCE', 'None'],
         value_type=schema.TextLine(),
         required=True
     )

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -859,28 +859,29 @@ class ISearchSchema(Interface):
         ),
         required=False,
         default=(
-            'ATBooleanCriterion',
-            'ATDateCriteria',
-            'ATDateRangeCriterion',
-            'ATListCriterion',
-            'ATPortalTypeCriterion',
-            'ATReferenceCriterion',
-            'ATSelectionCriterion',
-            'ATSimpleIntCriterion',
-            'ATSimpleStringCriterion',
-            'ATSortCriterion',
-            'ChangeSet',
             'Discussion Item',
             'Plone Site',
             'TempFolder',
-            'ATCurrentAuthorCriterion',
-            'ATPathCriterion',
-            'ATRelativePathCriterion',
         ),
         value_type=schema.Choice(
             source="plone.app.vocabularies.PortalTypes"
         ),
     )
+# TODO: These need to get moved into ATCT setup profile.
+# 'ATBooleanCriterion',
+# 'ATDateCriteria',
+# 'ATDateRangeCriterion',
+# 'ATListCriterion',
+# 'ATPortalTypeCriterion',
+# 'ATReferenceCriterion',
+# 'ATSelectionCriterion',
+# 'ATSimpleIntCriterion',
+# 'ATSimpleStringCriterion',
+# 'ATSortCriterion',
+# 'ChangeSet',
+# 'ATCurrentAuthorCriterion',
+# 'ATPathCriterion',
+# 'ATRelativePathCriterion',
 
 
 class ISecuritySchema(Interface):

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -997,6 +997,17 @@ class ISiteSchema(Interface):
         default=False,
         required=False)
 
+    icon_visibility = schema.Choice(
+        title=_(u'Icon visibility'),
+        description=_(u'Show icons...'),
+        default=u'false',
+        vocabulary=SimpleVocabulary([
+            SimpleTerm('false', 'false', _(u'Never')),
+            SimpleTerm('enabled', 'enabled', _(u'Always')),
+            SimpleTerm('authenticated', 'authenticated',
+                       _('For authenticated users only'))]),
+        required=False)
+
     toolbar_position = schema.Choice(
         title=_(u'Position where the toolbar is displayed'),
         description=_(

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -3,7 +3,6 @@ from plone.supermodel import model
 from Products.CMFPlone import PloneMessageFactory as _  # NOQA
 from Products.CMFPlone.utils import validate_json
 from basetool import IPloneBaseTool
-from plone.locking.interfaces import ILockSettings
 from zope import schema
 from zope.interface import Interface, implements
 from zope.schema.vocabulary import SimpleTerm
@@ -947,8 +946,7 @@ class ISecuritySchema(Interface):
         required=False)
 
 
-# XXX: Why does ISiteSchema inherit from ILockSettings here ???
-class ISiteSchema(ILockSettings):
+class ISiteSchema(Interface):
 
     site_title = schema.TextLine(
         title=_(u'Site title'),

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -992,6 +992,12 @@ class ISiteSchema(ILockSettings):
         default=u'',
         required=False)
 
+    display_publication_date_in_byline = schema.Bool(
+        title=_(u'Display publication date'),
+        description=_(u'Show the date a content item was published in the byline.'),
+        default=False,
+        required=False)
+
     toolbar_position = schema.Choice(
         title=_(u'Position where the toolbar is displayed'),
         description=_(

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -37,7 +37,6 @@
    <element value="ATRelativePathCriterion"/>
   </property>
   <property name="enable_wf_state_filtering" type="boolean">False</property>
-  <property name="wf_states_to_show" type="lines"/>
  </object>
  <object name="site_properties" meta_type="Plone Property Sheet">
   <property name="title">Site wide properties</property>

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -44,12 +44,6 @@
   <property name="displayPublicationDateInByline" type="boolean">False</property>
   <property name="default_language" type="string">en</property>
   <property name="default_charset" type="string">utf-8</property>
-  <property name="ext_editor" type="boolean">False</property>
-  <property name="available_editors" type="lines">
-   <element value="None"/>
-   <element value="TinyMCE"/>
-  </property>
-  <property name="default_editor" type="string">TinyMCE</property>
   <property name="allowRolesToAddKeywords" type="lines">
    <element value="Manager"/>
    <element value="Site Administrator"/>
@@ -72,84 +66,16 @@
   <property name="typesLinkToFolderContentsInFC" type="lines">
    <element value="Folder"/>
   </property>
-  <property name="visible_ids" type="boolean">False</property>
-  <property name="exposeDCMetaTags" type="boolean">False</property>
-  <property name="types_not_searched" type="lines">
-   <element value="ATBooleanCriterion"/>
-   <element value="ATDateCriteria"/>
-   <element value="ATDateRangeCriterion"/>
-   <element value="ATListCriterion"/>
-   <element value="ATPortalTypeCriterion"/>
-   <element value="ATReferenceCriterion"/>
-   <element value="ATSelectionCriterion"/>
-   <element value="ATSimpleIntCriterion"/>
-   <element value="ATSimpleStringCriterion"/>
-   <element value="ATSortCriterion"/>
-   <element value="ChangeSet"/>
-   <element value="Discussion Item"/>
-   <element value="Plone Site"/>
-   <element value="TempFolder"/>
-   <element value="ATCurrentAuthorCriterion"/>
-   <element value="ATPathCriterion"/>
-   <element value="ATRelativePathCriterion"/>
-  </property>
-  <property name="search_review_state_for_anon"
-     type="boolean">False</property>
-  <property name="search_enable_title_search" type="lines"/>
-  <property name="search_enable_description_search" type="lines"/>
-  <property name="search_enable_sort_on" type="lines">
-   <element value="auth"/>
-   <element value="anon"/>
-  </property>
-  <property name="search_enable_batch_size" type="lines">
-   <element value="auth"/>
-   <element value="anon"/>
-  </property>
-  <property name="search_collapse_options" type="boolean">True</property>
-  <property name="disable_folder_sections" type="boolean">False</property>
-  <property name="disable_nonfolderish_sections"
-     type="boolean">False</property>
   <property name="typesUseViewActionInListings" type="lines">
    <element value="Image"/>
    <element value="File"/>
   </property>
   <property name="verify_login_name" type="boolean">True</property>
-  <property name="many_users" type="boolean">False</property>
-  <property name="many_groups" type="boolean">False</property>
-  <property name="enable_livesearch" type="boolean">True</property>
-  <property name="use_folder_contents" type="lines"/>
-  <property name="forbidden_contenttypes" type="lines">
-   <element value="text/structured"/>
-   <element value="text/restructured"/>
-   <element value="text/x-rst"/>
-   <element value="text/plain"/>
-   <element value="text/plain-pre"/>
-   <element value="text/x-python"/>
-   <element value="text/x-web-markdown"/>
-   <element value="text/x-web-intelligent"/>
-   <element value="text/x-html-captioned"/>
-  </property>
-  <property name="default_contenttype" type="string">text/html</property>
-  <property name="enable_sitemap" type="boolean">False</property>
-  <property name="number_of_days_to_keep" type="int">7</property>
-  <property name="enable_inline_editing" type="boolean">False</property>
-  <property name="lock_on_ttw_edit" type="boolean">True</property>
-  <property name="enable_link_integrity_checks" type="boolean">True</property>
-  <property name="webstats_js" type="text"></property>
   <property name="external_links_open_new_window"
      type="string">false</property>
   <property name="icon_visibility" type="string">false</property>
   <property name="mark_special_links" type="string">false</property>
   <property name="redirect_links" type="boolean">True</property>
-  <property name="use_email_as_login" type="boolean">False</property>
-  <property name="use_uuid_as_userid" type="boolean">False</property>
-  <property name="user_registration_fields" type="lines">
-   <element value="fullname"/>
-   <element value="username"/>
-   <element value="email"/>
-   <element value="password"/>
-   <element value="mail_me"/>
-  </property>
   <property name="allow_external_login_sites" type="lines"/>
   <property name="external_login_url" type="string"/>
   <property name="external_logout_url" type="string"/>

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -40,7 +40,6 @@
  </object>
  <object name="site_properties" meta_type="Plone Property Sheet">
   <property name="title">Site wide properties</property>
-  <property name="default_language" type="string">en</property>
   <property name="default_charset" type="string">utf-8</property>
   <property name="allowRolesToAddKeywords" type="lines">
    <element value="Manager"/>
@@ -71,7 +70,6 @@
   <property name="verify_login_name" type="boolean">True</property>
   <property name="external_links_open_new_window"
      type="string">false</property>
-  <property name="icon_visibility" type="string">false</property>
   <property name="mark_special_links" type="string">false</property>
   <property name="redirect_links" type="boolean">True</property>
   <property name="allow_external_login_sites" type="lines"/>

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -41,7 +41,6 @@
  </object>
  <object name="site_properties" meta_type="Plone Property Sheet">
   <property name="title">Site wide properties</property>
-  <property name="displayPublicationDateInByline" type="boolean">False</property>
   <property name="default_language" type="string">en</property>
   <property name="default_charset" type="string">utf-8</property>
   <property name="allowRolesToAddKeywords" type="lines">

--- a/Products/CMFPlone/tests/testNavigationView.py
+++ b/Products/CMFPlone/tests/testNavigationView.py
@@ -339,9 +339,12 @@ class TestBaseNavTree(PloneTestCase.PloneTestCase):
         self.portal._delObject('news')
         self.portal._delObject('events')
         workflow = self.portal.portal_workflow
-        ntp = self.portal.portal_properties.navtree_properties
-        ntp.manage_changeProperties(wf_states_to_show=['published'])
-        ntp.manage_changeProperties(enable_wf_state_filtering=True)
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(INavigationSchema, prefix='plone')
+
+        settings.workflow_states_to_show = ('published',)
+        settings.filter_on_workflow = True
         view = self.view_class(self.portal.folder2, self.request)
         tree = view.navigationTree()
         self.assertTrue(tree)
@@ -574,9 +577,14 @@ class TestBasePortalTabs(PloneTestCase.PloneTestCase):
         self.portal._delObject('news')
         self.portal._delObject('events')
         workflow = self.portal.portal_workflow
-        ntp = self.portal.portal_properties.navtree_properties
-        ntp.manage_changeProperties(wf_states_to_show=['published'])
-        ntp.manage_changeProperties(enable_wf_state_filtering=True)
+        
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(
+            INavigationSchema,
+            prefix="plone"
+        )
+        navigation_settings.workflow_states_to_show = ('published',)
+        navigation_settings.filter_on_workflow = True
         view = self.view_class(self.portal, self.request)
         tabs = view.topLevelTabs(actions=[])
         #Should contain no folders

--- a/Products/CMFPlone/tests/testNavigationView.py
+++ b/Products/CMFPlone/tests/testNavigationView.py
@@ -522,8 +522,10 @@ class TestBasePortalTabs(PloneTestCase.PloneTestCase):
         self.assertEqual(len(tabs), 8)
 
         #Only the folders show up (Members, news, events, folder1, folder2)
-        self.portal.portal_properties \
-               .site_properties.disable_nonfolderish_sections = True
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(INavigationSchema,
+                                                    prefix="plone")
+        navigation_settings.nonfolderish_tabs = False
         tabs = view.topLevelTabs(actions=[])
         self.assertEqual(len(tabs), 5)
 
@@ -648,8 +650,10 @@ class TestBasePortalTabs(PloneTestCase.PloneTestCase):
         self.assertFalse('folder2' in tab_names)
 
     def testTabsExcludeNonFolderishItems(self):
-        self.portal.portal_properties.site_properties \
-               .disable_nonfolderish_sections = True
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(INavigationSchema,
+                                                    prefix="plone")
+        navigation_settings.nonfolderish_tabs = False
         view = self.view_class(self.portal, self.request)
         tabs = view.topLevelTabs(actions=[])
         orig_len = len(tabs)
@@ -671,8 +675,11 @@ class TestBasePortalTabs(PloneTestCase.PloneTestCase):
         self.setRoles(['Member'])
 
         self.portal.portal_properties.navtree_properties.root = '/folder1'
-        self.portal.portal_properties.site_properties \
-                .disable_nonfolderish_sections = True
+
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(INavigationSchema,
+                                                    prefix="plone")
+        navigation_settings.nonfolderish_tabs = False
 
         view = self.view_class(self.portal, self.request)
         tabs = view.topLevelTabs(actions=[])

--- a/Products/CMFPlone/tests/testPloneTool.py
+++ b/Products/CMFPlone/tests/testPloneTool.py
@@ -1,10 +1,13 @@
 from Acquisition import Implicit
 from plone.app.testing import SITE_OWNER_NAME
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IReorderedEvent
+from Products.CMFPlone.interfaces import ISearchSchema
 from Products.CMFPlone.tests import PloneTestCase
 from Products.CMFPlone.tests import dummy
 from zope.component import getGlobalSiteManager
+from zope.component import getUtility
 from zope.interface import Interface
 
 default_user = PloneTestCase.default_user
@@ -154,9 +157,10 @@ class TestPloneTool(PloneTestCase.PloneTestCase):
     def testGetUserFriendlyTypes(self):
         ttool = getToolByName(self.portal, 'portal_types')
         types = set(ttool.keys())
-        ptool = getToolByName(self.portal, 'portal_properties')
-        site_props = getattr(ptool, 'site_properties')
-        blacklistedTypes = site_props.getProperty('types_not_searched', [])
+        registry = getUtility(IRegistry)
+        search_settings = registry.forInterface(ISearchSchema, prefix="plone")
+        blacklistedTypes = search_settings.types_not_searched
+
         # 'ChangeSet' is blacklisted, but not in the types by default,
         # so we filter that out.
         blacklistedTypes = set([t for t in blacklistedTypes if t in types])

--- a/Products/CMFPlone/tests/testPloneView.py
+++ b/Products/CMFPlone/tests/testPloneView.py
@@ -1,5 +1,8 @@
+from zope.component import getUtility
 from Products.CMFPlone.tests import PloneTestCase
 from Products.CMFPlone.tests import dummy
+from Products.CMFPlone.interfaces import IEditingSchema
+from plone.registry.interfaces import IRegistry
 
 from Products.CMFPlone.browser.ploneview import Plone
 
@@ -158,12 +161,13 @@ class TestVisibleIdsEnabled(PloneTestCase.PloneTestCase):
     def afterSetUp(self):
         self.view = Plone(self.portal, self.app.REQUEST)
         self.member = self.portal.portal_membership.getAuthenticatedMember()
-        self.props = self.portal.portal_properties.site_properties
+        registry = getUtility(IRegistry)
+        self.props = registry.forInterface(IEditingSchema, prefix="plone")
 
     def testFailsWithSitePropertyDisabled(self):
         # Set baseline
         self.member.setProperties(visible_ids=False)
-        self.props.manage_changeProperties(visible_ids=False)
+        self.props.visible_ids = False
         # Should fail when site property is set false
         self.assertFalse(self.view.visibleIdsEnabled())
         self.member.setProperties(visible_ids=True)
@@ -172,11 +176,11 @@ class TestVisibleIdsEnabled(PloneTestCase.PloneTestCase):
     def testFailsWithMemberPropertyDisabled(self):
         # Should fail when member property is false
         self.member.setProperties(visible_ids=False)
-        self.props.manage_changeProperties(visible_ids=True)
+        self.props.visible_ids = True
         self.assertFalse(self.view.visibleIdsEnabled())
 
     def testSucceedsWithMemberAndSitePropertyEnabled(self):
         # Should succeed only when site property and member property are true
-        self.props.manage_changeProperties(visible_ids=True)
+        self.props.visible_ids = True
         self.member.setProperties(visible_ids=True)
         self.assertTrue(self.view.visibleIdsEnabled())

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -20,6 +20,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import setuphandlers
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 from Products.CMFPlone.interfaces import INavigationSchema
+from Products.CMFPlone.interfaces import ISearchSchema
 from Products.CMFPlone.UnicodeSplitter import Splitter, I18NNormalizer
 from Products.GenericSetup.browser.manage import ExportStepsView
 from Products.GenericSetup.browser.manage import ImportStepsView
@@ -176,8 +177,8 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
 
     def testVisibleIdsProperties(self):
         # visible_ids should be a site property and a memberdata property
-        self.assertTrue(
-            self.properties.site_properties.hasProperty('visible_ids'))
+        registry = getUtility(IRegistry)
+        self.assertTrue('plone.visible_ids' in registry)
         self.assertTrue(self.memberdata.hasProperty('visible_ids'))
 
     def testFormToolTipsProperty(self):
@@ -210,13 +211,10 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
 
     def testUnfriendlyTypesProperty(self):
         # We should have an types_not_searched property
-        self.assertTrue(
-            self.properties.site_properties.hasProperty('types_not_searched')
-        )
-        self.assertTrue(
-            'Plone Site' in
-            self.properties.site_properties.getProperty('types_not_searched')
-        )
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchSchema, prefix="plone")
+        self.assertTrue('plone.types_not_searched' in registry)
+        self.assertTrue('Plone Site' in settings.types_not_searched)
 
     def testNonDefaultPageTypes(self):
         # We should have a default_page_types property
@@ -875,7 +873,10 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
                                 if r['selected']])
 
     def testNonFolderishTabsProperty(self):
-        self.assertEqual(False, self.properties.site_properties.disable_nonfolderish_sections)
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(INavigationSchema,
+                                                    prefix="plone")
+        self.assertEqual(True, navigation_settings.nonfolderish_tabs)
 
     def testNoDoubleGenericSetupImportSteps(self):
         view = ImportStepsView(self.setup, None)

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -439,10 +439,9 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
         self.assertEqual(self.types.Link.default_view, 'link_redirect_view')
 
     def testTTWLockableProperty(self):
-        self.assertTrue(self.properties.site_properties \
-            .hasProperty('lock_on_ttw_edit'))
-        self.assertEqual(True,
-                          self.properties.site_properties.lock_on_ttw_edit)
+        registry = getUtility(IRegistry)
+        self.assertTrue('plone.lock_on_ttw_edit' in registry)
+        self.assertEqual(True, registry['plone.lock_on_ttw_edit'])
 
     def testPortalFTIIsDynamicFTI(self):
         # Plone Site FTI should be a DynamicView FTI

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -19,6 +19,7 @@ from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import setuphandlers
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
+from Products.CMFPlone.interfaces import INavigationSchema
 from Products.CMFPlone.UnicodeSplitter import Splitter, I18NNormalizer
 from Products.GenericSetup.browser.manage import ExportStepsView
 from Products.GenericSetup.browser.manage import ImportStepsView
@@ -32,6 +33,7 @@ from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.constants import CONTEXT_CATEGORY as CONTEXT_PORTLETS
+from plone.registry.interfaces import IRegistry
 
 
 class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
@@ -361,12 +363,15 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
                          'Topic'):
             self.assertTrue(metaType in types)
 
-    def testDisableFolderSectionsSiteProperty(self):
-        # The disable_folder_sections site property should be emtpy
-        props = self.portal.portal_properties.site_properties
-        self.assertTrue(
-            props.getProperty('disable_folder_sections', None) is not None)
-        self.assertFalse(props.getProperty('disable_folder_sections'))
+    def testGenerateTabsSiteProperty(self):
+        # The generate_tabs site property should be emtpy
+        registry = getUtility(IRegistry)
+        navigation_settings = registry.forInterface(
+            INavigationSchema,
+            prefix="plone"
+        )
+        self.assertTrue('plone.generate_tabs' in registry)
+        self.assertTrue(navigation_settings.generate_tabs)
 
     def testSelectableViewsOnFolder(self):
         views = self.portal.portal_types.Folder.getAvailableViewMethods(None)
@@ -421,9 +426,9 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
             'string:${folder_url}/view')
 
     def testEnableLivesearchProperty(self):
-        # site_properties should have enable_livesearch property
-        self.assertTrue(self.properties.site_properties \
-            .hasProperty('enable_livesearch'))
+        # registry should have enable_livesearch property
+        registry = getUtility(IRegistry)
+        self.assertTrue('plone.enable_livesearch' in registry)
 
     def testRedirectLinksProperty(self):
         self.assertTrue(self.properties.site_properties \

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -193,8 +193,10 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
         self.assertTrue(self.properties.navtree_properties.hasProperty('sortOrder'))
         self.assertTrue(self.properties.navtree_properties.hasProperty('sitemapDepth'))
         self.assertTrue(self.properties.navtree_properties.hasProperty('showAllParents'))
-        self.assertTrue(self.properties.navtree_properties.hasProperty('wf_states_to_show'))
-        self.assertTrue(self.properties.navtree_properties.hasProperty('enable_wf_state_filtering'))
+
+        registry = getUtility(IRegistry)
+        self.assertTrue('plone.workflow_states_to_show' in registry)
+        self.assertTrue('plone.filter_on_workflow' in registry)
 
     def testSitemapAction(self):
         # There should be a sitemap action

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -130,11 +130,6 @@ class TestPortalCreation(PloneTestCase.PloneTestCase, WarningInterceptor):
         mailhost = self.portal.MailHost
         self.assertEqual(mailhost.meta_type, 'Mail Host')
 
-    def testUseFolderContentsProperty(self):
-        # The use_folder_contents site property should be emtpy
-        props = self.portal.portal_properties.site_properties
-        self.assertEqual(props.getProperty('use_folder_contents'), ())
-
     def testFolderEditActionHasEditTitle(self):
         # Edit tab of folders should be named 'edit', not 'properties'
         folder = self.types.getTypeInfo('Folder')

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -672,7 +672,7 @@ def getSiteLogo(site=None):
     if site is None:
         site = getSite()
     registry = getUtility(IRegistry)
-    settings = registry.forInterface(ISiteSchema, prefix="plone")
+    settings = registry.forInterface(ISiteSchema, prefix="plone", check=False)
     site_url = site.absolute_url()
 
     if getattr(settings, 'site_logo', False):


### PR DESCRIPTION
These properties either:
* Have been migrated to the configuration registry
* Are no longer used in Plone core

See also: https://github.com/plone/plone.app.upgrade/pull/45