### PR TITLE
fix: image preview in TinyMCE editor when in modals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,9 @@ Changelog
   `#1041`_.
   [maurits]
 
+- Fix image preview in TinyMCE editor when in modals.
+  [Gagaro]
+
 
 5.0rc3 (2015-09-21)
 -------------------

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -248,7 +248,7 @@ class PloneSettingsAdapter(object):
             'tiny': generator.get_tiny_config(),
             # This is for loading the languages on tinymce
             'loadingBaseUrl': '%s/++plone++static/components/tinymce-builded/js/tinymce' % generator.portal_url,  # noqa
-            'prependToUrl': 'resolveuid/',
+            'prependToUrl': '{0}/resolveuid/'.format(generator.portal_url),
             'linkAttribute': 'UID',
             'prependToScalePart': '/@@images/image/',
             'folderTypes': folder_types,


### PR DESCRIPTION
This ensure the `resolveuid` path is at the root of the plone site.