### PR TITLE
Allow access to the site if content_css is None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Changelog
   plone.app.linkintegrity's variant
   [vangheem]
 
+- Fix error to allow site navigation if TinyMCE content_css setting is None
+  [Gagaro]
 
 5.0b4 (2015-08-23)
 ------------------

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -34,7 +34,8 @@ class TinyMCESettingsGenerator(object):
             '%s/++plone++static/plone-compiled.css' % self.portal_url,
             '%s/++plone++static/tinymce-styles.css' % self.portal_url
         ]
-        for url in self.settings.content_css:
+        content_css = self.settings.content_css or []
+        for url in content_css:
             files.append('%s/%s' % (self.portal_url, url))
         theme = self.get_theme()
         if (theme and hasattr(theme, 'tinymce_content_css') and


### PR DESCRIPTION
Hi,

I had an issue where the TinyMCE `content_css` settings was None (I don't know why or how yet), but it blocked the entire site.

This allow to navigate the site and to fix the settings afterward.