### PR TITLE
Ensured front-page is English when creating an English site. [Plone 5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,12 @@ New:
 
 Fixes:
 
-- *add item here*
+- Ensured front-page is English when creating an English site.
+  Previously, when creating an English site with a browser that
+  prefers a different language, the body text ended up being in the
+  browser language.  For languages without a front-page text
+  translation the same happened: they got the other language instead
+  of English.  [maurits]
 
 - Bundle aggregation must use ++plone++static overrided versions if any.
   [ebrehault]

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -81,6 +81,12 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     context._setObject(site_id, PloneSite(site_id))
     site = context._getOb(site_id)
     site.setLanguage(default_language)
+    # Set the accepted language for the rest of the request.  This makes sure
+    # the front-page text gets the correct translation also when your browser
+    # prefers non-English and you choose English as language for the Plone
+    # Site.
+    request = context.REQUEST
+    request['HTTP_ACCEPT_LANGUAGE'] = default_language
 
     site[_TOOL_ID] = SetupTool(_TOOL_ID)
     setup_tool = site[_TOOL_ID]

--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -34,6 +34,7 @@ from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.constants import CONTEXT_CATEGORY as CONTEXT_PORTLETS
+from plone.protect import createToken
 from plone.registry.interfaces import IRegistry
 
 
@@ -922,3 +923,32 @@ class TestManagementPageCharset(PloneTestCase.PloneTestCase):
         manage_charset = getattr(self.portal, 'management_page_charset', None)
         self.assertTrue(manage_charset)
         self.assertEqual(manage_charset, 'utf-8')
+
+
+class TestAddPloneSite(PloneTestCase.PloneTestCase):
+
+    def afterSetUp(self):
+        self.request = self.app.REQUEST
+
+    def addsite(self):
+        self.loginAsPortalOwner()
+        # Set up a request for the plone-addsite view.
+        form = self.request.form
+        form['form.submitted'] = 1
+        form['site_id'] = 'plonesite1'
+        form['setup_content'] = 1
+        self.request['_authenticator'] = createToken()
+        addsite = self.app.restrictedTraverse('@@plone-addsite')
+        addsite()
+
+    def test_addsite_en_as_nl(self):
+        # Add an English site with a Dutch browser.
+        self.request['HTTP_ACCEPT_LANGUAGE'] = 'nl'
+        self.request.form['default_language'] = 'en'
+        self.addsite()
+        plonesite = self.app.plonesite1
+        fp = plonesite['front-page']
+        # Unfortunately, the next test passes even without the fix (overriding
+        # HTTP_ACCEPT_LANGUAGE on the request in factory.py).  This seems to be
+        # because translations are not available in the tests.
+        self.assertIn('Learn more about Plone', fp.text.raw)


### PR DESCRIPTION
This is the Plone 5.0 version of #1490.

Previously, when creating an English site with a browser that
prefers a different language, the body text ended up being in the
browser language.

For languages without a front-page text translation the same happened:
they got the other language instead of English.