### PR TITLE
feat: allow all TinyMCE settings to be set from control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changelog
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow all TinyMCE settings to be set from control panel.
+  [Gagaro]
 
 
 5.0 (2015-09-27)

--- a/Products/CMFPlone/controlpanel/browser/tinymce.py
+++ b/Products/CMFPlone/controlpanel/browser/tinymce.py
@@ -2,6 +2,7 @@ from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.interfaces import ITinyMCELayoutSchema
 from Products.CMFPlone.interfaces import ITinyMCESpellCheckerSchema
 from Products.CMFPlone.interfaces import ITinyMCEResourceTypesSchema
+from Products.CMFPlone.interfaces import ITinyMCEAdvancedSchema
 from Products.CMFPlone.interfaces import ITinyMCESchema
 from Products.CMFPlone.interfaces import ITinyMCEPluginSchema
 from plone.app.registry.browser import controlpanel
@@ -25,6 +26,11 @@ class TinyMCEResourceTypesForm(group.GroupForm):
     fields = field.Fields(ITinyMCEResourceTypesSchema)
 
 
+class TinyMCEAdvancedForm(group.GroupForm):
+    label = _(u"Advanced")
+    fields = field.Fields(ITinyMCEAdvancedSchema)
+
+
 class TinyMCEControlPanelForm(controlpanel.RegistryEditForm):
 
     id = "TinyMCEControlPanel"
@@ -33,7 +39,7 @@ class TinyMCEControlPanelForm(controlpanel.RegistryEditForm):
     schema_prefix = "plone"
     fields = field.Fields(ITinyMCELayoutSchema)
     groups = (TinyMCEPluginForm, TinyMCESpellCheckerForm,
-              TinyMCEResourceTypesForm)
+              TinyMCEResourceTypesForm, TinyMCEAdvancedForm)
 
     def updateFields(self):
         super(TinyMCEControlPanelForm, self).updateFields()

--- a/Products/CMFPlone/interfaces/__init__.py
+++ b/Products/CMFPlone/interfaces/__init__.py
@@ -22,6 +22,7 @@ from controlpanel import ISiteSchema
 from controlpanel import ITinyMCELayoutSchema
 from controlpanel import ITinyMCESpellCheckerSchema
 from controlpanel import ITinyMCEResourceTypesSchema
+from controlpanel import ITinyMCEAdvancedSchema
 from controlpanel import ITinyMCESchema
 from controlpanel import ITinyMCEPluginSchema
 from controlpanel import ITypesSchema

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -763,11 +763,24 @@ class ITinyMCEResourceTypesSchema(Interface):
         required=False)
 
 
+class ITinyMCEAdvancedSchema(Interface):
+    """This interface defines the resource types properties."""
+
+    other_settings = schema.Text(
+        title=_('label_tinymce_other_settings', 'Other settings'),
+        description=_('hint_tinymce_other_settings',
+                      default='Other TinyMCE configuration formatted as JSON.'),
+        required=False,
+        default=u"{}",
+    )
+
+
 class ITinyMCESchema(
     ITinyMCELayoutSchema,
     ITinyMCEPluginSchema,
     ITinyMCESpellCheckerSchema,
-    ITinyMCEResourceTypesSchema
+    ITinyMCEResourceTypesSchema,
+    ITinyMCEAdvancedSchema
 ):
     """TinyMCE Schema"""
 

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -161,6 +161,9 @@ class TinyMCESettingsGenerator(object):
             except ValueError:
                 pass
 
+        if settings.other_settings:
+            tiny_config.update(json.loads(settings.other_settings))
+
         return tiny_config
 
 

--- a/Products/CMFPlone/tests/testPatternSettings.py
+++ b/Products/CMFPlone/tests/testPatternSettings.py
@@ -26,3 +26,10 @@ class TestTinyMCESettings(PloneTestCase.PloneTestCase):
     def test_style_formats(self):
         conf = self.get_conf()
         self.assertEqual(len(conf['tiny']['style_formats']), 5)
+
+    def test_other_settings(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ITinyMCESchema, prefix="plone")
+        settings.other_settings = u'{"foo": "bar"}'
+        conf = self.get_conf()
+        self.assertEqual(conf['tiny']['foo'], 'bar')


### PR DESCRIPTION
This allows the possibility to set all TinyMCE settings. (There are a lot of things possible: http://www.tinymce.com/wiki.php/Configuration)

This change should need an upgrade step, but I'm not sure how to add it in plone.app.upgrade (if I'd have to create a new profile or if I could use `to_500`)?

So if someone could direct me in the right direction, thanks!