### PR TITLE
Let npm install work on windows for plone-compile-resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 
 Breaking changes:
 
+- Remove discontinued module ``grunt-debug-task`` from ``plone-compile-resources``.
+  [jensens]
+
 - Remove deprecated resource registrations for ``mockup-parser`` and ``mockup-registry`` from mockup-core.
   Use those from patternslib instead.
   [thet]
@@ -66,6 +69,7 @@ New features:
 Bug fixes:
 
 - Use ``Plone Test Setup`` and ``Plone Test Teardown`` from ``plone.app.robotframework`` master.  [maurits]
+
 - Let npm install work on windows for plone-compile-resources.
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ New features:
 Bug fixes:
 
 - Use ``Plone Test Setup`` and ``Plone Test Teardown`` from ``plone.app.robotframework`` master.  [maurits]
+- Let npm install work on windows for plone-compile-resources.
+  [jensens]
 
 - Don't fail, when combining bundles and the target resource files (``BUNLDE-compiled.[min.js|css]``) do not yet exist on the filesystem.
   Fixes GenericSetup failing silently on import with when a to-be-compiled bundle which exists only as registry entry is processed in the ``combine-bundle`` step.

--- a/Products/CMFPlone/_scripts/compile_resources.py
+++ b/Products/CMFPlone/_scripts/compile_resources.py
@@ -17,7 +17,6 @@ package_json_contents = """{
     "grunt-contrib-requirejs": "~1.0.0",
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",
-    "grunt-debug-task": "~0.1.8",
     "grunt-sed": "~0.1.1",
     "less-plugin-inline-urls": "^1.1.0"
   }

--- a/Products/CMFPlone/_scripts/compile_resources.py
+++ b/Products/CMFPlone/_scripts/compile_resources.py
@@ -23,6 +23,11 @@ package_json_contents = """{
   }
 }"""
 
+if os.name == 'nt':
+    NPM_CMD = 'npm.cmd'
+else:
+    NPM_CMD = 'npm'
+
 
 def generate_package_json(base_path):
     # generate package.json file here if not exists...
@@ -129,13 +134,19 @@ def main(argv=sys.argv):
     # generates only if not already there
     generate_package_json(base_path)
     if not args.skip_npminstall:
-        cmd = ['npm', 'install']
+        cmd = [NPM_CMD, 'install']
         print('Setup npm env')
         print('Running command: %s' % ' '.join(cmd))
         subprocess.check_call(cmd)
 
     # Generate Gruntfile
-    grunt = os.path.join(base_path, 'node_modules', 'grunt-cli', 'bin', 'grunt')
+    grunt = os.path.join(
+        base_path,
+        'node_modules',
+        'grunt-cli',
+        'bin',
+        'grunt'
+    )
     if not args.skip_gruntfile:
         generate_gruntfile(
             base_path,


### PR DESCRIPTION
On windows command ist ``npm.cmd`` instead of shell script ``npm``.