### PR TITLE
Login settings migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0rc2 (unreleased)
 -------------------
 
+- Move login properties to the configuration registry.
+  [esteele]
+
 - Fix changing searchable in types-controlpanel.
   Fix https://github.com/plone/Products.CMFPlone/issues/926
   [pbauer]

--- a/Products/CMFPlone/URLTool.py
+++ b/Products/CMFPlone/URLTool.py
@@ -3,7 +3,9 @@ from Products.CMFCore.utils import getToolByName
 from AccessControl import ClassSecurityInfo
 from App.class_init import InitializeClass
 from Products.CMFPlone.PloneBaseTool import PloneBaseTool
-
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import ILoginSchema
 from posixpath import normpath
 from urlparse import urlparse, urljoin
 import re
@@ -65,8 +67,9 @@ class URLTool(PloneBaseTool, BaseTool):
         if host == u_host and u_path.startswith(path):
             return True
 
-        props = getToolByName(self, 'portal_properties').site_properties
-        for external_site in props.getProperty('allow_external_login_sites', []):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ILoginSchema, prefix='plone')
+        for external_site in settings.allow_external_login_sites:
             _, host, path, _, _, _ = urlparse(external_site)
             if not path.endswith('/'):
                 path += '/'

--- a/Products/CMFPlone/interfaces/__init__.py
+++ b/Products/CMFPlone/interfaces/__init__.py
@@ -10,6 +10,7 @@ from controlpanel import IDateAndTimeSchema
 from controlpanel import IEditingSchema
 from controlpanel import ILanguageSchema
 from controlpanel import IFilterSchema
+from controlpanel import ILoginSchema
 from controlpanel import IMaintenanceSchema
 from controlpanel import IMailSchema
 from controlpanel import IMarkupSchema

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -1285,3 +1285,43 @@ class IImagingSchema(Interface):
         max=95,
         default=88
     )
+
+
+class ILoginSchema(Interface):
+
+    auth_cookie_length = schema.Int(
+        title=_(u'Auth cookie length'),
+        default=0,
+        required=False
+    )
+
+    verify_login_name = schema.Bool(
+        title=_(u'Verify login name'),
+        default=True,
+        required=False
+    )
+
+    allow_external_login_sites = schema.Tuple(
+        title=_(u'Allow external login sites'),
+        default=(),
+        value_type=schema.ASCIILine(),
+        required=False
+    )
+
+    external_login_url = schema.ASCIILine(
+        title=_(u'External login url'),
+        default=None,
+        required=False
+    )
+
+    external_logout_url = schema.ASCIILine(
+        title=_(u'External logout url'),
+        default=None,
+        required=False
+    )
+
+    external_login_iframe = schema.Bool(
+        title=_(u'External login iframe'),
+        default=False,
+        required=False
+    )

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -65,13 +65,9 @@
    <element value="Image"/>
    <element value="File"/>
   </property>
-  <property name="verify_login_name" type="boolean">True</property>
   <property name="external_links_open_new_window"
      type="string">false</property>
   <property name="mark_special_links" type="string">false</property>
   <property name="redirect_links" type="boolean">True</property>
-  <property name="external_login_url" type="string"/>
-  <property name="external_logout_url" type="string"/>
-  <property name="external_login_iframe" type="boolean"/>
  </object>
 </object>

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -70,7 +70,6 @@
      type="string">false</property>
   <property name="mark_special_links" type="string">false</property>
   <property name="redirect_links" type="boolean">True</property>
-  <property name="allow_external_login_sites" type="lines"/>
   <property name="external_login_url" type="string"/>
   <property name="external_logout_url" type="string"/>
   <property name="external_login_iframe" type="boolean"/>

--- a/Products/CMFPlone/profiles/default/propertiestool.xml
+++ b/Products/CMFPlone/profiles/default/propertiestool.xml
@@ -45,7 +45,6 @@
    <element value="Site Administrator"/>
    <element value="Reviewer"/>
   </property>
-  <property name="auth_cookie_length" type="int">0</property>
   <property name="calendar_starting_year" type="int">2001</property>
   <property name="calendar_future_years_available" type="int">5</property>
   <property name="invalid_ids" type="lines">

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -28,6 +28,8 @@
            prefix="plone" />
   <records interface="Products.CMFPlone.interfaces.IImagingSchema"
            prefix="plone" />
+  <records interface="Products.CMFPlone.interfaces.ILoginSchema"
+           prefix="plone" />
   <record interface="Products.ResourceRegistries.interfaces.settings.IResourceRegistriesSettings" field="resourceBundlesForThemes">
     <value purge="false">
       <element key="(default)">

--- a/Products/CMFPlone/skins/plone_login/login.py
+++ b/Products/CMFPlone/skins/plone_login/login.py
@@ -17,9 +17,8 @@ if (next is not None and context.portal_url.isURLInPortal(next)
     return context.restrictedTraverse('external_login_return')()
 
 # Handle login on this portal where login is internal
-site_properties = context.portal_properties.site_properties
-external_login_url = site_properties.getProperty('external_login_url')
-external_login_iframe = site_properties.getProperty('external_login_iframe')
+external_login_url = context.portal_registry['plone.external_login_url']
+external_login_iframe = context.portal_registry['plone.external_login_iframe']
 if not external_login_url or external_login_iframe:
     return context.restrictedTraverse('login_form')()
 

--- a/Products/CMFPlone/skins/plone_login/login_form.cpt
+++ b/Products/CMFPlone/skins/plone_login/login_form.cpt
@@ -31,10 +31,9 @@
                         ac_persist auth/persist_cookie|nothing;
                         login_name python:request.get('login_name', request.get(ac_name, ''));
                         checkPermission nocall: context/portal_membership/checkPermission;
-                        site_properties context/portal_properties/site_properties;
                         use_email_as_login python:context.portal_registry['plone.use_email_as_login'];
-                        external_login_url site_properties/external_login_url|nothing;
-                        external_login_iframe site_properties/external_login_iframe|nothing;
+                        external_login_url python:context.portal_registry['plone.external_login_url'];
+                        external_login_iframe python:context.portal_registry['plone.external_login_iframe'];
                         mail_password python:test(checkPermission('Mail forgotten password', context), portal_url + '/mail_password_form', '');
                         mail_password_url request/mail_password_url|nothing;
                         mail_password_url python:test(mail_password_url and isURLInPortal(mail_password_url), mail_password_url, mail_password);
@@ -49,6 +48,13 @@
                         target request/target|nothing;
                         target python:test(target in ('_parent', '_top', '_blank', '_self'), target, None);
                         ztu modules/ZTUtils;">
+
+  <span>external_login_url: ${external_login_url}</span>
+  <span>external_login_iframe: ${external_login_iframe}</span>
+  <span>use_iframe: ${use_iframe}</span>
+  <span>use_external: ${use_external}</span>
+  <span>request/mail_password_url: ${request/mail_password_url|nothing}</span>
+  <span>in portal: ${python:isURLInPortal(mail_password_url)}</span>
 
             <div class="portalMessage error pat-cookietrigger" style="display:none">
                 <strong i18n:translate="">

--- a/Products/CMFPlone/skins/plone_login/login_form_validate.vpy
+++ b/Products/CMFPlone/skins/plone_login/login_form_validate.vpy
@@ -25,7 +25,6 @@ if js_enabled and not cookies_enabled:
 
 mt=context.portal_membership
 if mt.isAnonymousUser():
-    props = getToolByName(context, 'portal_properties').site_properties
     email_login = context.portal_registry['plone.use_email_as_login']
     if js_enabled:  # javascript is enabled - we can diagnose the failure
         # using cookie authentication?
@@ -53,7 +52,7 @@ if mt.isAnonymousUser():
                         ac_password,
                         _(u'Please enter your password.'),
                         'password_required')
-            verify_login_name = props.getProperty('verify_login_name', 0)
+            verify_login_name = context.portal_registry['plone.verify_login_name']
             if user_name and verify_login_name:
                 # XXX mixing up username and loginname here
                 if mt.getMemberById(user_name) is None:

--- a/Products/CMFPlone/skins/plone_login/logout.cpy
+++ b/Products/CMFPlone/skins/plone_login/logout.cpy
@@ -24,8 +24,7 @@ if (next is not None and context.portal_url.isURLInPortal(next)):
     target_url = next
 else:
     target_url = request.URL1 + '/logged_out'
-    site_properties = context.portal_properties.site_properties
-    external_logout_url = site_properties.getProperty('external_logout_url')
+    external_logout_url = context.portal_registry['plone.external_logout_url']
     if external_logout_url:
         target_url = "%s?next=%s" % (external_logout_url, target_url)
 

--- a/Products/CMFPlone/skins/plone_scripts/setAuthCookie.py
+++ b/Products/CMFPlone/skins/plone_scripts/setAuthCookie.py
@@ -3,7 +3,7 @@
 ##parameters=resp, cookie_name, cookie_value
 
 try:
-    length = context.portal_properties.site_properties.auth_cookie_length
+    length = context.portal_registry['plone.auth_cookie_length']
 except AttributeError:
     length = 0
 

--- a/Products/CMFPlone/tests/testSSOLogin.py
+++ b/Products/CMFPlone/tests/testSSOLogin.py
@@ -44,11 +44,9 @@ class SSOLoginTestCase(PloneTestCase):
         # Configure our sites to use the login portal for logins and logouts
         login_portal_url = self.login_portal.absolute_url()
         for portal in (self.portal, self.another_portal):
-            site_properties = portal.portal_properties.site_properties
-            site_properties._updateProperty('external_login_url',
-                                            login_portal_url + '/login')
-            site_properties._updateProperty('external_logout_url',
-                                            login_portal_url + '/logout')
+            reg = portal.portal_registry
+            reg['plone.external_login_url'] = login_portal_url + '/login'
+            reg['plone.external_logout_url'] = login_portal_url + '/logout'
 
         # Configure all sites to use a shared secret and set cookies per path
         # (normally they would have different domains.)
@@ -131,8 +129,7 @@ class TestSSOLoginIframe(SSOLoginTestCase):
         SSOLoginTestCase.afterSetUp(self)
         # Configure our sites to use the iframe
         for portal in (self.portal, self.another_portal):
-            site_properties = portal.portal_properties.site_properties
-            site_properties._updateProperty('external_login_iframe', True)
+            portal.portal_registry['plone.external_login_iframe'] = True
         transaction.commit()
 
     def test_loginAndLogoutSSO(self):

--- a/Products/CMFPlone/tests/testSSOLogin.py
+++ b/Products/CMFPlone/tests/testSSOLogin.py
@@ -3,6 +3,9 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing import TEST_USER_ROLES
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import ILoginSchema
 from Products.CMFPlone.tests.PloneTestCase import PloneTestCase
 from Products.CMFPlone.factory import addPloneSite
 import transaction
@@ -32,13 +35,11 @@ class SSOLoginTestCase(PloneTestCase):
         for role in TEST_USER_ROLES:
             portal.acl_users.portal_role_manager.doAssignRoleToPrincipal(TEST_USER_ID, role)
 
+        registry = self.login_portal.portal_registry
+
         # Configure the login portal to allow logins from our sites.
-        self.login_portal.portal_properties.site_properties._updateProperty(
-            'allow_external_login_sites', [
-                self.portal.absolute_url(),
-                self.another_portal.absolute_url(),
-                ]
-            )
+        registry['plone.allow_external_login_sites'] = (self.portal.absolute_url(),
+                                                        self.another_portal.absolute_url())
 
         # Configure our sites to use the login portal for logins and logouts
         login_portal_url = self.login_portal.absolute_url()


### PR DESCRIPTION
Move login settings out of portal_properties and into the registry. Since these are settings you really aren't going to use unless you know you need them, I opted to not put them into a control panel. They can easily be set from the configuration registry UI. 