### PR TITLE
Registered ILinkSchema to the portal registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 5.0rc4 (unreleased)
 -------------------
 
-- Fix #1071: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
+- Fixes #1071: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
   was registered with registry.xml
   [pigeonflight]
   

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 5.0rc4 (unreleased)
 -------------------
 
-- Fixes `#1071`_: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
+- Closes `#1071`_: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
   was registered with registry.xml
   [pigeonflight]
   
@@ -882,3 +882,4 @@ Changelog
 .. _`#1015`: https://github.com/plone/Products.CMFPlone/issues/1015
 .. _`#1041`: https://github.com/plone/Products.CMFPlone/issues/1041
 .. _`#1053`: https://github.com/plone/Products.CMFPlone/issues/1053
+.. _`#1071`: https://github.com/plone/Products.CMFPlone/issues/1071

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 5.0rc4 (unreleased)
 -------------------
 
+- Fix #1071: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
+  was registered with registry.xml
+  [pigeonflight]
+  
 - Fix #817: When saving the filter control panel show a flash message with
   info on caching.
   [jcerjak]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 5.0rc4 (unreleased)
 -------------------
 
-- Fixes #1071: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
+- Fixes `#1071`_: AttributeError: mark_special_links when saving theme details. Ensured that ILinkSchema
   was registered with registry.xml
   [pigeonflight]
   

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -4,6 +4,8 @@
            prefix="plone" />
   <records interface="Products.CMFPlone.interfaces.ILanguageSchema"
            prefix="plone" />
+  <records interface="Products.CMFPlone.interfaces.ILinkSchema"
+           prefix="plone" />
   <records interface="Products.CMFPlone.interfaces.IFilterSchema"
            prefix="plone" />
   <records interface="Products.CMFPlone.interfaces.IMaintenanceSchema"


### PR DESCRIPTION
ILinkSchema needs to be registered, newer versions of plone.app.theming rely on this.
This fixes #1071