### PR TITLE
Add dl.portalMessage.warning to common_content_filter in popupforms.js.

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/popupforms.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/popupforms.js
@@ -23,7 +23,7 @@ function msieversion() {
     }
 }
 
-var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info';
+var common_content_filter = '#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.warning,dl.portalMessage.info';
 
 jQuery.extend(jQuery.tools.overlay.conf,
     {

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 4.3.8 (unreleased)
 ------------------
 
+- Add dl.portalMessage.warning to common_content_filter in popupforms.js so
+  warnings get also pulled into the popup. [pcdummy]
+
 - Disabled CSRF protection on site creation form and upgrade form.  [maurits]
 
 - When migration fails, do not upgrade addons or recatalog or


### PR DESCRIPTION
We found that dl.portalMessage.warning is missing in common_content_filter while debugging an error in a addon.