### PR TITLE
Simpler generate gruntfile/ compile resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,11 +14,15 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Deprecated Gruntfile generation script ``plone-generate-gruntfile``. 
+  Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too. 
+  Also clean up of parameters, better help and refactored parts of the code.
+  [jensens]
 
 Fixes:
 
-- *add item here*
+- Gruntfile failed if only css or only javascripts were registered.
+  [jensens]
 
 
 5.1a1 (2016-03-31)
@@ -32,11 +36,6 @@ Incompatibilities:
   [maurits]
 
 New:
-
-- Deprecated Gruntfile generation script ``plone-generate-gruntfile``. 
-  Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too. 
-  Also clean up of parameters, better help and refactored parts of the code.
-  [jensens]
 
 - Upgrade to tinymce to 4.3.4
   [vangheem]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ Incompatibilities:
 
 New:
 
+- Deprecated Gruntfile generation script ``plone-generate-gruntfile``. 
+  Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too. 
+  Also clean up of parameters, better help and refactored parts of the code.
+  [jensens]
+
 - Upgrade to tinymce to 4.3.4
   [vangheem]
 
@@ -46,8 +51,7 @@ New:
 - Control panel to mange portal actions
   [ebrehault]
 
-- new less variable to configure the width of the toolbars submenu called
-  ``plone-toolbar-submenu-width``.
+- new less variable to configure the width of the toolbars submenu called ``plone-toolbar-submenu-width``.
   [jensens]
 
 - new zcml feature "plone-51" added. Profile version set to 5101.

--- a/Products/CMFPlone/_scripts/compile_resources.py
+++ b/Products/CMFPlone/_scripts/compile_resources.py
@@ -1,49 +1,134 @@
+# -*- coding: utf-8 -*-
 import argparse
 import os
 import sys
-from Products.CMFPlone._scripts import generate_gruntfile
 import subprocess
-
-parser = argparse.ArgumentParser(
-    description='Compile plone bundle JS/LESS')
-parser.add_argument('--site-id', dest='site_id',
-                    default='Plone', help='ID for the plone site id')
-parser.add_argument('--grunt', dest='grunt',
-                    help='path to grunt executable. If not provided, '
-                         'will look in path')
-parser.add_argument('--instance', dest='instance',
-                    help='path to instance executable. If not provided, '
-                         'will look in bin this was executed from for '
-                         'instance or client1')
-parser.add_argument('--bundle', dest='bundle', default='all',
-                    help='Name of bundle to compile. Defaults to all of them.')
-parser.add_argument('--compile-dir', dest='compile_dir', default='',
-                    help='Output directory for the compiled bundle files.')
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
-
 package_json_contents = """{
   "name": "gruntrunner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-contrib-less": "1.0.1",
-    "less-plugin-inline-urls": "^1.1.0",
-    "grunt-contrib-requirejs": "~0.4.3",
-    "grunt-contrib-uglify": "",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-sed": "",
-    "grunt-debug-task": "~0.1.5"
+    "grunt": "~0.4.5",
+    "grunt-contrib-less": "1.2.0",
+    "grunt-contrib-requirejs": "~1.0.0",
+    "grunt-contrib-uglify": "~1.0.1",
+    "grunt-contrib-watch": "~1.0.0",
+    "grunt-debug-task": "~0.1.8",
+    "grunt-sed": "~0.1.1",
+    "less-plugin-inline-urls": "^1.1.0"
   }
 }"""
 
 
+def generate_package_json(base_path):
+    # generate package.json file here if not exists...
+    package_json = os.path.join(base_path, 'package.json')
+    if not os.path.exists(package_json):
+        with open(package_json, 'w') as fi:
+            fi.write(package_json_contents)
+
+
+def generate_gruntfile(base_path, instance, site_id, compile_dir):
+    if not instance:
+        # look for it, get bin directory, search for plone instance
+        bin_path = os.path.join(base_path, 'bin')
+        files = os.listdir(bin_path)
+        if 'instance' in files:
+            instance = os.path.join(bin_path, 'instance')
+        elif 'client1' in files:
+            instance = os.path.join(bin_path, 'client1')
+    if not instance:
+        print("Could not find plone instance to run command against.")
+        sys.exit()
+    script_path = os.path.join(this_dir, '_generate_gruntfile.py')
+    cmd = [instance, 'run', script_path]
+    os.environ['SITE_ID'] = site_id
+    os.environ['COMPILE_DIR'] = compile_dir
+    print('Running command: %s' % ' '.join(cmd))
+    subprocess.check_call(cmd, env=os.environ)
+    print('Grunfile generated.')
+
+
 def main(argv=sys.argv):
+    parser = argparse.ArgumentParser(
+        description='Generate and setup Grunt infrastructure, '
+                    'then compile JS/LESS bundles for Plone.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        '-i',
+        '--instance',
+        dest='instance',
+        help='path to instance executable. If not provided, '
+             'will look in bin this was executed from for '
+             'instance or client1'
+        )
+    parser.add_argument(
+        '-s',
+        '--site-id',
+        dest='site_id',
+        default='Plone',
+        help='ID of the Plone site to fetch the configuration from. '
+             'Used only while Gruntfile generation.'
+    )
+    parser.add_argument(
+        '-b',
+        '--bundle',
+        dest='bundle',
+        default='all',
+        help='Name of bundle to compile. Used while compile step.'
+    )
+    parser.add_argument(
+        '--compile-dir',
+        dest='compile_dir',
+        default='',
+        help='Output directory for the compiled bundle files. '
+             'Used only while Gruntfile generation. '
+             'If not given the directory is looked up from Plone registry. '
+    )
+    parser.add_argument(
+        '-g',
+        '--grunt',
+        dest='grunt_bin',
+        help='path to grunt executable. If not provided, '
+             'will look in system path.'
+    )
+    parser.add_argument(
+        '-d',
+        '--base-dir',
+        dest='base_dir',
+        default='.',
+        help='Base directory for this script '
+             '(by default current working directory).'
+    )
+    parser.add_argument(
+        '-G',
+        '--skip-generate-gruntfile',
+        dest='skip_gruntfile',
+        action='store_true',
+        help='Skip generation of Gruntfile.js'
+    )
+    parser.add_argument(
+        '-I',
+        '--skip-npm-install',
+        dest='skip_npminstall',
+        action='store_true',
+        help='Skip npm install step',
+    )
+    parser.add_argument(
+        '-C',
+        '--skip-compile',
+        dest='skip_compile',
+        action='store_true',
+        help='Skip compile step (running grunt)',
+    )
+
     args = parser.parse_args()
 
-    grunt = args.grunt
+    grunt = args.grunt_bin
 
     if not grunt:
         if 'PATH' in os.environ:
@@ -62,28 +147,44 @@ def main(argv=sys.argv):
         print('Error: no grunt executable found. Exiting')
         sys.exit(0)
 
-    generate_gruntfile.main(args)
+    base_path = args.base_dir
+    if base_path == '.':
+        base_path = os.getcwd()
 
-    # XXX is this a good way to do it?
-    base_path = os.path.sep.join(
-        os.path.abspath(sys.argv[0]).split(os.path.sep)[:-2])
+    if not args.skip_gruntfile:
+        generate_gruntfile(
+            base_path,
+            args.instance,
+            args.site_id,
+            args.compile_dir
+        )
+
     gruntfile = os.path.join(base_path, 'Gruntfile.js')
 
     if not os.path.exists(gruntfile):
-        print("Error, no Gruntfile.js generated at %s where expected" % gruntfile)
+        print(
+            "Error, no Gruntfile.js generated at {0} where expected".format(
+                gruntfile
+            )
+        )
 
-    # generate package.json file here if not exists...
-    package_json = os.path.join(base_path, 'package.json')
-    if not os.path.exists(package_json):
-        fi = open(package_json, 'w')
-        fi.write(package_json_contents)
-        fi.close()
+    # generates only if not already there
+    generate_package_json(base_path)
 
-    cmd = ['npm', 'install']
-    print('Setup npm env')
-    print('Running command: %s' % ' '.join(cmd))
-    subprocess.check_call(cmd)
+    if not args.skip_npminstall:
+        cmd = ['npm', 'install']
+        print('Setup npm env')
+        print('Running command: %s' % ' '.join(cmd))
+        subprocess.check_call(cmd)
 
-    cmd = [grunt, '--gruntfile=%s' % gruntfile, 'compile-%s' % args.bundle]
-    print('Running command: %s' % ' '.join(cmd))
-    subprocess.check_call(cmd)
+    if not args.skip_compile:
+        print('Compile {0}'.format(args.bundle))
+        cmd = [
+            grunt,
+            '--gruntfile={0}'.format(gruntfile),
+            'compile-{0}'.format(args.bundle)
+        ]
+        print('Running command: %s' % ' '.join(cmd))
+        subprocess.check_call(cmd)
+
+    print('Done.')

--- a/Products/CMFPlone/_scripts/generate_gruntfile.py
+++ b/Products/CMFPlone/_scripts/generate_gruntfile.py
@@ -1,11 +1,12 @@
-#
+# -*- coding: utf-8 -*-
+# DEPRECATED
 # This is more of a script runner for the _generate_gruntfile.py
 # script. Just a wrapper so that script can be simply called
 # from the bin directory
-import os
+from Products.CMFPlone._scripts.compile_resources import generate_gruntfile
 import argparse
+import os
 import sys
-import subprocess
 
 parser = argparse.ArgumentParser(
     description='Generate Gruntfile.js from a Plone site configuration')
@@ -18,29 +19,26 @@ parser.add_argument('--instance', dest='instance',
 parser.add_argument('--compile-dir', dest='compile_dir', default='',
                     help='Output directory for the compiled bundle files.')
 
-this_dir = os.path.dirname(os.path.realpath(__file__))
-
 
 def main(argv=sys.argv):
+    print ('-' * 80)
+    print(
+        'DEPRECATED: {0}\n'
+        'Use "bin/plone-compile-resources -IC [other params]" instead.\n'
+        'For more information use "bin/plone-compile-resources --help"'.format(
+            argv[0]
+        )
+    )
+    print ('-' * 80)
     args, _ = parser.parse_known_args()
-    instance = args.instance
-    if not instance:
-        # look for it, get bin directory, search for plone instance
-        bin_path = os.path.sep.join(
-            os.path.abspath(sys.argv[0]).split(os.path.sep)[:-1])
-        files = os.listdir(bin_path)
-        if 'instance' in files:
-            instance = os.path.join(bin_path, 'instance')
-        elif 'client1' in files:
-            instance = os.path.join(bin_path, 'client1')
-    if not instance:
-        print("Could not find plone instance to run command against.")
-        sys.exit()
-    script_path = os.path.join(this_dir, '_generate_gruntfile.py')
-    cmd = [instance, 'run', script_path]
-    os.environ['SITE_ID'] = args.site_id
-    os.environ['COMPILE_DIR'] = args.compile_dir
+    # XXX is this a good way to do it?
+    base_path = os.path.sep.join(
+        os.path.abspath(sys.argv[0]).split(os.path.sep)[:-2])
 
-    print('Running command: %s' % ' '.join(cmd))
-    subprocess.check_call(cmd, env=os.environ)
-    print('Grunfile generated.')
+    generate_gruntfile(
+        base_path,
+        args.instance,
+        args.site_id,
+        args.compile_dir
+    )
+    print('DONE DEPRECATED {0} (see above)'.format(argv[0]))


### PR DESCRIPTION
One command to rule them all:

```
$ ./bin/plone-compile-resources --help
usage: plone-compile-resources [-h] [-i INSTANCE] [-s SITE_ID] [-b BUNDLE]
                               [--compile-dir COMPILE_DIR] [-g GRUNT_BIN]
                               [-d BASE_DIR] [-G] [-I] [-C]

Generate and setup Grunt infrastructure, then compile JS/LESS bundles for
Plone.

optional arguments:
  -h, --help            show this help message and exit
  -i INSTANCE, --instance INSTANCE
                        path to instance executable. If not provided, will
                        look in bin this was executed from for instance or
                        client1 (default: None)
  -s SITE_ID, --site-id SITE_ID
                        ID of the Plone site to fetch the configuration from.
                        Used only while Gruntfile generation. (default: Plone)
  -b BUNDLE, --bundle BUNDLE
                        Name of bundle to compile. Used while compile step.
                        (default: all)
  --compile-dir COMPILE_DIR
                        Output directory for the compiled bundle files. Used
                        only while Gruntfile generation. If not given the
                        directory is looked up from Plone registry. (default: )
  -g GRUNT_BIN, --grunt GRUNT_BIN
                        path to grunt executable. If not provided, will look
                        in system path. (default: None)
  -d BASE_DIR, --base-dir BASE_DIR
                        Base directory for this script (by default current
                        working directory). (default: .)
  -G, --skip-generate-gruntfile
                        Skip generation of Gruntfile.js (default: False)
  -I, --skip-npm-install
                        Skip npm install step (default: False)
  -C, --skip-compile    Skip compile step (running grunt) (default: False)

```
Deprecated Gruntfile generation script ``plone-generate-gruntfile``. 

Modified the ``plone-compile-resources`` script to support more parameters in order to take over that single task too. 

Also clean up of parameters, better help and refactored parts of the code.
