### PR TITLE
Fix bundle aggregation when bundle has no CSS (or no JS) on 5.0.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Fixes:
 - Bundle aggregation must use ++plone++static overrided versions if any.
   [ebrehault]
 
+- Fix bundle aggregation when bundle has no CSS (or no JS)
+  [ebrehault]
+
 
 5.0.4 (2016-04-06)
 ------------------

--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -70,7 +70,7 @@ def write_js(context, folder, meta_bundle):
     bundles = registry.collectionOfInterface(
         IBundleRegistry, prefix="plone.bundles", check=False)
     for bundle in bundles.values():
-        if bundle.merge_with == meta_bundle:
+        if bundle.merge_with == meta_bundle and bundle.jscompilation:
             resources.append(get_resource(context, bundle.jscompilation))
 
     fi = StringIO()
@@ -86,7 +86,7 @@ def write_css(context, folder, meta_bundle):
     bundles = registry.collectionOfInterface(
         IBundleRegistry, prefix="plone.bundles", check=False)
     for bundle in bundles.values():
-        if bundle.merge_with == meta_bundle:
+        if bundle.merge_with == meta_bundle and bundle.csscompilation:
             resources.append(get_resource(context, bundle.csscompilation))
 
     fi = StringIO()


### PR DESCRIPTION
I have already a PR for the same fix on master https://github.com/plone/Products.CMFPlone/pull/1523.

Here is a PR for 5.0.x.
(@plone/release-team, are we supposed to do that for all our important fixes?)