### PR TITLE
Fixed failing location query robot test. [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ New features:
 
 Bug fixes:
 
+- Fixed failing location query robot test.  [maurits]
+
 - Don't fail, when combining bundles and the target resource files (``BUNLDE-compiled.[min.js|css]``) do not yet exist on the filesystem.
   Fixes GenericSetup failing silently on import with when a to-be-compiled bundle which exists only as registry entry is processed in the ``combine-bundle`` step.
   [thet]

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -83,9 +83,11 @@ should show warning when deleting page
 
 should show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
+  Sleep  1
   Wait until keyword succeeds  30  1  Page should contain element  css=tr[data-id="foo"] input
   Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
+  Sleep  1
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled
   Click Link  Delete
   Wait until page contains element  css=.popover-content .btn-danger
@@ -99,12 +101,14 @@ should not show warning when deleting page from folder_contents
   Wait until page contains element  css=tr[data-id="foo"] input
   Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
+  Sleep  1
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled
   Click Link  Delete
   Wait until page contains element  css=.popover-content .btn-danger
   Page should not contain element  css=.breach-container .breach-item
   Click Button  Yes
   Wait until page contains  Successfully delete items
+  Sleep  1
   Wait until keyword succeeds  30  1  Page should not contain Element  css=tr[data-id="foo"] input
 
 

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -77,6 +77,7 @@ I expect to be in Simple mode
     Click Element  css=body
 
 open the select box titled ${NAME}
+    Click Element  css=body
     Click Element  css=.querystring-criteria-${NAME} .select2-container a
 
 select index type ${INDEX}


### PR DESCRIPTION
Well, I hope this fixes it anyway, similar to what Johannes has already done. Locally, with Firefox 46 (or chrome) this change is not needed, at least not when running the location query test individually. But Jenkins has been failing for a while, for example http://jenkins.plone.org/job/plone-5.1-python-2.7-robot/558/robot/