### PR TITLE
fix: getIcon for archetypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,9 @@ Fixes:
   https://github.com/plone/Products.CMFPlone/issues/1226
   [fgrcon]
 
+- Also remove deprecated icons for archetypes
+  [Gagaro]
+
 - Fixed white space pep8 warnings.
   [maurits]
 

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -256,8 +256,16 @@ def is_default_page(obj):
 
 @indexer(Interface)
 def getIcon(obj):
-    """Make sure we index icon relative to portal"""
-    return obj.getIcon(True)
+    """
+    geticon redefined in Plone > 5.0
+    see https://github.com/plone/Products.CMFPlone/issues/1226
+
+    reuse of metadata field,
+    now used for showing thumbs in content listings etc.
+    when obj is an image or has a lead image
+    or has an image field with name 'image': true else false
+    """
+    return bool(getattr(obj.aq_base, 'image', False))
 
 
 @indexer(Interface)


### PR DESCRIPTION
Archetypes show a broken img as icon since https://github.com/plone/Products.CMFPlone/issues/1226