### PR TITLE
Filter members based on group membership

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,10 @@ New features:
 Bug fixes:
 
 - Use ``Plone Test Setup`` and ``Plone Test Teardown`` from ``plone.app.robotframework`` master.  [maurits]
+- The group membership page should filter search results based on
+  group membership test. This fixes an issue where all members would
+  be shown regardless of membership to the selected group.
+  [malthe]
 
 - Don't fail, when combining bundles and the target resource files (``BUNLDE-compiled.[min.js|css]``) do not yet exist on the filesystem.
   Fixes GenericSetup failing silently on import with when a to-be-compiled bundle which exists only as registry entry is processed in the ``combine-bundle`` step.

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
@@ -64,8 +64,19 @@ class GroupMembershipControlPanel(UsersGroupsControlPanelView):
                 form['searchstring'] = ''
             self.searchString = form.get('searchstring', '')
             if findAll or bool(self.searchString):
-                self.searchResults = self.getPotentialMembers(
-                    self.searchString)
+                members = self.getPotentialMembers(self.searchString)
+                acl = getToolByName(self, 'acl_users')
+                plugins = acl.plugins.listPlugins(IGroupsPlugin)
+                results = self.searchResults = []
+                for member in members:
+                    for gid, plugin in plugins:
+                        groups = plugin.getGroupsForPrincipal(
+                            member,
+                            self.request
+                        )
+                        if self.groupname in groups:
+                            results.append(member)
+                            break
 
             if search or findAll:
                 self.newSearch = True


### PR DESCRIPTION
This fixes an issue where all members would be shown, regardless of group membership.
