### PR TITLE
Prettify toolbar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,8 @@ New features:
 
   - Make menu hover background fit whole menu width.
 
+  - Don't show toolbar scroll bars for bigger screens and make scroll buttons full-width.
+
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,10 @@ New features:
 
   - Let the toolbar submenus be as wide as they need by setting a ``min-width`` and ``width: auto;``.
 
+  - Raise the width of the expanded toolbar from ``120px`` to ``180px``.
+
+  - Make menu hover background fit whole menu width.
+
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ New features:
 
   - Don't break workflow contentmenu header and better place the current status icon.
 
+  - Let the toolbar submenus be as wide as they need by setting a ``min-width`` and ``width: auto;``.
+
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,11 @@ New features:
 - Prevent workflow menu overflowing in toolbar [MatthewWilkes]
 
 - Add default icon for top-level contentview and contentmenu toolbar entries [alecm]
+- Toolbar styles:
+
+  - Don't break workflow contentmenu header and better place the current status icon.
+
+  [thet]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ New features:
 
   - dont force scoll buttons to be left, when toolbar is right.
 
+  - nicer toolbar submenus
+
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ New features:
 - Prevent workflow menu overflowing in toolbar [MatthewWilkes]
 
 - Add default icon for top-level contentview and contentmenu toolbar entries [alecm]
+
 - Toolbar styles:
 
   - Don't break workflow contentmenu header and better place the current status icon.
@@ -60,6 +61,8 @@ New features:
   - Make menu hover background fit whole menu width.
 
   - Don't show toolbar scroll bars for bigger screens and make scroll buttons full-width.
+
+  - dont force scoll buttons to be left, when toolbar is right.
 
   [thet]
 

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -139,11 +139,13 @@
           line-height: 20px;
         }
 
-        &:hover > span {
-          margin-top: 0;
-          -webkit-transition: none;
-          transition: none;
+        &:hover {
           background: #007bb3;
+          & > span {
+              margin-top: 0;
+              -webkit-transition: none;
+              transition: none;
+          }
         }
       }
     }
@@ -175,8 +177,8 @@
       background: @plone-toolbar-pending-color;
     }
 
-    li.active a.label-state-pending > span,
-    a.label-state-pending > span:hover {
+    li.active a.label-state-pending,
+    a.label-state-pending:hover {
       color: (#fff - @plone-toolbar-text-color) !important;
     } //contrast
 
@@ -474,7 +476,7 @@
     width: 0;
   }
 
-  li:not(.active) a:hover > span {
+  li:not(.active) a:hover {
     background: @plone-toolbar-link;
   }
 
@@ -495,8 +497,8 @@
   }
 
   li {
-    a.label-state-published:hover > span,
-    li a.label-state-external:hover > span {
+    a.label-state-published:hover,
+    li a.label-state-external:hover {
       background: @plone-toolbar-published-color;
 
       &:first-child:before {
@@ -504,7 +506,7 @@
       }
     }
 
-    a.label-state-internally_published:hover > span {
+    a.label-state-internally_published:hover {
       background: @plone-toolbar-internally-published-color;
 
       &:first-child:before {
@@ -512,7 +514,7 @@
       }
     }
 
-    a.label-state-pending:hover > span {
+    a.label-state-pending:hover {
       background: @plone-toolbar-pending-color;
 
       &:first-child:before {
@@ -520,8 +522,8 @@
       }
     }
 
-    a.label-state-draft:hover > span,
-    li a.label-state-internal:hover > span {
+    a.label-state-draft:hover,
+    li a.label-state-internal:hover {
       background: @plone-toolbar-draft-color;
 
       &:first-child:before {
@@ -529,7 +531,7 @@
       }
     }
 
-    a.label-state-private:hover > span {
+    a.label-state-private:hover {
       background: @plone-toolbar-private-color;
 
       &:first-child:before {

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -297,6 +297,8 @@
       li {
         min-width: @plone-toolbar-submenu-width;
         width: auto;
+        white-space: nowrap;
+        padding-right: 1em;
 
         &:last-child {
           padding-bottom: 5px;

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -62,6 +62,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    overflow: hidden;  // scrolling done via buttons
 
     [class^='icon'] {
       font-size: 20px;
@@ -110,6 +111,7 @@
       position: fixed;
       z-index: 10;
       left: 0;
+      width: @plone-left-toolbar;
       background-color: black;
 
       &.up {
@@ -129,6 +131,7 @@
 
         > span {
           height: 20px;
+          width: 100% !important;
         }
 
         span:before {
@@ -453,6 +456,10 @@
     left: @plone-left-toolbar-expanded;
   }
 
+  .scroll-btn {
+      width: @plone-left-toolbar-expanded;
+  }
+
   nav > ul a > [class^='icon'] {
     display: table-cell;
     width: 40px;
@@ -465,7 +472,7 @@
   }
 
   nav > ul a > span + span {
-    width: @plone-left-toolbar-expanded - 40px;
+    width: auto;
     text-align: left;
     word-wrap: break-word;
     word-break: break-word;
@@ -493,7 +500,7 @@
         span:after {
             right: 5px; // workflow status icon
         }
-    } 
+    }
   }
 
   li {
@@ -827,17 +834,8 @@
       }
     }
 
-    .plone-toolbar-main {
-      width: @plone-left-toolbar-expanded+18px; /* hide scroll bar */
-      padding-right: 18px;
-    }
   }
 
-  .plone-toolbar-left-default #edit-zone {
-    .plone-toolbar-main {
-      width: @plone-left-toolbar+18px; /* hide scroll bar */
-    }
-  }
 }
 
 /*mobile*/

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -483,6 +483,15 @@
 
   /*states*/
 
+  ul#plone-contentmenu-workflow {
+     li span {
+        white-space: nowrap;
+        span:after {
+            right: 5px; // workflow status icon
+        }
+    } 
+  }
+
   li {
     a.label-state-published:hover > span,
     li a.label-state-external:hover > span {

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -110,7 +110,6 @@
     .scroll-btn {
       position: fixed;
       z-index: 10;
-      left: 0;
       width: @plone-left-toolbar;
       background-color: black;
 

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -291,7 +291,8 @@
       }
 
       li {
-        width: @plone-toolbar-submenu-width;
+        min-width: @plone-toolbar-submenu-width;
+        width: auto;
 
         &:last-child {
           padding-bottom: 5px;
@@ -430,7 +431,8 @@
 }
 
 .plone-toolbar-top #edit-zone nav > ul ul {
-  width: @plone-toolbar-submenu-width;
+  min-width: @plone-toolbar-submenu-width;
+  width: auto;
   height: 0;
   max-height: 0;
 }
@@ -548,7 +550,8 @@
 #edit-zone nav > ul > li.active {
   ul {
     display: block;
-    width: @plone-toolbar-submenu-width;
+    min-width: @plone-toolbar-submenu-width;
+    width: auto;
   }
 
   a > span {
@@ -882,7 +885,8 @@
   }
 
   #edit-zone nav ul li.active ul {
-    width: @plone-toolbar-submenu-width;
+    min-width: @plone-toolbar-submenu-width;
+    width: auto;
   }
 
   .plone-toolbar-left-default {

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -826,7 +826,7 @@
       border-top: 1px solid #ddd;
       background-color: black;
       box-shadow: -6px 2px 6px 2px #ddd;
-
+      width: @plone-left-toolbar;
       ul {
         position: fixed;
         top: 0;
@@ -834,6 +834,12 @@
       }
     }
 
+  }
+
+  .plone-toolbar-left.plone-toolbar-expanded #edit-zone {
+    #personal-bar-container {
+      width: @plone-left-toolbar-expanded;
+    }
   }
 
 }


### PR DESCRIPTION
# DONE

- Don't break workflow contentmenu header and better place the current status icon.
- Let the toolbar submenus be as wide as they need by setting a ``min-width`` and ``width: auto;``.
- Raise the width of the expanded toolbar from ``120px`` to ``180px``.
- Make menu hover background fit whole menu width.
- Don't show toolbar scroll bars for bigger screens and make scroll buttons full-width.

# TODO

- [x] Mobile styles are a bit more broken. Has to be fixed.

- [ ] Just checked the left toolbar option, not top one.

- [ ] On normal screens the scrollbars are hidden (no change so far for smaller screens). But now you can't scroll the overflown toolbar with mouse/touchpad.

/cc @jensens @hvelarde @agitator @zopyx 

BTW. any help is appreciated.

![screen shot 2016-08-29 at 12 33 12](https://cloud.githubusercontent.com/assets/170891/18060609/d9d6bafa-6de4-11e6-8e36-9f911463009d.png)
