### PR TITLE
Remove unused types_link_to_folder_contents setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
   [vangheem]
 
 - Fix #1071: AttributeError when saving theme settings
+- Remove unused types_link_to_folder_contents setting
   [vangheem]
 
 - Fix #817: When saving the filter control panel show a flash message with

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -1179,17 +1179,6 @@ class IDateAndTimeSchema(Interface):
 class ITypesSchema(Interface):
     """Controlpanel settings for the types settings.
     """
-    types_link_to_folder_contents = schema.List(
-        title=_(u'Types linking to folder contents in folder contents view'),
-        description=_(
-            u"help_types_link_to_folder_contents",
-            default=u"When clicking items in folder contents view, these "
-                    u"types will display their contents instead of using "
-                    u"their default view."),
-        required=False,
-        default=[u'Folder'],
-        value_type=schema.TextLine()
-    )
 
     types_use_view_action_in_listings = schema.List(
         title=_(u'Types which use the view action in listing views.'),


### PR DESCRIPTION
@esteele I see that you did the migration of this configuration. I don't believe this is used anymore. We should remove this setting.