### PR TITLE
Add icon fallback for addons in Site Setup (closes #1232)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New:
   customization.
   [tomgross]
 
+- Add icon fallback for addons in Site Setup
+  [davilima6]
+
 Fixes:
 
 - Fixed white space pep8 warnings.

--- a/Products/CMFPlone/static/fonts/plone-fontello.less
+++ b/Products/CMFPlone/static/fonts/plone-fontello.less
@@ -100,6 +100,7 @@
 .icon-plone-contentmenu-portletmanager:before { content: '\e82b'; } /* '' */
 .icon-plone-contentmenu-display:before { content: '\e82c'; } /* '' */
 .icon-calendar-empty:before { content: '\e82d'; } /* '' */
+[class^="icon-controlpanel-"]:before { content: '\e849'; } /* '' */
 .icon-controlpanel-plone_app_caching:before { content: '\e82e'; } /* '' */
 .icon-controlpanel-plone_app_registry:before { content: '\e82f'; } /* '' */
 .icon-controlpanel-dexterity-types:before { content: '\e830'; } /* '' */


### PR DESCRIPTION
This is the gear icon, using the same character code of the Maintenance icon.

The same icon is used as placeholder inside Fontello for yet to be selected icons such as ZMI, Configuration and Resource Registries but I preferred Maintenance code because I thought it'd the more likely to remain with the generic settings icon.