### PR TITLE
Marked some robot tests as unstable, non-critical. [5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ New features:
 
 Bug fixes:
 
+- Marked two robot tests as unstable, non-critical.
+  Refs https://github.com/plone/Products.CMFPlone/issues/1656  [maurits]
+
 - Use ``Plone Test Setup`` and ``Plone Test Teardown`` from ``plone.app.robotframework`` master.  [maurits]
 
 - Fix select2 related robot test failures and give the test_tinymce.robot scenario a more unique name.

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -24,6 +24,8 @@ Test Teardown  Run keywords  Plone Test Teardown
 *** Test Cases ***************************************************************
 
 Scenario: When page is linked show warning
+  [Tags]  unstable
+  [Documentation]  This sometimes fails with: StaleElementReferenceException: Message: Element not found in the cache.
   Given a logged-in site administrator
     a page to link to
     and a page to edit
@@ -32,6 +34,8 @@ Scenario: When page is linked show warning
 
 
 Scenario: After you fix linked page no longer show warning
+  [Tags]  unstable
+  [Documentation]  This sometimes fails with: StaleElementReferenceException: Message: Element not found in the cache.
   Given a logged-in site administrator
   a page to link to
     and a page to edit
@@ -42,6 +46,9 @@ Scenario: After you fix linked page no longer show warning
 
 
 Scenario: Show warning when deleting linked item from folder_contents
+  [Tags]  unstable
+  [Documentation]  This sometimes fails with: StaleElementReferenceException: Message: Element not found in the cache.
+                   This one seems to fail more often than the others.
   Given a logged-in site administrator
   a page to link to
     and a page to edit

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -13,6 +13,9 @@ Test Teardown  Run keywords  Plone Test Teardown
 *** Test Cases **************************************************************
 
 Scenario: Location query
+    [Tags]  unstable
+    [Documentation]  This sometimes fails with: Element locator 'jquery=:focus' did not match any elements.
+                     This sometimes fails with: Element locator 'jquery=.pattern-relateditems-tree-select' did not match any elements.
     Given a logged-in site administrator
     and a bunch of folders
     and the querystring pattern

--- a/Products/CMFPlone/tests/test_robot.py
+++ b/Products/CMFPlone/tests/test_robot.py
@@ -16,7 +16,10 @@ def test_suite():
         doc.startswith('test_')
     ]
     for robot_test in robot_tests:
-        robottestsuite = robotsuite.RobotTestSuite(robot_test)
+        robottestsuite = robotsuite.RobotTestSuite(
+            robot_test,
+            noncritical=['unstable'],
+        )
         robottestsuite.level = ROBOT_TEST_LEVEL
         suite.addTests([
             layered(


### PR DESCRIPTION
These are the single querystring test and the three linkintegrity tests.

Refs https://github.com/plone/Products.CMFPlone/issues/1656

Taken over from master branch.