### PR TITLE
the advanced_search input is present twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,6 +156,9 @@ Bug fixes:
 - Use zope.interface decorator.
   [gforcada]
 
+- Remove advanced_search input which is in double.
+  [Gagaro]
+
 5.1a1 (2016-03-31)
 ------------------
 

--- a/Products/CMFPlone/browser/templates/search.pt
+++ b/Products/CMFPlone/browser/templates/search.pt
@@ -37,7 +37,6 @@
                       DateTime python:modules['DateTime'].DateTime;
                       navigation_root_url view/navroot_url;">
 
-        <input type="hidden" name="advanced_search" value="False" />
         <input type="hidden" name="sort_on" value="" />
         <input type="hidden" name="sort_order" value="" />
 


### PR DESCRIPTION
The second occurence is [there](https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/browser/templates/search.pt#L64-L65).

I think the first one shouldn't be there. We have the advanced_query parameter in double with both False and True as a value if we keep them both.