### PR TITLE
Mock MailHost on testing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Fixes:
 - Fix use of icons in search results
   [vangheem]
 
+- Mock MailHost on testing.py so that tests relying on mails can use it.
+  [gforcada]
 
 
 5.0.2 (2016-01-08)


### PR DESCRIPTION
So that any test relying on mails does not need to set up it by itself.

That's related to #1349.

A more sustainable, long term approach would be https://github.com/plone/plone.app.testing/issues/19 but by now and to not be hold off I would like to merge this.