### PR TITLE
Added publishing patch from Products.PloneHotfix20160419. [5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,8 +41,12 @@ New features:
 
 Bug fixes:
 
+- Added publishing patch from Products.PloneHotfix20160419.
+  This avoids publishing some methods inherited from Zope or CMF.  [maurits]
+
 - Fix issue where incorrectly configured formats would cause TinyMCE to error
   [vangheem]
+
 
 
 5.0.4 (2016-04-06)

--- a/Products/CMFPlone/patches/__init__.py
+++ b/Products/CMFPlone/patches/__init__.py
@@ -27,3 +27,5 @@ sendmail.applyPatches()
 
 import templatecookcheck        # Make sure templates aren't re-read in
 # production sites
+
+import publishing

--- a/Products/CMFPlone/patches/publishing.py
+++ b/Products/CMFPlone/patches/publishing.py
@@ -1,0 +1,64 @@
+# From Products.PloneHotfix20160419
+from OFS.ZDOM import Document
+from OFS.ZDOM import Node
+from Products.CMFPlone.Portal import PloneSite
+
+
+try:
+    from plone.dexterity.content import Item
+    from plone.dexterity.content import Container
+except ImportError:
+    class Item(object):
+        pass
+
+    class Container(object):
+        pass
+
+try:
+    from Products.ATContentTypes.content.base import ATCTContent
+    from Products.ATContentTypes.content.base import ATCTBTreeFolder
+except ImportError:
+
+    class ATCTContent(object):
+        pass
+
+    class ATCTBTreeFolder(object):
+        pass
+
+
+klasses = (
+    Node,
+    Document,
+    PloneSite,
+    Item,
+    Container,
+    ATCTContent,
+    ATCTBTreeFolder
+)
+methods = (
+    'EffectiveDate',
+    'ExpirationDate',
+    'getAttributes',
+    'getChildNodes',
+    'getFirstChild',
+    'getLastChild',
+    'getLayout',
+    'getNextSibling',
+    'getNodeName',
+    'getNodeType',
+    'getNodeValue',
+    'getOwnerDocument',
+    'getParentNode',
+    'getPhysicalPath',
+    'getPreviousSibling',
+    'getTagName',
+    'hasChildNodes',
+    'Type'
+)
+
+for klass in klasses:
+    for method_name in methods:
+        method = getattr(klass, method_name, None)
+        if (method is not None and hasattr(method, 'im_func') and
+                hasattr(method.im_func, '__doc__')):
+            del method.im_func.__doc__


### PR DESCRIPTION
This avoids publishing some methods inherited from Zope or CMF.