### PR TITLE
contact form fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ New:
 - Remove Zope mention in logout form 
   [tkimnguyen]
 
+- Do not encode reply-to email address for contact-info form
+  [tkimnguyen]
+
 Fixes:
 
 - *add item here*

--- a/Products/CMFPlone/browser/contact_info.py
+++ b/Products/CMFPlone/browser/contact_info.py
@@ -68,7 +68,7 @@ class ContactForm(form.Form):
         data['url'] = portal.absolute_url()
         message = self.generate_mail(data, encoding)
         message = MIMEText(message, 'plain', encoding)
-        message['Reply-To'] = Header(data['sender_from_address'], encoding)
+        message['Reply-To'] = data['sender_from_address']
 
         try:
             # This actually sends out the mail


### PR DESCRIPTION
Remove the encoding of the Reply-To header which was garbling the return address