### PR TITLE
Fixed syntaxerror for duplicate tag in robot tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ New features:
 
 Bug fixes:
 
+- Fixed syntaxerror for duplicate tag in robot tests.  [maurits]
+
 - Marked two robot tests as unstable, non-critical.
   Refs https://github.com/plone/Products.CMFPlone/issues/1656  [maurits]
 

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -48,7 +48,7 @@ Scenario: After you fix linked page no longer show warning
 Scenario: Show warning when deleting linked item from folder_contents
   [Tags]  unstable
   [Documentation]  This sometimes fails with: StaleElementReferenceException: Message: Element not found in the cache.
-  [Documentation]  This one seems to fail more often than the others.
+                   This one seems to fail more often than the others.
   Given a logged-in site administrator
   a page to link to
     and a page to edit

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -15,7 +15,7 @@ Test Teardown  Run keywords  Plone Test Teardown
 Scenario: Location query
     [Tags]  unstable
     [Documentation]  This sometimes fails with: Element locator 'jquery=:focus' did not match any elements.
-    [Documentation]  This sometimes fails with: Element locator 'jquery=.pattern-relateditems-tree-select' did not match any elements.
+                     This sometimes fails with: Element locator 'jquery=.pattern-relateditems-tree-select' did not match any elements.
     Given a logged-in site administrator
     and a bunch of folders
     and the querystring pattern


### PR DESCRIPTION
Otherwise robotframework 3.0 and higher complain:

```
Invalid syntax in test case 'Scenario: Location query':
Setting '[Documentation]' used multiple times.
```