### PR TITLE
Added publishing patch from Products.PloneHotfix20160419. [4.3]

### DIFF
--- a/Products/CMFPlone/patches/__init__.py
+++ b/Products/CMFPlone/patches/__init__.py
@@ -32,3 +32,4 @@ except ImportError:
     pass
 
 import addMember
+import publishing

--- a/Products/CMFPlone/patches/publishing.py
+++ b/Products/CMFPlone/patches/publishing.py
@@ -1,0 +1,64 @@
+# From Products.PloneHotfix20160419
+from OFS.ZDOM import Document
+from OFS.ZDOM import Node
+from Products.CMFPlone.Portal import PloneSite
+
+
+try:
+    from plone.dexterity.content import Item
+    from plone.dexterity.content import Container
+except ImportError:
+    class Item(object):
+        pass
+
+    class Container(object):
+        pass
+
+try:
+    from Products.ATContentTypes.content.base import ATCTContent
+    from Products.ATContentTypes.content.base import ATCTBTreeFolder
+except ImportError:
+
+    class ATCTContent(object):
+        pass
+
+    class ATCTBTreeFolder(object):
+        pass
+
+
+klasses = (
+    Node,
+    Document,
+    PloneSite,
+    Item,
+    Container,
+    ATCTContent,
+    ATCTBTreeFolder
+)
+methods = (
+    'EffectiveDate',
+    'ExpirationDate',
+    'getAttributes',
+    'getChildNodes',
+    'getFirstChild',
+    'getLastChild',
+    'getLayout',
+    'getNextSibling',
+    'getNodeName',
+    'getNodeType',
+    'getNodeValue',
+    'getOwnerDocument',
+    'getParentNode',
+    'getPhysicalPath',
+    'getPreviousSibling',
+    'getTagName',
+    'hasChildNodes',
+    'Type'
+)
+
+for klass in klasses:
+    for method_name in methods:
+        method = getattr(klass, method_name, None)
+        if (method is not None and hasattr(method, 'im_func') and
+                hasattr(method.im_func, '__doc__')):
+            del method.im_func.__doc__

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -14,6 +14,9 @@ Changelog
 
 Fixes:
 
+- Added publishing patch from Products.PloneHotfix20160419.
+  This avoids publishing some methods inherited from Zope or CMF.  [maurits]
+
 - Removed docstrings from some methods to avoid publishing them.  [maurits]
 
 - Ensured front-page is English when creating an English site.


### PR DESCRIPTION
This avoids publishing some methods inherited from Zope or CMF.