### PR TITLE
Purge profile versions. Let plone-final depend on workflow step.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ Changelog
 - Fix traceback style (closes `#1053`_).
   [rodfersou]
 
+- Purge profile upgrade versions from portal_setup when applying our
+  default CMFPlone:plone profile.  This signals that nothing has been
+  installed yet, so depencies will get reapplied instead of possibly
+  upgraded.  This could cause problems mostly in tests.  Closes
+  `#1041`_.
+  [maurits]
 
 
 5.0rc3 (2015-09-21)
@@ -850,4 +856,5 @@ Changelog
 .. _`#991`: https://github.com/plone/Products.CMFPlone/issues/991
 .. _`#996`: https://github.com/plone/Products.CMFPlone/issues/996
 .. _`#1015`: https://github.com/plone/Products.CMFPlone/issues/1015
+.. _`#1041`: https://github.com/plone/Products.CMFPlone/issues/1041
 .. _`#1053`: https://github.com/plone/Products.CMFPlone/issues/1053

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ Changelog
 - Fix traceback style (closes `#1053`_).
   [rodfersou]
 
+- Let plone-final import step also depend on the workflow step.
+  Otherwise the plone-final step installs plone.app.discussion with an
+  extra workflow, and then our own workflow step throws it away again.
+  Closes `#1041`_.
+  [maurits]
+
 - Purge profile upgrade versions from portal_setup when applying our
   default CMFPlone:plone profile.  This signals that nothing has been
   installed yet, so depencies will get reapplied instead of possibly

--- a/Products/CMFPlone/exportimport/configure.zcml
+++ b/Products/CMFPlone/exportimport/configure.zcml
@@ -74,6 +74,7 @@
    <depends name="viewlets" />
    <depends name="controlpanel" />
    <depends name="propertiestool" />
+   <depends name="workflow" />
   </genericsetup:importStep>
 
   <genericsetup:importStep

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -7,12 +7,6 @@ from zope.component import queryUtility
 from zope.event import notify
 from zope.interface import implements
 from zope.site.hooks import setSite
-try:
-    # GenericSetup 1.7.8 and higher
-    from Products.GenericSetup.tool import DEPENDENCY_STRATEGY_REAPPLY
-    DEPENDENCY_STRATEGY_REAPPLY  # pyflakes
-except ImportError:
-    DEPENDENCY_STRATEGY_REAPPLY = None
 
 _TOOL_ID = 'portal_setup'
 _DEFAULT_PROFILE = 'Products.CMFPlone:plone'
@@ -96,18 +90,7 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     setSite(site)
 
     setup_tool.setBaselineContext('profile-%s' % profile_id)
-    # TODO: we somehow rely on reapplying all profiles, instead of
-    # being happy with upgrades.
-    if DEPENDENCY_STRATEGY_REAPPLY is None:
-        # Older GenericSetup.  Reapply is the default.  No alternative
-        # strategy can be given.
-        setup_tool.runAllImportStepsFromProfile('profile-%s' % profile_id)
-    else:
-        # Newer GenericSetup.  Upgrade is the default.  We want to
-        # reapply.
-        setup_tool.runAllImportStepsFromProfile(
-            'profile-%s' % profile_id,
-            dependency_strategy=DEPENDENCY_STRATEGY_REAPPLY)
+    setup_tool.runAllImportStepsFromProfile('profile-%s' % profile_id)
 
     reg = queryUtility(IRegistry, context=site)
     reg['plone.portal_timezone'] = portal_timezone
@@ -116,13 +99,8 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     reg['plone.available_languages'] = [default_language]
 
     if setup_content:
-        if DEPENDENCY_STRATEGY_REAPPLY is None:
-            setup_tool.runAllImportStepsFromProfile(
-                'profile-%s' % content_profile_id)
-        else:
-            setup_tool.runAllImportStepsFromProfile(
-                'profile-%s' % content_profile_id,
-                dependency_strategy=DEPENDENCY_STRATEGY_REAPPLY)
+        setup_tool.runAllImportStepsFromProfile(
+            'profile-%s' % content_profile_id)
 
     props = dict(
         title=title,
@@ -133,13 +111,8 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     site.manage_changeProperties(**props)
 
     for extension_id in extension_ids:
-        if DEPENDENCY_STRATEGY_REAPPLY is None:
-            setup_tool.runAllImportStepsFromProfile(
-                'profile-%s' % extension_id)
-        else:
-            setup_tool.runAllImportStepsFromProfile(
-                'profile-%s' % extension_id,
-                dependency_strategy=DEPENDENCY_STRATEGY_REAPPLY)
+        setup_tool.runAllImportStepsFromProfile(
+            'profile-%s' % extension_id)
 
     if snapshot is True:
         setup_tool.createSnapshot('initial_configuration')


### PR DESCRIPTION
This signals that nothing has been installed yet, so depencies will get reapplied instead of possibly upgraded.  This could cause problems mostly in tests. Some tests were (needlessly) applying the CMFPlone:plone profile, even though there was a portal already.

And I noticed the plone-final import step was hardly the last one in the list. It need not be exactly the last, but it should at least come after all import steps that the default profile itself uses, more specifically: after workflow. Having it the wrong way around was part of the reason why you could create a Plone Site and miss the comment workflow from plone.app.discussion.

This solves issue #1041 in a better, cleaner way.