### PR TITLE
 Use fork of grunt-sed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ Bug fixes:
 - Remove LanguageTool layer.
   [gforcada]
 
+- Use fork of grunt-sed which is compatible with newer grunt version.
+  [gforcada]
+
 5.1a2 (2016-08-19)
 ------------------
 

--- a/Products/CMFPlone/_scripts/compile_resources.py
+++ b/Products/CMFPlone/_scripts/compile_resources.py
@@ -17,7 +17,7 @@ package_json_contents = """{
     "grunt-contrib-requirejs": "~1.0.0",
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",
-    "grunt-sed": "~0.1.1",
+    "grunt-sed": "collective/grunt-sed#e625902539f5c29f1246228270a0330c1097b1e4", 
     "less-plugin-inline-urls": "^1.2.0"
   }
 }"""


### PR DESCRIPTION
The problem with released versions is that they are not compatible with newer grunt versions.

This grunt-sed fork in collective *only* differs from latest official release with the grunt version fixes. There's no new/removed functionality.

/cc @thet can it be merged together with https://github.com/plone/mockup/pull/702 ?