### PR TITLE
getToolByName: accept tool from mock module.

### DIFF
--- a/Products/CMFPlone/patches/security.py
+++ b/Products/CMFPlone/patches/security.py
@@ -63,6 +63,7 @@ def check_getToolByName(obj, name, default=_marker):
             name in _tool_interface_registry or \
             (isinstance(result, FauxArchetypeTool)) or \
             '.test' in result.__class__.__module__ or \
+            result.__class__.__module__ == 'mock' or \
             result is _marker or \
             result is default:
         return result


### PR DESCRIPTION
This is needed for me locally when running:

  bin/test -s Products.Archetypes -m test_pawidgets

No idea why Jenkins is happy.  Locally I get errors:

  TypeError: Object found is not a portal tool (portal_properties)

This is because those tests are accessing
self.context.portal_properties where self.context is an instance of
mock.Mock, so the portal_properties are also mock.Mock.

If anyone knows why Jenkins is hopping along nicely without failures, that would be interesting to know. Maybe it is because these are errors, not failures, but I do not see those errors on Jenkins either.