### PR TITLE
Fix plone-legacy RequireJS errors in development mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,10 @@ Bug fixes:
 - Add utf8 headers to all Python source files. [jensens]
 
 - Add default icon for top-level contentview and contentmenu toolbar entries [alecm]
+- Reset and re-enable ``define`` and ``require`` for the ``plone-legacy`` bundle in development mode.
+  Fixes issues with legacy scripts having RequireJS integration in development mode.
+  In Production mode, resetting  and re-enabling is done in the compiled bundle.
+  [thet]
 
 - Apply security hotfix 20160830 for ``z3c.form`` widgets.  [maurits]
 

--- a/Products/CMFPlone/resources/browser/scripts.pt
+++ b/Products/CMFPlone/resources/browser/scripts.pt
@@ -1,11 +1,21 @@
 <script type="text/javascript" tal:content="string:PORTAL_URL = '${view/base_url}';"></script>
-<tal:scripts repeat="script view/scripts"
-  ><tal:block define="condcomment script/conditionalcomment"
-    ><tal:wcondcomment tal:condition="condcomment">
-       <tal:opencc tal:replace="structure string:&lt;!--[if ${condcomment}]&gt;" />
-     </tal:wcondcomment
-        ><script type="text/javascript" tal:attributes="src script/src; data-bundle script/bundle"></script><tal:wcondcomment tal:condition="condcomment">
-       <tal:closecc tal:replace="structure string:&lt;![endif]--&gt;" />
-     </tal:wcondcomment
-    ></tal:block
-></tal:scripts>
+<tal:scripts repeat="script view/scripts"><tal:block define="condcomment script/conditionalcomment; resetrjs script/resetrjs|nothing"><tal:if condition="resetrjs">
+  <tal:openreset content='structure string:&lt;script type="text/javascript"&gt;'/>
+      /* reset requirejs definitions so that people who put requirejs in legacy compilation do not get errors */
+      var _old_define = define;
+      var _old_require = require;
+      define = undefined;
+      require = undefined;
+  <tal:endreset content='structure string:&lt;/script&gt;'/>
+</tal:if><tal:if condition="condcomment">
+    <tal:opencc tal:replace="structure string:&lt;!--[if ${condcomment}]&gt;" />
+</tal:if>
+  <script type="text/javascript" tal:attributes="src script/src; data-bundle script/bundle"></script>
+<tal:if condition="condcomment">
+  <tal:closecc tal:condition="condcomment" tal:replace="structure string:&lt;![endif]--&gt;" />
+</tal:if><tal:if condition="resetrjs">
+  <tal:openredefine content='structure string:&lt;script type="text/javascript"&gt;'/>
+      define = _old_define;
+      require = _old_require;
+  <tal:endredefine content='structure string:&lt;/script&gt;'/>
+</tal:if></tal:block></tal:scripts>

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -14,6 +14,7 @@ class ScriptsView(ResourceView):
     def get_data(self, bundle, result):
         bundle_name = bundle.__prefix__.split('/', 1)[1].rstrip('.')
         if self.develop_bundle(bundle, 'develop_javascript'):
+            # Bundle development mode
             resources = self.get_resources()
             for resource in bundle.resources:
                 if resource in resources:
@@ -29,7 +30,12 @@ class ScriptsView(ResourceView):
                         data = {
                             'bundle': bundle_name,
                             'conditionalcomment': bundle.conditionalcomment,  # noqa
-                            'src': src}
+                            'src': src,
+                            # Reset RequireJS if bundle is in non-compile to
+                            # avoid "Mismatched anonymous define()" in legacy
+                            # scripts.
+                            'resetrjs': bundle.compile is False
+                        }
                         result.append(data)
         else:
             if bundle.compile is False:


### PR DESCRIPTION
Reset and re-enable ``define`` and ``require`` for the ``plone-legacy`` bundle in development mode.
Fixes issues with legacy scripts having RequireJS integration in development mode.
In Production mode, resetting  and re-enabling is done in the compiled bundle.

Please note: This does only work for ``plone-legacy`` and not for other "legacy" bundles with "compile" set to False.
I couldn't find a way quickly, to reliably check the compiled attribute of the bundle object in resources/browser/scripts.py - looks like it always returns False in development mode - so this doesn't help much.

~~I just recognized, that I do not check if the plone-legacy bundle itself is in development mode - I just check if the resourceregistry is. That has to be fixed I guess.~~ ... it is checked....

But for the general fix: Comments welcome!

/cc @jensens @vangheem 

This addresses: 
https://github.com/plone/Products.CMFPlone/issues/1529
https://github.com/plone/Products.CMFPlone/issues/1742