### PR TITLE
In the combine-bundles import step do not set Content Type header.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,11 @@ New:
 
 Fixes:
 
-- *add item here*
+- In the ``combine-bundles`` import step, make sure the Content Type
+  header is not set to ``application/javascript``.  This would result
+  in the ``plone-upgrade`` result page being shown in plain text.
+  Fixes https://github.com/plone/Products.CMFPlone/issues/1436
+  [maurits]
 
 
 5.0.3c1 (2016-03-02)

--- a/Products/CMFPlone/resources/exportimport/bundles.py
+++ b/Products/CMFPlone/resources/exportimport/bundles.py
@@ -1,5 +1,6 @@
 from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
+from zope.globalrequest import getRequest
 
 from ..browser.combine import combine_bundles
 
@@ -16,4 +17,20 @@ def combine(context):
     body = context.readDataFile('registry.xml')
     if body and "IBundleRegistry" in body:
         site = context.getSite()
+        # Calling combine_bundles will have as side effect that the
+        # Content-Type header of the response is set to application/javascript,
+        # which we do not want.  So we reset it to the original at the end.
+        site = context.getSite()
+        request = getattr(site, 'REQUEST', getRequest())
+        if request is not None:
+            # Easily happens in tests.
+            orig_header = request.response.getHeader('Content-Type')
         combine_bundles(site)
+        if request is not None:
+            new_header = request.response.getHeader('Content-Type')
+            if new_header != orig_header:
+                if orig_header is None:
+                    # Setting it to None would result in the string 'None'.
+                    # So pick a saner one.
+                    orig_header = 'text/html'
+                request.response.setHeader('Content-Type', orig_header)


### PR DESCRIPTION
It would be set to application/javascript.  This would result in the plone-upgrade result page being shown in plain text.

Fixes #1436

I tried adding a test, but that is tricky because in tests the request is not always properly set.
For the record, this was the test I added in `test_metabundles.py`:

```
from Products.CMFCore.utils import getToolByName
from Products.CMFPlone.factory import _DEFAULT_PROFILE


class BundlesImportStepTest(PloneTestCase):

    def test_import_step_content_type(self):
        # The 5.0.2 to 5.0.3 upgrade had a problem: the plone-upgrade result
        # page showed as plain text instead of html, because the
        # combine-bundles import step resulted in a wrong Content Type header.
        # We test it here.
        setup = getToolByName(self.portal, 'portal_setup')
        self.assertEqual(
            setup.REQUEST.response.getHeader('Content-Type'), None)
        setup.setLastVersionForProfile(_DEFAULT_PROFILE, '5012')
        setup.upgradeProfile(_DEFAULT_PROFILE, '5013')
        # We do not mind too much if the header is text/html or None, certainly
        # in tests, where a request can be None, but important is that it is
        # not javascript:
        self.assertNotEqual(
            setup.REQUEST.response.getHeader('Content-Type'),
            'application/javascript')
        # If the next fails, then the above test does not actually prove
        # anything, because the Content Type was never changed...  Apparently
        # getRequest returned None in resources/browser/configjs.py
        self.assertEqual(
            setup.REQUEST.response.getHeader('Content-Type'),
            'text/html')
```

The last `assertEqual` fails with the old and the new code. The `assertNotEqual` above it passes with the old and new code. So the test brings us nothing.

Anyway, the bug is fixed. :-)