### PR TITLE
Fixed Forbidden error in users and groups overview.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ New:
 
 Fixes:
 
+- Fixed Forbidden error when using the users and groups overview as
+  Site Administrator.  This could happen when there are users that
+  inherit the Manager role from the Administrators group.
+  Fixes issue https://github.com/plone/Products.CMFPlone/issues/1293
+  [maurits]
+
 - Fixed Unauthorized error in folder_full_view for anonymous users.
   Fixes issue https://github.com/plone/Products.CMFPlone/issues/1292
   [maurits]

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -146,7 +146,7 @@
                             <input type="hidden"
                                 name="users.roles:list:records"
                                 value="Manager"
-                                tal:condition="python:explicit and not enabled and not inherited"
+                                tal:condition="python:inherited"
                                 tal:attributes="value portal_role" />
                             <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
                           </tal:block>
@@ -238,4 +238,3 @@
 
 </body>
 </html>
-


### PR DESCRIPTION
This is when using it as Site Administrator.  This could happen when
there are users that inherit the Manager role from the Administrators
group.

Fixes issue #1293.