### PR TITLE
Fix #1067: mail controlpanel not keeping password field when saving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 5.0rc4 (unreleased)
 -------------------
 
+- Fix mail controlpanel not keeping password field when saving
+  [allusa]
+
 - Remove trying to install plone.protect to global site manager
   as that is now handled by plone.protect
   [vangheem]

--- a/Products/CMFPlone/controlpanel/browser/mail.py
+++ b/Products/CMFPlone/controlpanel/browser/mail.py
@@ -36,6 +36,10 @@ class MailControlPanelForm(controlpanel.RegistryEditForm):
         if errors:
             self.status = self.formErrorsMessage
             return False
+        #keep password field
+        if (data.get('smtp_userid') is not None
+            and data.get('smtp_pass') is None):
+            del data['smtp_pass']
         self.applyChanges(data)
         return True
 


### PR DESCRIPTION
ESMTP password is not shown in controlpanel, thus it is returned as None when saving #1067
@bloodbare 