### PR TITLE
try to fix random robot testing failure

### DIFF
--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -55,6 +55,7 @@ I open the ${OPERATOR} operator in the ${CRITERIA} criteria
 
 I search in ${NAME} subfolder in the related items widget
     Click Element  jquery=.pattern-relateditems-tree-select
+    Wait Until Element Is Visible  jquery=.pat-tree li.jqtree_common:contains("${NAME}") .pattern-relateditems-result-browse
     Click Element  jquery=.pat-tree li.jqtree_common:contains("${NAME}") .pattern-relateditems-result-browse
     Wait Until Element Is Visible    css=.select2-highlighted a
     Click Element  css=.select2-highlighted a


### PR DESCRIPTION
tries to fix random test failure like
http://jenkins.plone.org/job/pull-request-5.0/993/testReport/junit/Products.CMFPlone.tests.test_robot/RobotTestCase/Scenario_Location_query/
which are probably caused by a timing problem because of a missing wait.