### PR TITLE
Registered post_handler instead of plone-final.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ Changelog
 
 New:
 
+- Registered post_handler instead of plone-final.  The plone-final
+  import step now does nothing.  Instead, we redefined the old handler
+  as a post_handler explicitly for our main profile.  This is
+  guaranteed to really run after all other import steps, which was
+  never possible in the old way.  The plone-final step is kept for
+  backwards compatibility.  [maurits]
+
 - If a bundle does not provide any resources, do not attempt to compile it
   [vangheem]
 

--- a/Products/CMFPlone/exportimport/configure.zcml
+++ b/Products/CMFPlone/exportimport/configure.zcml
@@ -63,9 +63,9 @@
 
   <genericsetup:importStep
       name="plone-final"
-      handler="Products.CMFPlone.setuphandlers.importFinalSteps"
-      title="Final Plone Config"
-      description="Final Plone configuration.">
+      handler="Products.CMFPlone.setuphandlers.dummy_import_step"
+      title="Final Plone Config (old)"
+      description="Dummy import step for backwards compatibility. The old import step is now used as a post_handler.">
    <depends name="portlets" />
    <depends name="rolemap" />
    <depends name="catalog" />

--- a/Products/CMFPlone/profiles.zcml
+++ b/Products/CMFPlone/profiles.zcml
@@ -9,6 +9,7 @@
       directory="profiles/default"
       description="Profile for a default Plone."
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      post_handler="Products.CMFPlone.setuphandlers.importFinalSteps"
       />
 
   <genericsetup:registerProfile

--- a/Products/CMFPlone/profiles/default/plone-final.txt
+++ b/Products/CMFPlone/profiles/default/plone-final.txt
@@ -1,1 +1,0 @@
-The plone-final step is run if this file is present in the profile

--- a/Products/CMFPlone/setuphandlers.py
+++ b/Products/CMFPlone/setuphandlers.py
@@ -172,14 +172,30 @@ def assignTitles(portal):
             setattr(aq_base(obj), 'title', title)
 
 
+def dummy_import_step(context):
+    """Dummy import step.
+
+    The plone-final import step used to call importFinalSteps below.
+    But plone-final was never guaranteed to be run as final step.  So
+    more and more import steps were added to its dependencies to let it
+    run later and later.  Not nice.
+
+    With Products.GenericSetup 1.8.2, we can add a post_handler to a
+    profile (and a pre_handler).  We now do that.  So the plone-final
+    import step is no longer needed.  But others may depend on it, so we
+    keep it for now.  This dummy import step handler is meant for
+    that.
+    """
+    pass
+
+
 def importFinalSteps(context):
+    """Final Plone import steps.
+
+    This was an import step, but is now registered as post_handler
+    specifically for our main 'plone' (profiles/default) profile.
     """
-    Final Plone import steps.
-    """
-    # Only run step if a flag file is present (e.g. not an extension profile)
-    if context.readDataFile('plone-final.txt') is None:
-        return
-    site = context.getSite()
+    site = getSite()
 
     # Unset all profile upgrade versions in portal_setup.  Our default
     # profile should only be applied when creating a new site, so this

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -900,16 +900,8 @@ class TestPortalBugs(PloneTestCase.PloneTestCase):
         self.loginAsPortalOwner()
         portal = self.portal
         portal.manage_delObjects(['Members'])
-
-        class FakeContext:
-
-            def getSite(self):
-                return portal
-
-            def readDataFile(self, filename):
-                return True  # Anything other than None runs the step
-
-        setuphandlers.importFinalSteps(FakeContext())  # raises error if fail
+        setup_tool = getToolByName(self.portal, 'portal_setup')
+        setuphandlers.importFinalSteps(setup_tool)  # raises error if fail
         self.assertTrue(1 == 1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'Products.DCWorkflow',
         'Products.ExtendedPathIndex',
         'Products.ExternalEditor',
-        'Products.GenericSetup >= 1.8.0',
+        'Products.GenericSetup >= 1.8.2',
         'Products.MimetypesRegistry',
         'Products.PasswordResetTool',
         'Products.PlacelessTranslationService',


### PR DESCRIPTION
The plone-final import step now does nothing.

Instead, we redefined the old handler as a post_handler explicitly for
our main profile.  This is guaranteed to really run after all other
import steps, which was never possible in the old way.

The plone-final step is kept for backwards compatibility.

This requires Products.GenericSetup 1.8.2.