### PR TITLE
grunt / less-plugin-inline-urls: handle VML urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ New features:
 
 Bug fixes:
 
+- Upgrade ``less-plugin-inline-urls`` to ``1.2.0`` to properly handle VML url node values in CSS.
+  [thet]
+
 - Fixed missing keyword in robot tests due to wrong documentation lines.
   [maurits]
 

--- a/Products/CMFPlone/_scripts/compile_resources.py
+++ b/Products/CMFPlone/_scripts/compile_resources.py
@@ -8,7 +8,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 
 package_json_contents = """{
   "name": "gruntrunner",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "devDependencies": {
     "grunt": "~0.4.5",
@@ -18,7 +18,7 @@ package_json_contents = """{
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-sed": "~0.1.1",
-    "less-plugin-inline-urls": "^1.1.0"
+    "less-plugin-inline-urls": "^1.2.0"
   }
 }"""
 


### PR DESCRIPTION
Upgrade ``less-plugin-inline-urls`` to ``1.2.0`` to properly handle VML url node values in CSS.

VML url node values are used for example in Leaflet.

See: https://github.com/less/less-plugin-inline-urls/pull/7