### PR TITLE
Do not fail when viewing any page, when the persistent resource directory is not registered.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ New:
 
 Fixes:
 
+- Do not fail when viewing any page, or during migration, when Diazo
+  is not installed and the persistent resource directory is not
+  registered.  Fixes
+  https://github.com/plone/Products.CMFPlone/issues/1187
+  [maurits]
+
 - Move hero on welcome page from theme into managed content.
   Issue https://github.com/plone/Products.CMFPlone/issues/974
   [gyst]
@@ -59,7 +65,7 @@ Fixes:
 
 - Mock MailHost on testing.py so that tests relying on mails can use it.
   [gforcada]
-  
+
 - Fix `aria-hidden` attribute control problem on toolbar
   https://github.com/plone/Products.CMFPlone/issues/866
   [terapyon]

--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -9,12 +9,15 @@ from Products.CMFPlone.interfaces.resources import (
 )
 from StringIO import StringIO
 from zope.component import getUtility
+from zope.component import queryUtility
 
 PRODUCTION_RESOURCE_DIRECTORY = "production"
 
 
 def get_production_resource_directory():
-    persistent_directory = getUtility(IResourceDirectory, name="persistent")
+    persistent_directory = queryUtility(IResourceDirectory, name="persistent")
+    if persistent_directory is None:
+        return ''
     container = persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
     production_folder = container[PRODUCTION_RESOURCE_DIRECTORY]
     timestamp = production_folder.readFile('timestamp.txt')
@@ -81,7 +84,9 @@ def write_css(context, folder, meta_bundle):
 
 
 def combine_bundles(context):
-    persistent_directory = getUtility(IResourceDirectory, name="persistent")
+    persistent_directory = queryUtility(IResourceDirectory, name="persistent")
+    if persistent_directory is None:
+        return
     if OVERRIDE_RESOURCE_DIRECTORY_NAME not in persistent_directory:
         persistent_directory.makeDirectory(OVERRIDE_RESOURCE_DIRECTORY_NAME)
     container = persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -111,7 +111,7 @@ class ScriptsView(ResourceView):
         """The requirejs scripts, the ones that are not resources are loaded on
         configjs.py
         """
-        if self.development:
+        if self.development or not self.production_path:
             result = self.default_resources()
             result.extend(self.ordered_bundles_result())
         else:

--- a/Products/CMFPlone/resources/browser/styles.py
+++ b/Products/CMFPlone/resources/browser/styles.py
@@ -89,7 +89,7 @@ class StylesView(ResourceView):
         """
         Get all the styles
         """
-        if self.development:
+        if self.development or not self.production_path:
             result = self.ordered_bundles_result()
         else:
             result = [{

--- a/Products/CMFPlone/traversal.py
+++ b/Products/CMFPlone/traversal.py
@@ -1,5 +1,5 @@
 from plone.resource.traversal import ResourceTraverser
-from zope.component import getUtility
+from zope.component import queryUtility
 from plone.resource.interfaces import IResourceDirectory
 from plone.resource.interfaces import IUniqueResourceRequest
 from Products.CMFPlone.interfaces.resources import (
@@ -27,9 +27,10 @@ class PloneBundlesTraverser(ResourceTraverser):
         if more_traversal:
             resource_filepath = resource_filepath.split('/')[-1]
 
-        persistentDirectory = getUtility(IResourceDirectory, name="persistent")
+        persistentDirectory = queryUtility(IResourceDirectory, name="persistent")
         directory = None
-        if OVERRIDE_RESOURCE_DIRECTORY_NAME in persistentDirectory:
+        if (persistentDirectory is not None and
+                OVERRIDE_RESOURCE_DIRECTORY_NAME in persistentDirectory):
             container = persistentDirectory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
             if resource_name in container:
                 directory = container[resource_name]


### PR DESCRIPTION
This can happen if Diazo is not installed.
We might want to install it when migrating to Plone 5,ut meanwhile this fixes the immediate error in Plone 5.

With the meta-bundles plip, added in Plone 5.0.3, it would already fail during migration.

Fixes #1187.