### PR TITLE
Do not hide document byline viewlet by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,10 @@ Fixes:
 - Fixed versioning for File and Image.
    [iham]
 
+- Do not hide document byline viewlet by default;
+  it is controled by the `Allow anyone to view 'about' information` option in the `Security Settings` of `Site Setup` (closes `#1556`_).
+  [hvelarde]
+
 - Removed docstrings from some methods to avoid publishing them.  From
   Products.PloneHotfix20160419.  [maurits]
 
@@ -1296,3 +1300,4 @@ Fixes:
 .. _`#1053`: https://github.com/plone/Products.CMFPlone/issues/1053
 .. _`#1232`: https://github.com/plone/Products.CMFPlone/issues/1232
 .. _`#1255`: https://github.com/plone/Products.CMFPlone/issues/1255
+.. _`#1556`: https://github.com/plone/Products.CMFPlone/issues/1556

--- a/Products/CMFPlone/profiles/default/viewlets.xml
+++ b/Products/CMFPlone/profiles/default/viewlets.xml
@@ -38,7 +38,4 @@
   <hidden manager="plone.belowcontent" skinname="Plone Default">
     <viewlet name="plone.manage_portlets_fallback"/>
   </hidden>
-  <hidden manager="plone.belowcontenttitle" skinname="Plone Default">
-    <viewlet name="plone.belowcontenttitle.documentbyline" />
-  </hidden>
 </object>


### PR DESCRIPTION
It is now controlled by the Allow anyone to view 'about' information option in the Security Settings of Site Setup.

This solves the following issues:
* document byline would be visible for anonymous users if enabled
* document byline is not visible for authenticated users as the information it provides should be accessible using the toolbar (there are some pending issues on this, but that must be the final goal)

closes #1556
refs. https://github.com/plone/plone.app.layout/pull/90