### PR TITLE
Fixed versioning for File and Image.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,12 +16,15 @@ New:
 
 - Supported ``remove`` keyword for configlets in controlpanel.xml.  [maurits]
 
-- Deprecated Gruntfile generation script ``plone-generate-gruntfile``. 
-  Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too. 
+- Deprecated Gruntfile generation script ``plone-generate-gruntfile``.
+  Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too.
   Also clean up of parameters, better help and refactored parts of the code.
   [jensens]
 
 Fixes:
+
+- Fixed versioning for File and Image.
+  [iham]
 
 - Gruntfile failed if only css or only javascripts were registered.
   [jensens]
@@ -75,10 +78,10 @@ New:
 
 Fixes:
 
-- Make Gruntfile.js generation script a bit more verbose to show the effective 
-  locations of the generated bundles. This helps in case of non-working setups 
-  also as if bundle compilation was started in browser at a first run a and  
-  next run was run using the script and files were generated at different 
+- Make Gruntfile.js generation script a bit more verbose to show the effective
+  locations of the generated bundles. This helps in case of non-working setups
+  also as if bundle compilation was started in browser at a first run a and
+  next run was run using the script and files were generated at different
   places than expected.
   [jensens]
 

--- a/Products/CMFPlone/controlpanel/browser/types.py
+++ b/Products/CMFPlone/controlpanel/browser/types.py
@@ -94,7 +94,12 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
         behaviors = list(fti.behaviors)
         if self.behavior_name not in behaviors:
             behaviors.append(self.behavior_name)
-            fti.behaviors = behaviors
+        # locking must be turned on for versioning support on the type
+        locking = 'plone.app.lockingbehavior.behaviors.ILocking'
+        if locking not in behaviors:
+            behaviors.append(locking)
+
+        fti.behaviors = behaviors
 
     def remove_versioning_behavior(self, fti):
         if not IDexterityFTI.providedBy(fti):
@@ -102,7 +107,8 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
         behaviors = list(fti.behaviors)
         if self.behavior_name in behaviors:
             behaviors.remove(self.behavior_name)
-            fti.behaviors = behaviors
+        # TODO: remove locking if it wasn't set in first place
+        fti.behaviors = behaviors
 
     def __call__(self):
         """Perform the update and redirect if necessary, or render the page

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
@@ -117,7 +117,7 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         self.assertTrue(
             'plone.app.versioningbehavior.behaviors.IVersionable' not in doc_type.behaviors)  # noqa
 
-    def test_enable_versioning_behavior(self):
+    def test_enable_versioning_behavior_on_document(self):
         self.browser.open(self.types_url)
         self.browser.getControl(name='type_id').value = ['Document']
         self.browser.getForm(action=self.types_url).submit()
@@ -134,3 +134,27 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
 
         self.assertTrue(
             'plone.app.versioningbehavior.behaviors.IVersionable' in doc_type.behaviors)
+
+    def test_enable_versioning_behavior_on_file(self):
+        self.browser.open(self.types_url)
+        self.browser.getControl(name='type_id').value = ['File']
+        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(name='versionpolicy').value = ['off']
+        self.browser.getForm(action=self.types_url).submit()
+
+        portal_types = self.portal.portal_types
+        file_type = portal_types.File
+
+        # File has no Versioning and no Locking on default, but needs it to work
+        self.assertTrue(
+            'plone.app.versioningbehavior.behaviors.IVersionable' not in file_type.behaviors)  # noqa
+        self.assertTrue(
+            'plone.app.lockingbehavior.behaviors.ILocking' not in file_type.behaviors)  # noqa
+
+        self.browser.getControl(name='versionpolicy').value = ['manual']
+        self.browser.getForm(action=self.types_url).submit()
+
+        self.assertTrue(
+            'plone.app.versioningbehavior.behaviors.IVersionable' in file_type.behaviors)
+        self.assertTrue(
+            'plone.app.lockingbehavior.behaviors.ILocking' in file_type.behaviors)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
             'Products.ATContentTypes',
         ],
         test=[
+            'mock',
             'lxml',
             'plone.app.robotframework',
             'plone.app.testing',


### PR DESCRIPTION
After fixing the problem with plone/Products.CMFEditions#36, adding a File or Image failed by not having Locking-support.

This is fixed, as ilocking (if not already present - not at blobtypes) is also added when iversioning is applied to the dexterity type.

I also added the python package "mock" to the test requirements as it is used in the tests.