### PR TITLE
update generator value to point to Plone.com for consistency

### DIFF
--- a/Products/CMFPlone/browser/templates/main_template.pt
+++ b/Products/CMFPlone/browser/templates/main_template.pt
@@ -38,7 +38,7 @@
     <metal:javascriptslot define-slot="javascript_head_slot" />
 
     <link tal:replace="structure provider:plone.htmlhead.links" />
-    <meta name="generator" content="Plone - http://plone.org" />
+    <meta name="generator" content="Plone - http://plone.com" />
 
   </head>
 


### PR DESCRIPTION
as per discussion at https://community.plone.org/t/change-url-in-meta-name-generator-to-plone-com/1337 