### PR TITLE
avoid dependency on plone.app.imaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ New features:
 
 Bug fixes:
 
+- Avoid dependency on plone.app.imaging. [davisagli]
+
 - Add utf8 headers to all Python source files. [jensens]
 
 - Apply security hotfix 20160830 for ``z3c.form`` widgets.  [maurits]

--- a/Products/CMFPlone/controlpanel/browser/configure.zcml
+++ b/Products/CMFPlone/controlpanel/browser/configure.zcml
@@ -2,8 +2,13 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser">
 
-  <!-- needed for control panel permission -->
-  <include package="plone.app.imaging" />
+  <!-- the condition is to avoid a conflict with the
+       older permission that is registered by plone.app.imaging -->
+  <configure zcml:condition="not-installed plone.app.imaging">
+    <permission
+        id="plone.app.controlpanel.Imaging"
+        title="Plone Site Setup: Imaging" />
+  </configure>
 
   <permission
       id="plone.app.controlpanel.TinyMCE"

--- a/Products/CMFPlone/controlpanel/browser/configure.zcml
+++ b/Products/CMFPlone/controlpanel/browser/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser">
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <!-- the condition is to avoid a conflict with the
        older permission that is registered by plone.app.imaging -->

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -20,6 +20,7 @@ from Products.CMFCore.permissions import ManageUsers
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.utils import ToolInit as CMFCoreToolInit
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from types import ClassType
 from webdav.interfaces import IWriteLock

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -666,15 +666,31 @@ def bodyfinder(text):
     return text[bodystart:bodyend]
 
 
-# XXX nasty? better than re-writting same method. Circular import issues here
 def getAllowedSizes():
-    from plone.app.imaging.utils import getAllowedSizes as func
-    return func()
+    registry = queryUtility(IRegistry)
+    if not registry:
+        return None
+    settings = registry.forInterface(
+        IImagingSchema, prefix="plone", check=False)
+    if not settings.allowed_sizes:
+        return None
+    sizes = {}
+    for line in settings.allowed_sizes:
+        line = line.strip()
+        if line:
+            name, width, height = pattern.match(line).groups()
+            name = name.strip().replace(' ', '_')
+            sizes[name] = int(width), int(height)
+    return sizes
 
 
 def getQuality():
-    from plone.app.imaging.utils import getQuality as func
-    return func()
+    registry = queryUtility(IRegistry)
+    if registry:
+        settings = registry.forInterface(
+            IImagingSchema, prefix="plone", check=False)
+        return settings.quality or QUALITY_DEFAULT
+    return QUALITY_DEFAULT
 
 
 def getSiteLogo(site=None):


### PR DESCRIPTION
We don't want to depend on plone.app.imaging, because it requires Archetypes.

This copies a permission and the implementation of 2 util functions from plone.app.imaging so we can stop depending on it.

See also https://github.com/plone/plone.app.vocabularies/pull/40