### PR TITLE
20114 plone.api integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'five.localsitemanager',
         'five.pt',
         'mockup',
-        'plone.api >= 1.4.1',
+        'plone.api >= 1.4.2',
         'plone.app.content',
         'plone.app.contentlisting',
         'plone.app.contentmenu >= 1.1.6dev-r22380',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'five.localsitemanager',
         'five.pt',
         'mockup',
-        'plone.api >= 1.4.2',
+        'plone.api >= 1.4.3',
         'plone.app.content',
         'plone.app.contentlisting',
         'plone.app.contentmenu >= 1.1.6dev-r22380',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'five.localsitemanager',
         'five.pt',
         'mockup',
+        'plone.api >= 1.4.1',
         'plone.app.content',
         'plone.app.contentlisting',
         'plone.app.contentmenu >= 1.1.6dev-r22380',


### PR DESCRIPTION
Refs https://dev.plone.org/ticket/20114
Travis CI builds have been stable for 4.2, 4.3 and 5.0, see https://travis-ci.org/plone/plone.api.