### PR TITLE
Fixed versioning for File and Image.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ New:
 
 Fixes:
 
+- Fixed versioning for File and Image.
+  [iham]
+
 - Removed docstrings from some methods to avoid publishing them.  From
   Products.PloneHotfix20160419.  [maurits]
 
@@ -63,7 +66,7 @@ Fixes:
 
 - Do not hard-code baseUrl in bundle to avoid bad URL when switching domains.
   [ebrehault]
-  
+
 - fix typo and comma splice error in HTML filtering control panel [tkimnguyen]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ New:
 Fixes:
 
 - Fixed versioning for File and Image.
-  [iham]
+   [iham]
 
 - Removed docstrings from some methods to avoid publishing them.  From
   Products.PloneHotfix20160419.  [maurits]

--- a/Products/CMFPlone/controlpanel/browser/types.py
+++ b/Products/CMFPlone/controlpanel/browser/types.py
@@ -94,7 +94,12 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
         behaviors = list(fti.behaviors)
         if self.behavior_name not in behaviors:
             behaviors.append(self.behavior_name)
-            fti.behaviors = behaviors
+        # locking must be turned on for versioning support on the type
+        locking = 'plone.app.lockingbehavior.behaviors.ILocking'
+        if locking not in behaviors:
+            behaviors.append(locking)
+
+        fti.behaviors = behaviors
 
     def remove_versioning_behavior(self, fti):
         if not IDexterityFTI.providedBy(fti):
@@ -102,7 +107,8 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
         behaviors = list(fti.behaviors)
         if self.behavior_name in behaviors:
             behaviors.remove(self.behavior_name)
-            fti.behaviors = behaviors
+        # TODO: remove locking if it wasn't set in first place
+        fti.behaviors = behaviors
 
     def __call__(self):
         """Perform the update and redirect if necessary, or render the page

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
@@ -115,9 +115,10 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         portal_types = self.portal.portal_types
         doc_type = portal_types.Document
         self.assertTrue(
-            'plone.app.versioningbehavior.behaviors.IVersionable' not in doc_type.behaviors)  # noqa
+            'plone.app.versioningbehavior.behaviors.IVersionable'
+            not in doc_type.behaviors)  # noqa
 
-    def test_enable_versioning_behavior(self):
+    def test_enable_versioning_behavior_on_document(self):
         self.browser.open(self.types_url)
         self.browser.getControl(name='type_id').value = ['Document']
         self.browser.getForm(action=self.types_url).submit()
@@ -127,10 +128,40 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         portal_types = self.portal.portal_types
         doc_type = portal_types.Document
         self.assertTrue(
-            'plone.app.versioningbehavior.behaviors.IVersionable' not in doc_type.behaviors)  # noqa
+            'plone.app.versioningbehavior.behaviors.IVersionable'
+            not in doc_type.behaviors)  # noqa
 
         self.browser.getControl(name='versionpolicy').value = ['manual']
         self.browser.getForm(action=self.types_url).submit()
 
         self.assertTrue(
-            'plone.app.versioningbehavior.behaviors.IVersionable' in doc_type.behaviors)
+            'plone.app.versioningbehavior.behaviors.IVersionable'
+            in doc_type.behaviors)
+
+    def test_enable_versioning_behavior_on_file(self):
+        self.browser.open(self.types_url)
+        self.browser.getControl(name='type_id').value = ['File']
+        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(name='versionpolicy').value = ['off']
+        self.browser.getForm(action=self.types_url).submit()
+
+        portal_types = self.portal.portal_types
+        file_type = portal_types.File
+
+        # File has no Versioning and no Locking on default, but needs it
+        self.assertTrue(
+            'plone.app.versioningbehavior.behaviors.IVersionable'
+            not in file_type.behaviors)  # noqa
+        self.assertTrue(
+            'plone.app.lockingbehavior.behaviors.ILocking'
+            not in file_type.behaviors)  # noqa
+
+        self.browser.getControl(name='versionpolicy').value = ['manual']
+        self.browser.getForm(action=self.types_url).submit()
+
+        self.assertTrue(
+            'plone.app.versioningbehavior.behaviors.IVersionable'
+            in file_type.behaviors)
+        self.assertTrue(
+            'plone.app.lockingbehavior.behaviors.ILocking'
+            in file_type.behaviors)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         ],
         test=[
             'lxml',
+            'mock',
             'plone.app.robotframework',
             'plone.app.testing',
             'zope.globalrequest',


### PR DESCRIPTION
After fixing the problem with plone/Products.CMFEditions#36, adding a File or Image failed by not having Locking-support.

This is fixed, as ilocking (if not already present - not at blobtypes) is also added when iversioning is applied to the dexterity type.

I also added the python package "mock" to the test requirements as it is used in the tests.