### PR TITLE
multiple TinyMCE styles from theme bundle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ New:
 
 - Add link to training.plone.org
   [svx]
+- Allow to define multiple ``tinymce-content-css`` in theme ``manifest.cfg`` files, seperated by a comma.
+  [thet]
 
 - Update npm package depencies.
   [thet]

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -42,7 +42,10 @@ class TinyMCESettingsGenerator(object):
         theme = self.get_theme()
         tinymce_content_css = getattr(theme, 'tinymce_content_css', None)
         if tinymce_content_css is not None:
-            files.append(self.nav_root_url + theme.tinymce_content_css)
+            files.extend([
+                self.nav_root_url + _
+                for _ in theme.tinymce_content_css.split(',')
+            ])
 
         return ','.join(files)
 


### PR DESCRIPTION
Allow to define multiple ``tinymce-content-css`` in theme ``manifest.cfg`` files, seperated by a comma.