### PR TITLE
Minor toolbar cleanup:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 
 New:
 
+- new less variable to configure the width of the toolbars submenu called
+  ``plone-toolbar-submenu-width``.
+  [jensens]
+
 - If a bundle does not provide any resources, do not attempt to compile it
   [vangheem]
 
@@ -30,6 +34,11 @@ New:
   [ebrehault]
 
 Fixes:
+
+- Toolbar cleanup: more less and less css, typo corrected in less variable,
+- better readability with a darker background in submenu, use font fallback
+- chain as in barcelonetta (works also w/o the theme).
+  [jensens]
 
 - Fix browser spell checking not working with TinyMCE
   [vangheem]

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -988,13 +988,10 @@
       <element key="plone-gray-light">lighten(#000, 46.5%)</element>
 
       <element key="plone-toolbar-bg">rgba(0,0,0,.9)</element>
-      <element key="plone-toolbar-submenu-bg">rgba(20,20,20,.9)</element>
-      <!--
-      <element key="plone-toolbar-font-primary">'Roboto Condensed', sans-serif</element>
-      <element key="plone-toolbar-font-secundary">'Roboto', sans-serif</element>
-      -->
-      <element key="plone-toolbar-font-primary">sans-serif</element>
-      <element key="plone-toolbar-font-secundary">sans-serif</element>
+      <element key="plone-toolbar-submenu-bg">rgba(45,45,45,.96)</element>
+      <element key="plone-toolbar-submenu-width">180px</element>
+      <element key="plone-toolbar-font-primary">Roboto, \"Helvetica Neue\", Helvetica, Arial, sans-serif</element>
+      <element key="plone-toolbar-font-secondary">Roboto, \"Helvetica Neue\", Helvetica, Arial, sans-serif</element>
       <element key="plone-toolbar-separator-color">rgba(255,255,255,.17)</element>
       <element key="plone-toolbar-link">{plone-link-color}</element>
       <element key="plone-toolbar-text-color">rgba(255,255,255,1)</element>

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -16,8 +16,7 @@ body.userrole-authenticated {
     left:0;
     z-index: 3;
     font-weight: 400;
-    /*font-family: 'Roboto', sans-serif;*/
-    font-family: sans-serif;
+    font-family: @plone-toolbar-font-primary;
     color: @plone-toolbar-text-color;
     background: @plone-toolbar-bg;
     a {
@@ -98,102 +97,115 @@ body.userrole-authenticated {
         /*states on first level*/
         a.label-state-published > span:before, a.label-state-external > span:before {color: @plone-toolbar-published-color; }
         a.label-state-published > span + span, a.label-state-external > span:before { background: @plone-toolbar-published-color; }
+
         a.label-state-internally_published > span:before {color: @plone-toolbar-internally-published-color; }
         a.label-state-internally_published > span + span { background: @plone-toolbar-internally-published-color; }
+
         a.label-state-pending > span:before {color: @plone-toolbar-pending-color; }
         a.label-state-pending > span + span { background: @plone-toolbar-pending-color; }
         li.active a.label-state-pending > span, a.label-state-pending > span:hover { color:(#fff - @plone-toolbar-text-color) !important;} //contrast
+
         a.label-state-draft > span:before, a.label-state-internal > span:before {color: @plone-toolbar-draft-color; }
         a.label-state-draft > span + span, a.label-state-internal > span + span  { background: @plone-toolbar-draft-color; }
+
         a.label-state-private > span:before {color: @plone-toolbar-private-color; }
-        a.label-state-private > span + span { background: @plone-toolbar-private-color; }
+        a.label-state-private > span + span { background: @plone-toolbar-private-color; }git diff
 
-    }
+        /*second-level*/
+        ul {
+            font-family:@plone-toolbar-font-secondary; font-size: 14px; list-style: none; padding:0; margin:0; line-height: 30px;
+            position: absolute;
+            left: @plone-left-toolbar;
+            background: @plone-toolbar-submenu-bg;
+            top: 0;
+            overflow-y: auto;
 
-    /*second-level*/
-    nav > ul ul {
-        font-family:@plone-toolbar-font-secundary; font-size: 14px; list-style: none; padding:0; margin:0; line-height: 30px;
-        a {
-            color: @plone-toolbar-submenu-text-color;
-            &:hover {
-                color: darken(@plone-toolbar-submenu-text-color, 15%);
-                background: lighten(@plone-toolbar-bg, 10%);
+            //prepare icon
+            [class^="icon"] {
+                display: inline !important; line-height: 0;
+                &:before {font-size: 10px;line-height: 18px;position: absolute;right: 10px;color: @plone-toolbar-private-color; margin-top: 7px; top:0;}
+            }
+            /*state marker*/
+            //dictionary translate flow into state
+            @flow-private: workflow-transition-reject;
+            @flow-published: workflow-transition-publish;
+            @flow-pending: workflow-transition-submit;
+            @flow-internally_published: workflow-transition-show_internally;
+            @flow-internal: workflow-transition-hide;
+
+            //states
+            .state-published:after, .state-external:after, #@{flow-published}:after  {right:15px; content:"•"; color:@plone-toolbar-published-color; position: absolute; font-size: 20px;}
+            .state-internally_published:after, #@{flow-internally_published}:after {right:15px; content:"•"; color:@plone-toolbar-internally-published-color; position: absolute; font-size: 20px;}
+            .state-pending:after, #@{flow-pending}:after {right:15px; content:"•"; color:@plone-toolbar-pending-color; position: absolute; font-size: 20px;}
+            .state-draft:after, .state-internal:after, #@{flow-internal}:after {right:15px; content:"•"; color:@plone-toolbar-draft-color; position: absolute; font-size: 20px;}
+            .state-private:after, #@{flow-private}:after {right:15px; content:"•"; color:@plone-toolbar-private-color; position: absolute; font-size: 20px;}
+
+            //submenu styles
+            a {
+                color: @plone-toolbar-submenu-text-color;
+                &:hover {
+                    color: darken(@plone-toolbar-submenu-text-color, 15%);
+                    background: lighten(@plone-toolbar-bg, 10%);
+                }
+            }
+            li {
+                width: @plone-toolbar-submenu-width;
+                &:last-child {padding-bottom: 5px; }
+                > span {display: block; padding: 5px 15px; height: auto; line-height: 20px;}
+                > a {padding: 5px 15px; height: auto; line-height: 20px;}
+                &.plone-toolbar-submenu-header {
+                    border-top: 1px solid @plone-toolbar-separator-color;
+                    padding: 5px 0 0;
+                    margin: 5px 0 0;
+                    &:first-child {border-top:0; margin:0;}
+                    &:after {font-size: 30px; right:13px;}
+                    > a {
+                        color: @plone-toolbar-link; font-weight: 400;
+                        &:hover {color: darken(@plone-toolbar-link, 15%);}
+                    }
+                    > span {font-weight: 400; color: @plone-toolbar-submenu-header-color;}
+                }
+                &:not(.plone-toolbar-submenu-header) {
+                    > :before {content:"•"; left: 15px; color: @plone-toolbar-link; position: absolute;}
+                    > span {color: @plone-toolbar-text-color; padding: 5px 15px 5px 30px; height: auto;}
+                    > a {
+                        padding: 5px 15px 5px 30px; height: auto;
+                        &:hover:before {color: lighten(@plone-toolbar-link, 25%);}
+                        &.actionMenuSelected {
+                            &:hover {color: @plone-toolbar-text-color; background: none; cursor: default;}
+                            &:before {color: @plone-toolbar-text-color;}
+                        }
+                    }
+                    > .actionMenuSelected {
+                        color: @plone-toolbar-text-color;
+                        font-weight: 500;
+                        &:before {color: darken(@plone-toolbar-text-color,15%);}
+                        &:before {content:"✓" !important; margin-left: -3px;}
+                    }
+                }
             }
         }
-        li:last-child {padding-bottom: 5px; }
-        li > span {display: block;}
-        .plone-toolbar-submenu-header > a {
-            color: @plone-toolbar-link; font-weight: 400;
-            &:hover {color: darken(@plone-toolbar-link, 15%);}
+        .plone-toolbar-separator {border-bottom: 1px solid @plone-toolbar-separator-color;}
+        .plone-toolbar-caret {
+            border-left: 4px solid;
+            border-bottom: 4px solid transparent;
+            border-top: 4px solid transparent;
+            position: absolute;
+            right: 0;
+            background: transparent !important;
+            margin-top: 0 !important;
+            top: 21px;
+            opacity: .67;
+            display: inline-block;
+            width: 0;
+            height: 0;
+            right: 2px;
+            padding: 0;
+            vertical-align: middle;
         }
-        .plone-toolbar-submenu-header > span {font-weight: 400; color: @plone-toolbar-submenu-header-color;}
-        li:not(.plone-toolbar-submenu-header) > a:before {content:"•"; left: 15px; color: @plone-toolbar-link; position: absolute;}
-        li:not(.plone-toolbar-submenu-header) > span:before {content:"•"; left: 15px; color: darken(@plone-toolbar-text-color,70%); position: absolute;}
-        li:not(.plone-toolbar-submenu-header) > a:hover:before {color: lighten(@plone-toolbar-link, 25%);}
-        .actionMenuSelected {
-            color: @plone-toolbar-text-color; font-weight: 500;
-            &:hover {color: @plone-toolbar-text-color; background: none; cursor: default;}
-            &:before {content:"✓" !important; margin-left: -3px;}
-        }
-        .actionMenuSelected:hover {color: @plone-toolbar-text-color; background: none; cursor: default;}
-        li:not(.plone-toolbar-submenu-header) > a.actionMenuSelected:before {color: @plone-toolbar-text-color;}
-    }
-    .plone-toolbar-separator {border-bottom: 1px solid @plone-toolbar-separator-color;}
-    .plone-toolbar-caret {
-        border-left: 4px solid;
-        border-bottom: 4px solid transparent;
-        border-top: 4px solid transparent;
-        position: absolute;
-        right: 0;
-        background: transparent !important;
-        margin-top: 0 !important;
-        top: 21px;
-        opacity: .67;
-        display: inline-block;
-        width: 0;
-        height: 0;
-        right: 2px;
-        padding: 0;
-        vertical-align: middle;
     }
 }
 
-/*de moment per borrar coses*/
-#edit-zone nav > ul ul {
-    position: absolute;
-    left: @plone-left-toolbar;
-    background: @plone-toolbar-submenu-bg;
-    top: 0;
-    overflow-y: auto;
-    li {width: 180px}
-    li > a, li > span {padding: 5px 15px; height: auto; line-height: 20px;}
-    li:not(.plone-toolbar-submenu-header) > a, li:not(.plone-toolbar-submenu-header) > span {padding: 5px 15px 5px 30px; height: auto;}
-    li:not(.plone-toolbar-submenu-header) > span { color: @plone-toolbar-text-color;}
-    .plone-toolbar-submenu-header {border-top: 1px solid @plone-toolbar-separator-color; padding: 5px 0 0;margin: 5px 0 0;}
-    .plone-toolbar-submenu-header:first-child {border-top:0; margin:0;}
-    [class^="icon"] {
-        display: inline !important; line-height: 0;
-        &:before {font-size: 10px;line-height: 18px;position: absolute;right: 10px;color: @plone-toolbar-private-color; margin-top: 7px; top:0;}
-    }
-    /*state marker*/
-    //dictionary translate flow into state
-    @flow-private: workflow-transition-reject;
-    @flow-published: workflow-transition-publish;
-    @flow-pending: workflow-transition-submit;
-    @flow-internally_published: workflow-transition-show_internally;
-    @flow-internal: workflow-transition-hide;
-
-    //states
-    .state-published:after, .state-external:after, #@{flow-published}:after  {right:15px; content:"•"; color:@plone-toolbar-published-color; position: absolute; font-size: 20px;}
-    .state-internally_published:after, #@{flow-internally_published}:after {right:15px; content:"•"; color:@plone-toolbar-internally-published-color; position: absolute; font-size: 20px;}
-    .state-pending:after, #@{flow-pending}:after {right:15px; content:"•"; color:@plone-toolbar-pending-color; position: absolute; font-size: 20px;}
-    .state-draft:after, .state-internal:after, #@{flow-internal}:after {right:15px; content:"•"; color:@plone-toolbar-draft-color; position: absolute; font-size: 20px;}
-    .state-private:after, #@{flow-private}:after {right:15px; content:"•"; color:@plone-toolbar-private-color; position: absolute; font-size: 20px;}
-
-
-    /*current*/
-    .plone-toolbar-submenu-header :after {font-size: 30px; right:13px;}
-}
 .plone-toolbar-left #edit-zone{
     z-index: 5;
     nav > ul ul {
@@ -204,7 +216,7 @@ body.userrole-authenticated {
         height: 100%;
     }
 }
-.plone-toolbar-top #edit-zone nav > ul ul {height: 0; max-height: 0; width: 180px}
+.plone-toolbar-top #edit-zone nav > ul ul {height: 0; max-height: 0; width: @plone-toolbar-submenu-width}
 
 
 .plone-toolbar-expanded #edit-zone {
@@ -230,25 +242,27 @@ body.userrole-authenticated {
     li:not(.active) a:hover > span {background: @plone-toolbar-link;}
 
     /*states*/
-    li a.label-state-published:hover > span, li a.label-state-external:hover > span  {
-        background: @plone-toolbar-published-color;
-        &:first-child:before {color:@plone-toolbar-text-color;}
-    }
-    li a.label-state-internally_published:hover > span {
-        background: @plone-toolbar-internally-published-color;
-        &:first-child:before {color:@plone-toolbar-text-color;}
-    }
-    li a.label-state-pending:hover > span {
-        background: @plone-toolbar-pending-color;
-        &:first-child:before {color:@plone-toolbar-text-color;}
-    }
-    li a.label-state-draft:hover > span, li a.label-state-internal:hover > span {
-        background: @plone-toolbar-draft-color;
-        &:first-child:before {color:@plone-toolbar-text-color;}
-    }
-    li a.label-state-private:hover > span {
-        background: @plone-toolbar-private-color;
-        &:first-child:before {color:@plone-toolbar-text-color;}
+    li {
+        a.label-state-published:hover > span, li a.label-state-external:hover > span  {
+            background: @plone-toolbar-published-color;
+            &:first-child:before {color:@plone-toolbar-text-color;}
+        }
+        a.label-state-internally_published:hover > span {
+            background: @plone-toolbar-internally-published-color;
+            &:first-child:before {color:@plone-toolbar-text-color;}
+        }
+        a.label-state-pending:hover > span {
+            background: @plone-toolbar-pending-color;
+            &:first-child:before {color:@plone-toolbar-text-color;}
+        }
+        a.label-state-draft:hover > span, li a.label-state-internal:hover > span {
+            background: @plone-toolbar-draft-color;
+            &:first-child:before {color:@plone-toolbar-text-color;}
+        }
+        a.label-state-private:hover > span {
+            background: @plone-toolbar-private-color;
+            &:first-child:before {color:@plone-toolbar-text-color;}
+        }
     }
     .plone-toolbar-logo {
         width: @plone-left-toolbar-expanded;
@@ -257,28 +271,29 @@ body.userrole-authenticated {
 }
 
 #edit-zone nav > ul > li.active {
-    > a:after {
-        content:"";
-        border-right: 10px solid #2a2a2a;
-        border-bottom: 10px solid transparent;
-        border-top: 10px solid transparent;
-        position: absolute;
-        right: 0;
-        margin-top: -35px;
-    }
+    ul {display: block; width: @plone-toolbar-submenu-width;}
     a > span {margin-top: -50px; }
-    > a {background: @plone-toolbar-link;
-        & span:before {color:@plone-toolbar-text-color !important;} /*state icon on white*/
+    > a {
+        background: @plone-toolbar-link;
+        &:after {
+            content:"";
+            border-right: 10px solid #2a2a2a;
+            border-bottom: 10px solid transparent;
+            border-top: 10px solid transparent;
+            position: absolute;
+            right: 0;
+            margin-top: -35px;
+        }
+        span:before {color:@plone-toolbar-text-color !important;} /*state icon on white*/
+        &.label-state-published,
+        &.label-state-external {background: @plone-toolbar-published-color;}
+        &.label-state-internally_published {background: @plone-toolbar-internally-published-color;}
+        &.label-state-pending {background: @plone-toolbar-pending-color;}
+        &.label-state-draft,
+        &.label-state-internal {background: @plone-toolbar-draft-color;}
+        &.label-state-private {background: @plone-toolbar-private-color;}
     }
-    > a.label-state-published, > a.label-state-external {background: @plone-toolbar-published-color;}
-    > a.label-state-internally_published {background: @plone-toolbar-internally-published-color;}
-    > a.label-state-pending {background: @plone-toolbar-pending-color;}
-    > a.label-state-draft, > a.label-state-internal {background: @plone-toolbar-draft-color;}
-    > a.label-state-private {background: @plone-toolbar-private-color;}
-    ul {display: block; width: 180px;}
-    }
-
-
+}
 
 /*plone-toolbar-top*/
 .plone-toolbar-top #edit-zone {
@@ -475,7 +490,7 @@ body.userrole-authenticated {
         width: 0;
     }
     #edit-zone nav ul li.active ul {
-        width: 180px;
+        width:@plone-toolbar-submenu-width;
     }
 
     .plone-toolbar-left-default { padding-left: 0px; }

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/variables.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/variables.less
@@ -6,7 +6,7 @@
 @plone-toolbar-bg:                          rgba(0,0,0,.9);
 @plone-toolbar-submenu-bg:                  rgba(20,20,20,.95);
 @plone-toolbar-font-primary:                'Roboto Condensed', sans-serif;
-@plone-toolbar-font-secundary:              'Roboto', sans-serif;
+@plone-toolbar-font-secondary:              'Roboto', sans-serif;
 @plone-toolbar-separator-color:             rgba(255,255,255,.17);
 @plone-toolbar-link:                        @plone-link-color;
 @plone-toolbar-text-color:                  rgba(255,255,255,.9);   


### PR DESCRIPTION
- more less and less css,
- typo corrected in less variable,
- use font fallback chain as in barcelonetta (works also w/o the theme),
- better readability with a darker background in submenu

This one needs to be merged together (or before) plone/plone.app.upgrade#69