### PR TITLE
Don't fail, if timestamp.txt was deleted from the resource registries…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 
 Breaking changes:
 
+- Don't fail, if ``timestamp.txt`` was deleted from the resource registries production folder.
+  [thet]
+
 - Add ``review_state`` to ``CatalogNavigationTabs.topLevelTabs`` results.
   This allows for exposing the items workflow state in portal navigation tabs.
   [thet]

--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -26,6 +26,8 @@ def get_production_resource_directory():
         production_folder = container[PRODUCTION_RESOURCE_DIRECTORY]
     except NotFound:
         return "%s/++unique++1" % PRODUCTION_RESOURCE_DIRECTORY
+    if 'timestamp.txt' not in production_folder:
+        return "%s/++unique++1" % PRODUCTION_RESOURCE_DIRECTORY
     timestamp = production_folder.readFile('timestamp.txt')
     return "%s/++unique++%s" % (
         PRODUCTION_RESOURCE_DIRECTORY, timestamp)


### PR DESCRIPTION
… production folder.