### PR TITLE
Fixed displaying the body text of a feed item.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New:
 
 Fixes:
 
+- Fixed displaying the body text of a feed item.  This is when
+  ``render_body`` is switched on in the Syndication settings.
+  [maurits]
+
 - In the ``combine-bundles`` import step, make sure the Content Type
   header is not set to ``application/javascript``.  This would result
   in the ``plone-upgrade`` result page being shown in plain text.

--- a/Products/CMFPlone/browser/syndication/templates/content_core.pt
+++ b/Products/CMFPlone/browser/syndication/templates/content_core.pt
@@ -1,4 +1,4 @@
-<tal:block tal:define="view context/defaultView;"
+<tal:block tal:define="default_view_template context/defaultView;"
            tal:on-error="nothing">
-   <div metal:use-macro="here/?view/macros/content-core"/>
+   <div metal:use-macro="here/?default_view_template/macros/content-core"/>
 </tal:block>


### PR DESCRIPTION
This is when render_body is switched on in the Syndication settings.

We were overwriting the definition of the `view` variable, which made it fail:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.browser.syndication.views, line 39, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 93, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 261, in render
  Module chameleon.template, line 171, in render
  Module 9a93a3a9db64b84dab01cae9a58bb733.py, line 503, in render
  Module five.pt.expressions, line 161, in __call__
  Module Products.CMFPlone.browser.syndication.adapters, line 236, in render_content_core
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 93, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 261, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module cd214db2eac084734315e0e6f7e14d77.py, line 102, in render
  Module b4e15de41a55c9fcbf57a3d38e8cffe9.py, line 137, in render_content_core
AttributeError: 'str' object has no attribute 'context'

 - Expression: "item/render_content_core"
 - Filename:   ... g/Products/CMFPlone/browser/syndication/templates/RSS.pt
 - Location:   (line 39: col 42)
 - Source:     ... l:replace="structure item/render_content_core"/>
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "python:context.text.output_relative_to(view.context)"
 - Filename:   ... egg/plone/app/contenttypes/browser/templates/newsitem.pt
 - Location:   (line 15: col 29)
 - Source:     ... ucture python:context.text.output_relative_to(view.context)"
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x10ee504d0>
               views: <ViewMapper - at 0x10edff050>
               modules: <instance - at 0x10443d878>
               args: <tuple - at 0x10023a050>
               here: <ImplicitAcquisitionWrapper first-news-item at 0x10dd8a5f0>
               user: <ImplicitAcquisitionWrapper - at 0x10e42daf0>
               nothing: <NoneType - at 0x100159108>
               container: <ImplicitAcquisitionWrapper first-news-item at 0x10dd8a5f0>
               request: <instance - at 0x10c8a3cf8>
               wrapped_repeat: <SafeMapping - at 0x10da079f0>
               traverse_subpath: <list - at 0x10eea4c68>
               default: <object - at 0x100290c10>
               loop: {...} (0)
               context: <ImplicitAcquisitionWrapper first-news-item at 0x10dd8a5f0>
               view: newsitem_view
               translate: <function translate at 0x10ebfb488>
               root: <ImplicitAcquisitionWrapper Zope at 0x10dc3b4b0>
               options: {...} (0)
               target_language: en
```

Strangely, this does not fail in the tests and I don't know why. This also makes it hard to write a test that fails with the original code.

Note that we caught the error so no error was visible to a visitor.

Also note that getting the content-core macro may fail anyway, for example for a Folder, because its default view does not have this macro.