### PR TITLE
Remove bobobase_modification_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,11 @@ New:
   [petschki]
 
 - Added new commandline argument to plone-compile-resource: --compile-dir
+- No longer rely on deprecated ``bobobase_modification_time`` from
+  ``Persistence.Persistent``.
+  [thet]
+
+- compress generated bundle css file when running plone-compile-resource
   [petschki]
 
 - Upgraded to patternslib 2.0.11.

--- a/Products/CMFPlone/DublinCore.py
+++ b/Products/CMFPlone/DublinCore.py
@@ -350,7 +350,7 @@ class DefaultDublinCoreImpl(PropertyManager):
         date = self.modification_date
         if date is None:
             # Upgrade.
-            date = self.bobobase_modification_time()
+            date = DateTime(self._p_mtime)
             self.modification_date = date
         return date
 


### PR DESCRIPTION
No longer rely on deprecated bobobase_modification_time from Persistence.Persistent.

see changelog for Zope 4.0a1: https://github.com/zopefoundation/Zope/blob/master/CHANGES.rst