### PR TITLE
fix: do not include domain in internal links and images src

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ New:
 
 Fixes:
 
+- Fix internal links and images src to not include the domain.
+  [Gagaro]
+
 - Update Site Setup link in all control panels (fixes .. _`#1255`)
   [davilima6]
 

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -26,6 +26,7 @@ class TinyMCESettingsGenerator(object):
         self.settings = registry.forInterface(
             ITinyMCESchema, prefix="plone", check=False)
         self.portal_url = get_portal_url(self.portal)
+        self.portal_url_path = self.portal.absolute_url_path()
 
     def get_theme(self):
         return theming_policy().get_theme()
@@ -261,7 +262,7 @@ class PloneSettingsAdapter(object):
             'tiny': generator.get_tiny_config(),
             # This is for loading the languages on tinymce
             'loadingBaseUrl': '%s/++plone++static/components/tinymce-builded/js/tinymce' % generator.portal_url,  # noqa
-            'prependToUrl': '{0}/resolveuid/'.format(generator.portal_url),
+            'prependToUrl': '{0}/resolveuid/'.format(generator.portal_url_path),
             'linkAttribute': 'UID',
             'prependToScalePart': '/@@images/image/',
             'imageTypes': image_types


### PR DESCRIPTION
The absolute url should not be used for internal links. When a site is on different domain (one for editing and the other one read-only), all internal links will point to the editing one otherwise.