### PR TITLE
Remove dependency on grunt executable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,17 @@ Changelog
 
 Breaking changes:
 
+- ``plone-compile-resources``: Install ``grunt-cli`` instead of depending on an installed ``grunt`` executable.
+  If you already have a auto-generated ``package.json`` file in buildout directory, remove it.
+  [thet]
+
+
 - Moved code around and deprecated old locations in ``Products/CMFPlone/patterns/__init__``.
   This goes together with same pattern settings changes in ``plone.app.layout.globals.pattern_settings``.
   Also moved general usable ``./patterns/utils/get_portal`` to ``./utils/.get_portal``.
   Deprecated ``./patterns/utils/get_portal`` and ``./patterns/utils/get_portal``.
   [jensens]
+
 
 New features:
 

--- a/Products/CMFPlone/_scripts/_generate_gruntfile.py
+++ b/Products/CMFPlone/_scripts/_generate_gruntfile.py
@@ -323,7 +323,7 @@ for name, value in resources.items():
 
 globalVars_string = ""
 for key, value in sorted(globalVars.items()):
-    globalVars_string += '{0}"{1}": "{2}",\n'.format(22*' ', key, value)
+    globalVars_string += '{0}"{1}": "{2}",\n'.format(22 * ' ', key, value)
 
 
 # BUNDLE LOOP

--- a/Products/CMFPlone/resources/browser/mixins.py
+++ b/Products/CMFPlone/resources/browser/mixins.py
@@ -70,6 +70,7 @@ class LessConfiguration(BrowserView):
             t = value.format(**less_vars_params)
             result += "'%s': \"%s\",\n" % (name, t)
 
+        # Adding all plone.resource entries css values as less vars
         for name, value in self.resource_registry().items():
             for css in value.css:
 


### PR DESCRIPTION
``plone-compile-resources``: Install ``grunt-cli`` instead of depending on an installed ``grunt`` executable.
If you already have a auto-generated ``package.json`` file in buildout directory, remove it.