### PR TITLE
Fix #862; input checkbox and radio now have min-width equal to width

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changelog
 5.0rc2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- fix #862: Profile listing on site creation has alignment issues
+  [ichim-david]
 
 
 5.0rc1 (2015-09-08)

--- a/Products/CMFPlone/browser/static/plone-admin-ui.css
+++ b/Products/CMFPlone/browser/static/plone-admin-ui.css
@@ -36,7 +36,7 @@ input:focus, select:focus {border-color: #a2a2a2; background: #fffbea; box-shado
 [type="submit"]:hover, .plone-btn:hover {box-shadow: inset 0 0 0 40px rgba(0,0,0,.15), 0 1px 3px rgba(0,0,0,.15);}
 [type="submit"]:active, .plone-btn:active, [type="submit"]:focus, .plone-btn:focus {box-shadow: inset 0 0 0 40px rgba(0,0,0,.15), 0 2px 6px rgba(0,0,0,.25); outline: 0}
 a.plone-btn {line-height: 2.5;display: inline-block;text-align: center; text-decoration: none !important; background:#0184bf;}
-label [type="checkbox"], label [type="radio"] {float: left; width: 20px; margin:2px 0 0; box-shadow: none !important;}
+label [type="checkbox"], label [type="radio"] {float: left; min-width:20px; width: 20px; margin:2px 0 0; box-shadow: none !important;}
 fieldset {border: 0; margin: 40px 0; padding:0;}
 fieldset fieldset {outline:1px solid #d9d9d9; padding: 20px; font-size: 87.5%; color: #666; margin:20px 0;}
 legend {font-size: 150%; font-weight: 300; border-top: 1px solid #d9d9d9; width: 100%; padding-top: 20px;}

--- a/Products/CMFPlone/browser/static/plone-admin-ui.css
+++ b/Products/CMFPlone/browser/static/plone-admin-ui.css
@@ -36,7 +36,7 @@ input:focus, select:focus {border-color: #a2a2a2; background: #fffbea; box-shado
 [type="submit"]:hover, .plone-btn:hover {box-shadow: inset 0 0 0 40px rgba(0,0,0,.15), 0 1px 3px rgba(0,0,0,.15);}
 [type="submit"]:active, .plone-btn:active, [type="submit"]:focus, .plone-btn:focus {box-shadow: inset 0 0 0 40px rgba(0,0,0,.15), 0 2px 6px rgba(0,0,0,.25); outline: 0}
 a.plone-btn {line-height: 2.5;display: inline-block;text-align: center; text-decoration: none !important; background:#0184bf;}
-label [type="checkbox"], label [type="radio"] {float: left; min-width:20px; width: 20px; margin:2px 0 0; box-shadow: none !important;}
+label [type="checkbox"], label [type="radio"] {float: left; min-width:20px; width: 20px; margin:2px 4px 0 0; box-shadow: none !important;}
 fieldset {border: 0; margin: 40px 0; padding:0;}
 fieldset fieldset {outline:1px solid #d9d9d9; padding: 20px; font-size: 87.5%; color: #666; margin:20px 0;}
 legend {font-size: 150%; font-weight: 300; border-top: 1px solid #d9d9d9; width: 100%; padding-top: 20px;}


### PR DESCRIPTION
This is done in order to override the big 180px rule set on normal inputs.

I'm attaching a Google Chrome inspector session which shows the fix in action.

![without-min-width](https://cloud.githubusercontent.com/assets/152852/9780556/1c1298e4-5793-11e5-8adc-fa4c2425e100.png)

![with-min-width](https://cloud.githubusercontent.com/assets/152852/9780555/1c0c1398-5793-11e5-9d82-1bb3baf7f726.png)

