### PR TITLE
Fixed tests in combination with CMFFormController that includes hotfix.

### DIFF
--- a/Products/CMFPlone/tests/testSSOLogin.py
+++ b/Products/CMFPlone/tests/testSSOLogin.py
@@ -30,6 +30,15 @@ class SSOLoginTestCase(ptc.FunctionalTestCase):
                 self.another_portal.absolute_url(),
                 ]
             )
+        # The normal portal needs to allow logins from the login portal,
+        # otherwise the redirect_to action on login or logout will refuse to
+        # redirect externally.  This may need to be done on another_portal too,
+        # but for the current tests this is not needed.
+        self.portal.portal_properties.site_properties._updateProperty(
+            'allow_external_login_sites', [
+                self.login_portal.absolute_url(),
+                ]
+            )
 
         # Configure our sites to use the login portal for logins and logouts
         login_portal_url = self.login_portal.absolute_url()

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -195,8 +195,17 @@ class TestAttackVectorsFunctional(ptc.FunctionalTestCase):
     def test_go_back(self):
         res = self.publish('/plone/front-page/go_back?last_referer=http://${request}',
             basic=ptc.portal_owner + ':' + ptc.default_password)
+        # This used to show the request as location, so something like:
+        # http://<h3>form</h3><table>... and then all kinds of data from the
+        # request.  This was fixed in PloneHotfix20121106.  For this request
+        # you then got redirected to url http://${request} which your browser
+        # obviously does not know how to handle.
+        #
+        # In PloneHotfix20160830 this fix was kept, but additionally Plone
+        # refuses to redirect to external sites by default.
         self.assertEqual(302, res.status)
-        self.assertEqual('http://${request}', res.headers['location'][:17])
+        self.assertEqual(res.headers['location'],
+                         self.portal.absolute_url() + '/front-page')
 
     def test_getFolderContents(self):
         res = self.publish('/plone/getFolderContents')

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,6 +19,8 @@ New features:
 
 Bug fixes:
 
+- Fixed tests in combination with newer CMFFormController which has the hotfix.  [maurits]
+
 - Apply security hotfix 20160830 for ``@@plone-root-login``.  [maurits]
 
 - Apply security hotfix 20160830 for ``isURLInPortal``.  [maurits]


### PR DESCRIPTION
This is from PloneHotfix20160830.

Test in combination with https://github.com/plone/Products.CMFFormController/pull/9

Deferred until merge of plone/plone.protect#53.

