### PR TITLE
Removing inconsistency in the 'Site Setup' links under Users settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,9 +23,9 @@ New:
 
 Fixes:
 
--Removed inconsistency in the display of `Site Setup` links under 'Users and Groups' 
- control panel.
- [kkhan]
+- Removed inconsistency in the display of `Site Setup` links under 'Users and Groups' 
+  control panel.
+  [kkhan]
  
 - Only encode JS body if unicode in gruntfile generation script to avoid
   unicode error.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ New:
 
 Fixes:
 
+-Removed inconsistency in the display of `Site Setup` links under 'Users and Groups' 
+ control panel.
+ [kkhan]
+ 
 - Only encode JS body if unicode in gruntfile generation script to avoid
   unicode error.
   [jensens]

--- a/Products/CMFPlone/controlpanel/browser/controlpanel_usergroups_layout.pt
+++ b/Products/CMFPlone/controlpanel/browser/controlpanel_usergroups_layout.pt
@@ -10,12 +10,11 @@
 
 <div metal:fill-slot="prefs_configlet_main">
 
-  <a href=""
-     id="setup-link"
-     tal:attributes="href string:$portal_url/@@overview-controlpanel"
-     i18n:translate="">
-      Site Setup
-  </a>
+  <a id="setup-link" class="link-parent"
+       tal:attributes="href string:$portal_url/@@overview-controlpanel"
+       i18n:translate="">
+        Site Setup
+    </a>
 
   <h1 class="documentFirstHeading"
       i18n:translate="">Users and Groups</h1>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
@@ -23,11 +23,10 @@
 
   <article id="content">
 
-    <a href=""
-       id="setup-link"
+    <a id="setup-link" class="link-parent"
        tal:attributes="href string:$portal_url/@@overview-controlpanel"
        i18n:translate="">
-      Site Setup
+        Site Setup
     </a>
 
     <h1 class="documentFirstHeading"

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -22,7 +22,7 @@
     <a id="setup-link" class="link-parent"
        tal:attributes="href string:$portal_url/@@overview-controlpanel"
        i18n:translate="">
-        Sites Setup
+        Site Setup
     </a>
 
     <h1 class="documentFirstHeading"

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -19,11 +19,10 @@
 
   <article id="content">
 
-    <a href=""
-       id="setup-link"
+    <a id="setup-link" class="link-parent"
        tal:attributes="href string:$portal_url/@@overview-controlpanel"
        i18n:translate="">
-        Site Setup
+        Sites Setup
     </a>
 
     <h1 class="documentFirstHeading"


### PR DESCRIPTION
In Site Setup control panel, under Users and Groups there is inconsistency in the way parent link is displayed under different tabs like `Users`, `Groups`, `Settings`, and `Member Fields`...
Other categories in Site Setup have similar look-and-feel of this link.
![ss1](https://cloud.githubusercontent.com/assets/17498833/14404833/5e35219a-fe9d-11e5-9390-b6250a7d64a6.png)
<br><hr>
![ss3](https://cloud.githubusercontent.com/assets/17498833/14404871/a9f8def4-fe9e-11e5-9c93-19ae80fc304c.png)

