### PR TITLE
TinyMCE default table styles were broken after install due to a wrong…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ New features:
 Bug fixes:
 
 - Fixed missing keyword in robot tests due to wrong documentation lines.  [maurits]
+- TinyMCE default table styles were broken after install due to a wrong default value.
+  [jensens]
 
 - Rewording of some Site control panel text [tkimnguyen]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,7 +75,9 @@ New features:
 
 Bug fixes:
 
-- Fixed missing keyword in robot tests due to wrong documentation lines.  [maurits]
+- Fixed missing keyword in robot tests due to wrong documentation lines.
+  [maurits]
+
 - TinyMCE default table styles were broken after install due to a wrong default value.
   [jensens]
 

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -534,7 +534,7 @@ class ITinyMCELayoutSchema(Interface):
         value_type=schema.TextLine(),
         missing_value=[],
         default=[
-            u'Listing|listing'
+            u'Listing|listing',
             u'Invisible Grid|invisible-grid'
         ])
 


### PR DESCRIPTION
… default value.

a missing ``,``