### PR TITLE
Apply security hotfix 20160830 for z3c.form widgets. [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ New features:
 
 Bug fixes:
 
+- Apply security hotfix 20160830 for ``z3c.form`` widgets.  [maurits]
+
 - Fixed tests in combination with newer CMFFormController which has the hotfix.  [maurits]
 
 - Apply security hotfix 20160830 for ``@@plone-root-login``.  [maurits]

--- a/Products/CMFPlone/patches/__init__.py
+++ b/Products/CMFPlone/patches/__init__.py
@@ -29,3 +29,5 @@ import templatecookcheck        # Make sure templates aren't re-read in
 # production sites
 
 import publishing
+
+import z3c_form

--- a/Products/CMFPlone/patches/z3c_form.py
+++ b/Products/CMFPlone/patches/z3c_form.py
@@ -1,0 +1,50 @@
+# This is from Products.PloneHotfix20160830.
+from urlparse import urlparse
+from z3c.form import widget
+
+
+# Attribute name to allow prefilling a widget with a value from a GET request.
+# Usually all forms are only for POST, and we disallow filling it with GET
+# data.  This works the way around too: allow prefilling from a POST request
+# when the form only handles GET.  But that is unlikely.
+ALLOW_PREFILL = 'allow_prefill_from_GET_request'
+
+
+def _wrap_update(update):
+    def _wrapped(self):
+        # If we are ignoring the request on the form, we should also ignore it
+        # on the widget.  This means that when on the first widget we conclude
+        # that the form should be ignored, we quickly ignore it on all widgets,
+        # without needing to check the referer and method again and again.
+        # When we do not ignore the request, we do still run these checks for
+        # all widgets.  But it seems an international sport to override the
+        # update or updateWidgets method of the base z3c form, which makes it
+        # hard to fix all occurrences by one check on the form.
+        if not self.ignoreRequest and getattr(self.form, 'ignoreRequest', False):
+            self.ignoreRequest = True
+        # If we are not already ignoring the request, check the request method.
+        if (not self.ignoreRequest
+                and hasattr(self.form, 'method')
+                and hasattr(self.request, 'REQUEST_METHOD')):
+            if self.request.REQUEST_METHOD.lower() != self.form.method.lower():
+                # This is an unexpected request method.
+                # For special cases we allow a form to bail out.
+                if not getattr(self.form, ALLOW_PREFILL, False):
+                    self.ignoreRequest = True
+                    self.form.ignoreRequest = True
+        # If we are not already ignoring the request, check the referer.
+        if not self.ignoreRequest and hasattr(self.request, 'environ'):
+            env = self.request.environ
+            referrer = env.get('HTTP_REFERER', env.get('HTTP_REFERRER'))
+            if referrer:
+                req_url_parsed = urlparse(self.request.URL)
+                referrer_parsed = urlparse(referrer)
+                if req_url_parsed.netloc != referrer_parsed.netloc:
+                    # We do not trust data from outside referrers.
+                    self.ignoreRequest = True
+                    self.form.ignoreRequest = True
+        return update(self)
+    return _wrapped
+
+
+widget.Widget.update = _wrap_update(widget.Widget.update)

--- a/Products/CMFPlone/tests/test_z3c_form_widgets.py
+++ b/Products/CMFPlone/tests/test_z3c_form_widgets.py
@@ -1,0 +1,116 @@
+from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
+from z3c.form import widget
+from z3c.form.browser.text import TextWidget
+
+import unittest
+
+
+WIDGETS_TO_TEST = [
+    TextWidget,
+    widget.Widget,
+    widget.MultiWidget,
+    widget.SequenceWidget,
+]
+
+_marker = object()
+
+
+class FakeForm(object):
+    method = 'post'
+    ignoreRequest = False
+
+
+class TestAttackVector(unittest.TestCase):
+    layer = PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
+    _widgets_to_test = WIDGETS_TO_TEST
+    _attack = '</textarea><script>alert("form.widgets.class_blacklist")</script>'  # noqa
+
+    def _terms(self):
+        # For the SequenceWidget we need basic terms.
+        # We make dummy (dumb) terms.
+        from z3c.form.term import Terms
+
+        class DummyTerms(Terms):
+            def getTermByToken(self, token):
+                return token
+
+        return DummyTerms()
+
+    def test_regression(self):
+        request = self.layer['request']
+        for Widget in self._widgets_to_test:
+            wi = Widget(request)
+            wi.name = 'foo'
+            request.REQUEST_METHOD = 'POST'
+            request.form.update({
+                'foo': 'bar'
+            })
+            wi.form = FakeForm()
+            self.assertEquals(wi.ignoreRequest, False)
+            # The SequenceWidget needs terms.  It will have terms=None,
+            # where the others have no terms attribute.
+            if getattr(wi, 'terms', _marker) is None:
+                wi.terms = self._terms()
+            wi.update()
+            self.assertEquals(wi.ignoreRequest, False)
+
+    def test_only_get_data_from_valid_request_method(self):
+        request = self.layer['request']
+        for Widget in self._widgets_to_test:
+            wi = Widget(request)
+            wi.name = 'foobar'
+            request.REQUEST_METHOD = 'GET'
+            request.form.update({
+                'foobar': self._attack
+            })
+            wi.form = FakeForm()
+            self.assertEquals(wi.ignoreRequest, False)
+            # The SequenceWidget needs terms.  It will have terms=None,
+            # where the others have no terms attribute.
+            if getattr(wi, 'terms', _marker) is None:
+                wi.terms = self._terms()
+            wi.update()
+            self.assertEquals(wi.ignoreRequest, True)
+
+    def test_explicitly_allow_data_from_invalid_request_method(self):
+        request = self.layer['request']
+        for Widget in self._widgets_to_test:
+            wi = Widget(request)
+            wi.name = 'foobar'
+            request.REQUEST_METHOD = 'GET'
+            request.form.update({
+                'foobar': self._attack
+            })
+            wi.form = FakeForm()
+            # Set attribute on form to explicitly allow prefill.
+            from Products.CMFPlone.patches.z3c_form import ALLOW_PREFILL
+            setattr(wi.form, ALLOW_PREFILL, True)
+            self.assertEquals(wi.ignoreRequest, False)
+            # The SequenceWidget needs terms.  It will have terms=None,
+            # where the others have no terms attribute.
+            if getattr(wi, 'terms', _marker) is None:
+                wi.terms = self._terms()
+            wi.update()
+            self.assertEquals(wi.ignoreRequest, False)
+
+    def test_only_get_data_from_valid_referrer(self):
+        # this handles the use case where hijacker gets user to click on
+        # button that submits to plone site
+        request = self.layer['request']
+
+        for Widget in self._widgets_to_test:
+            wi = Widget(request)
+            wi.name = 'foobar'
+            request.REQUEST_METHOD = 'POST'
+            request.form.update({
+                'foobar': self._attack
+            })
+            request.environ['HTTP_REFERER'] = 'http://attacker.com'
+            wi.form = FakeForm()
+            self.assertEquals(wi.ignoreRequest, False)
+            # The SequenceWidget needs terms.  It will have terms=None,
+            # where the others have no terms attribute.
+            if getattr(wi, 'terms', _marker) is None:
+                wi.terms = self._terms()
+            wi.update()
+            self.assertEquals(wi.ignoreRequest, True)


### PR DESCRIPTION
Small differences compared to the hotfix:
- We also set `form.ignoreRequest = True` instead of only setting this on the widget.
- When `form.ignoreRequest` is True, then we set `widget.ignoreRequest` to True. This avoids the longer taking tests for referrer and method.
- We first check the method, then the referrer, since the method check is cheaper.

Within the security team we were wondering about maybe patching/fixing the form class instead, but that seems hard. At least it seems hard to be sure that we have them all, since various classes inherit from the base z3c form, but override the `update` or `updateWidgets` methods without calling `super`. Well, [plone.z3cform extensible forms](https://github.com/zopefoundation/plone.z3cform/blob/0.9.0/src/plone/z3cform/fieldsets/extensible.py#L63) does call super. But [z3c.form group forms](https://github.com/zopefoundation/z3c.form/blob/3.2.10/src/z3c/form/group.py#L38-L63) don't, although those are sub forms so it might be okay. We could accept the current solution and revisit it later if we want.

Also, it looks like this does need to stay a patch in CMFPlone (or maybe in `plone(.app).z3cform`) and can't be done in `z3c.form` itself: that package should work outside of Plone and CMF too, so without a portal_url tool and without `getToolByName`.

CC @vangheem @davisagli 