### PR TITLE
Ensure cooked CSS/JS resources are treated as "stable resources" for caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 - Add syndication for plone.app.contenttypes collections.
   [do3cc]
+- Use unique traverser for stable resources to set proper cache headers.
+  [alecm]
 
 - fix "contains object" tinymce setting not getting passed into pattern
   correctly Fixes #1023

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -1,4 +1,5 @@
 from urlparse import urlparse
+from urllib import quote
 
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceView
@@ -38,12 +39,26 @@ class ScriptsView(ResourceView):
                     # because the compiling is done outside of plone
                     cookWhenChangingSettings(self.context, bundle)
             if bundle.jscompilation:
+                js_path = bundle.jscompilation
+                if '++plone++' in js_path:
+                    resource_path = js_path.split('++plone++')[-1]
+                    resource_name, resource_filepath = resource_path.split('/', 1)
+                    js_location = '%s/++plone++%s/++unique++%s/%s' % (
+                        self.site_url,
+                        resource_name,
+                        quote(str(bundle.last_compilation)),
+                        resource_filepath
+                    )
+                else:
+                    js_location = '%s/%s?version=%s' % (
+                        self.site_url,
+                        bundle.jscompilation,
+                        quote(str(bundle.last_compilation))
+                    )
                 result.append({
                     'bundle': bundle_name,
                     'conditionalcomment': bundle.conditionalcomment,
-                    'src': '%s/%s?version=%s' % (
-                        self.site_url, bundle.jscompilation,
-                        bundle.last_compilation)
+                    'src': js_location
                 })
 
     def scripts(self):

--- a/Products/CMFPlone/resources/browser/styles.py
+++ b/Products/CMFPlone/resources/browser/styles.py
@@ -1,4 +1,5 @@
 from urlparse import urlparse
+from urllib import quote
 
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceView
@@ -60,15 +61,27 @@ class StylesView(ResourceView):
                     cookWhenChangingSettings(self.context, bundle)
 
             if bundle.csscompilation:
+                css_path = bundle.csscompilation
+                if '++plone++' in css_path:
+                    resource_path = css_path.split('++plone++')[-1]
+                    resource_name, resource_filepath = resource_path.split('/', 1)
+                    css_location = '%s/++plone++%s/++unique++%s/%s' % (
+                        self.site_url,
+                        resource_name,
+                        quote(str(bundle.last_compilation)),
+                        resource_filepath
+                    )
+                else:
+                    css_location = '%s/%s?version=%s' % (
+                        self.site_url,
+                        bundle.csscompilation,
+                        quote(str(bundle.last_compilation))
+                    )
                 result.append({
                     'bundle': bundle_name,
                     'rel': 'stylesheet',
                     'conditionalcomment': bundle.conditionalcomment,
-                    'src': '%s/%s?version=%s' % (
-                        self.site_url,
-                        bundle.csscompilation,
-                        bundle.last_compilation
-                    )
+                    'src': css_location
                 })
 
     def styles(self):


### PR DESCRIPTION
Use the ++unique++ traverser instead of query string to make unique resource urls.  This has the advantage of marking the resource as stable for caching purposes.  Fix the custom traverser to properly pass persistent resource directories along to the ++unique++ traverser.