### PR TITLE
when aggregating bundles, use ++plone++static overrided versions if any

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Fixes:
 
 - *add item here*
 
+- Bundle aggregation must use ++plone++static overrided versions if any.
+  [ebrehault]
+
 
 5.0.4 (2016-04-06)
 ------------------

--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -30,6 +30,14 @@ def get_production_resource_directory():
 
 
 def get_resource(context, path):
+    if path.startswith('++plone++'):
+        # ++plone++ resources can be customized, we return their override
+        # value if any
+        overrides = get_override_directory(context)
+        filepath = path[9:]
+        if overrides.isFile(filepath):
+            return overrides.readFile(filepath)
+
     resource = context.unrestrictedTraverse(path)
     if isinstance(resource, FilesystemFile):
         (directory, sep, filename) = path.rpartition('/')
@@ -87,13 +95,17 @@ def write_css(context, folder, meta_bundle):
     folder.writeFile(meta_bundle + ".css", fi)
 
 
-def combine_bundles(context):
+def get_override_directory(context):
     persistent_directory = queryUtility(IResourceDirectory, name="persistent")
     if persistent_directory is None:
         return
     if OVERRIDE_RESOURCE_DIRECTORY_NAME not in persistent_directory:
         persistent_directory.makeDirectory(OVERRIDE_RESOURCE_DIRECTORY_NAME)
-    container = persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
+    return persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
+
+
+def combine_bundles(context):
+    container = get_override_directory(context)
     if PRODUCTION_RESOURCE_DIRECTORY not in container:
         container.makeDirectory(PRODUCTION_RESOURCE_DIRECTORY)
     production_folder = container[PRODUCTION_RESOURCE_DIRECTORY]

--- a/Products/CMFPlone/tests/test_metabundles.py
+++ b/Products/CMFPlone/tests/test_metabundles.py
@@ -38,3 +38,16 @@ class ProductsCMFPloneSetupTest(PloneTestCase):
             "jQuery",
             self.production_folder.readFile('default.js')
         )
+
+    def test_overrides(self):
+        persistent_directory = getUtility(
+            IResourceDirectory, name="persistent")
+        container = persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
+        container.makeDirectory('static')
+        static = container['static']
+        static.writeFile('plone-legacy-compiled.js', 'alert("Overrided legacy!");')
+        combine_bundles(self.portal)
+        self.assertIn(
+            'alert("Overrided legacy!");',
+            self.production_folder.readFile('default.js')
+        )


### PR DESCRIPTION
this is a port to Plone 5.0 of @ebrehault fix in Plone 5.1 (refs. #1511).