### PR TITLE
Minor fix for upgrade from old 4.0 instance

### DIFF
--- a/Products/CMFPlone/resources/exportimport/resourceregistry.py
+++ b/Products/CMFPlone/resources/exportimport/resourceregistry.py
@@ -40,7 +40,8 @@ def importResRegistry(context, reg_id, reg_title, filename):
 class ResourceRegistryNodeAdapter(XMLAdapterBase):
 
     resource_blacklist = set()
-
+    registry = None
+    
     def _importNode(self, node):
         """Import the object from the DOM node.
         """


### PR DESCRIPTION
When upgrading a 4.0 site, I get:

AttributeError: 'JSRegistryNodeAdapter' object has no attribute 'registry'

Declaring it as a class attribute should fix this
