### PR TITLE
Add review state to portal tabs results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 
 Breaking changes:
 
+- Add ``review_state`` to ``CatalogNavigationTabs.topLevelTabs`` results.
+  This allows for exposing the items workflow state in portal navigation tabs.
+  [thet]
+
 - Remove discontinued module ``grunt-debug-task`` from ``plone-compile-resources``.
   [jensens]
 

--- a/Products/CMFPlone/browser/navigation.py
+++ b/Products/CMFPlone/browser/navigation.py
@@ -155,7 +155,8 @@ class CatalogNavigationTabs(BrowserView):
                 'name': utils.pretty_title_or_id(context, item),
                 'id': item.getId,
                 'url': item_url,
-                'description': item.Description
+                'description': item.Description,
+                'review_state': item.review_state
             }
             result.append(data)
 

--- a/Products/CMFPlone/tests/testNavigationView.py
+++ b/Products/CMFPlone/tests/testNavigationView.py
@@ -565,6 +565,23 @@ class TestBasePortalTabs(PloneTestCase.PloneTestCase):
         # Should only contain the published folder
         self.assertEqual(len(tabs), 1)
 
+    def testTabInfo(self):
+        self.portal._delObject('Members')
+        self.portal._delObject('news')
+        self.portal._delObject('events')
+
+        view = self.view_class(self.portal, self.request)
+        tabs = view.topLevelTabs(actions=[])
+
+        self.assertEqual(len(tabs), 5)
+
+        tab = tabs[0]
+        self.assertTrue('url' in tab and tab['url'])  # url must not be empty
+        self.assertTrue('description' in tab)  # our description is empty
+        self.assertTrue('name' in tab and tab['name'])
+        self.assertTrue('id' in tab and tab['id'])
+        self.assertTrue('review_state' in tab and tab['review_state'])
+
     def testDisableFolderTabs(self):
         # Setting the site_property disable_folder_sections should remove
         # all folder based tabs


### PR DESCRIPTION
Add ``review_state`` to ``CatalogNavigationTabs.topLevelTabs`` results.
This allows for exposing the items workflow state in portal navigation tabs.