### PR TITLE
fix: sort relateditems tree by sortable_title in tinymce

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ Fixes:
   https://github.com/plone/Products.CMFPlone/issues/866
   [terapyon]
 
+- Sort relateditems tree by sortable_title in tinymce.
+  [Gagaro]
+
 
 5.0.2 (2016-01-08)
 ------------------

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -260,6 +260,8 @@ class PloneSettingsAdapter(object):
                 'folderTypes': folder_types,
                 'rootPath': '/'.join(nav_root.getPhysicalPath()) if nav_root
                             else '/',
+                'sort_on': 'sortable_title',
+                'sort_order': 'ascending',
             },
             'upload': {
                 'initialFolder': initial,


### PR DESCRIPTION
Trees are sorted on is_folderish at the moment, but they also are filtered to only show is_folderish contents. This allow easier finding of the folder/content we want.

See also https://github.com/plone/plone.app.widgets/pull/132