### PR TITLE
Use ``getSite()`` instead of portal url for controlpanel portlets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,11 @@ Incompatibilities:
 
 New:
 
-- Control panel to mange portal actions
+- For the controlpanel portlets, use the nearest site url as a base for the overview-controlpanel.
+  This gives more flexibility for sub site controlpanels.
+  [thet]
+
+- Control panel to mange portal actions.
   [ebrehault]
 
 - new less variable to configure the width of the toolbars submenu called

--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -14,6 +14,7 @@ from Products.CMFCore.utils import UniqueObject
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.interfaces import IControlPanel
 from Products.CMFPlone.PloneBaseTool import PloneBaseTool
+from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.i18nmessageid import Message
 from zope.interface import implements
@@ -296,6 +297,16 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             management_view='Actions',
             manage_tabs_message=manage_tabs_message,
         )
+
+    @property
+    def site_url(self):
+        """Return the absolute URL to the current site, which is likely not
+        necessarily the portal root.
+        Used by ``portlet_prefs`` to construct the URL to
+        ``@@overview-controlpanel``.
+        """
+        return getSite().absolute_url()
+
 
 InitializeClass(PloneControlPanel)
 registerToolInterface('portal_controlpanel', IControlPanel)

--- a/Products/CMFPlone/skins/plone_prefs/portlet_prefs.pt
+++ b/Products/CMFPlone/skins/plone_prefs/portlet_prefs.pt
@@ -7,14 +7,14 @@
 <metal:portlet define-macro="portlet"
    tal:define="controlPanel python:modules['Products.CMFCore.utils'].getToolByName(here, 'portal_controlpanel');
                groups python:controlPanel.getGroups('site');
-               portal_url context/portal_url;">
+               site_url controlPanel/site_url">
 
 <section class="portlet portletNavigationTree portletSiteSetup" role="section"
     id="portlet-prefs"
     tal:condition="controlPanel/maySeeSomeConfiglets">
   <header class="portletHeader">
         <a href=""
-           tal:attributes="href string:${portal_url}/@@overview-controlpanel"
+           tal:attributes="href string:${site_url}/@@overview-controlpanel"
            i18n:translate="">Site Setup</a>
   </header>
 


### PR DESCRIPTION
For the controlpanel portlets, use the nearest site url as a base for the overview-controlpanel.
This gives more flexibility for sub site controlpanels.