### PR TITLE
5.0 - Move ``get_top_site_from_url`` from plone.app.content to ``utils.py``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,15 +15,16 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Move ``get_top_site_from_url`` from plone.app.content to ``utils.py``.
+  This function allows in virtual hosting environments to acquire the top most visible portal object to operate on.
+  It is used for example to calculate the correct virtual root objects for Mockup's related items and structure pattern.
+  [thet]
 
 Bug fixes:
 
 - Prevent workflow menu overflowing in toolbar [MatthewWilkes]
 
 - Add default icon for top-level contentview and contentmenu toolbar entries [alecm]
-
-Bug fixes:
 
 - Fix various layout issues in toolbar [alecm]
 

--- a/Products/CMFPlone/tests/test_utils.py
+++ b/Products/CMFPlone/tests/test_utils.py
@@ -1,29 +1,17 @@
-##############################################################################
-#
-# Copyright (c) 2002 Zope Foundation and Contributors.
-#
-# This software is subject to the provisions of the Zope Public License,
-# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
-# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
-# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
-# FOR A PARTICULAR PURPOSE.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
 """ Unit tests for utils module. """
 
-import unittest
-from Products.CMFPlone.tests import PloneTestCase
-
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.tests.base.content import FAUX_HTML_LEADING_TEXT
 from Products.CMFCore.tests.base.content import SIMPLE_HTML
 from Products.CMFCore.tests.base.content import SIMPLE_STRUCTUREDTEXT
 from Products.CMFCore.tests.base.content import SIMPLE_XHTML
 from Products.CMFCore.tests.base.content import STX_WITH_HTML
-
 from Products.CMFPlone.interfaces import ISiteSchema
+from Products.CMFPlone.tests import PloneTestCase
 from zope.component import getUtility
-from plone.registry.interfaces import IRegistry
+
+import unittest
 
 
 SITE_LOGO_BASE64 = 'filenameb64:cGl4ZWwucG5n;datab64:iVBORw0KGgoAAAANSUhEUgAA'\
@@ -65,3 +53,79 @@ class LogoTests(PloneTestCase.PloneTestCase):
         self.assertTrue(
             'http://nohost/plone/logo.png'
             in getSiteLogo())
+
+
+class TestTopSiteFromUrl(unittest.TestCase):
+
+    def test_get_top_site_from_url(self):
+        """Unit test for ``get_top_site_from_url`` with context and request
+        mocks.
+
+        Test content structure:
+        /approot/PloneSite/folder/SubSite/folder
+        PloneSite and SubSite implement ISite
+        """
+        from plone.app.content.browser.contents import get_top_site_from_url
+        from zope.component.interfaces import ISite
+        from zope.interface import alsoProvides
+        from urlparse import urlparse
+
+        class MockContext(object):
+            vh_url = 'http://nohost'
+            vh_root = ''
+
+            def __init__(self, physical_path):
+                self.physical_path = physical_path
+                if self.physical_path.split('/')[-1] in ('PloneSite', 'SubSite'):  # noqa
+                    alsoProvides(self, ISite)
+
+            @property
+            def id(self):
+                return self.physical_path.split('/')[-1]
+
+            def absolute_url(self):
+                return self.vh_url + self.physical_path[len(self.vh_root):] or '/'  # noqa
+
+            def restrictedTraverse(self, path):
+                return MockContext(self.vh_root + path)
+
+        class MockRequest(object):
+            vh_url = 'http://nohost'
+            vh_root = ''
+
+            def physicalPathFromURL(self, url):
+                # Return the physical path from a URL.
+                # The outer right '/' is not part of the path.
+                path = self.vh_root + urlparse(url).path.rstrip('/')
+                return path.split('/')
+
+        # NO VIRTUAL HOSTING
+
+        req = MockRequest()
+
+        # Case 1:
+        ctx = MockContext('/approot/PloneSite')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # Case 2
+        ctx = MockContext('/approot/PloneSite/folder')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # Case 3:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite/folder')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # VIRTUAL HOSTING ON SUBSITE
+
+        req = MockRequest()
+        req.vh_root = '/approot/PloneSite/folder/SubSite'
+
+        # Case 4:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite')
+        ctx.vh_root = '/approot/PloneSite/folder/SubSite'
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'SubSite')
+
+        # Case 5:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite/folder')
+        ctx.vh_root = '/approot/PloneSite/folder/SubSite'
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'SubSite')

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from AccessControl import ClassSecurityInfo
 from AccessControl import getSecurityManager
 from AccessControl import ModuleSecurityInfo
 from AccessControl import Unauthorized
@@ -7,23 +8,34 @@ from Acquisition import aq_get
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from App.Common import package_home
+from App.Dialogs import MessageDialog
 from App.ImageFile import ImageFile
+from cgi import escape
 from DateTime import DateTime
 from DateTime.interfaces import DateTimeError
-from os.path import join, abspath, split
+from log import log
+from log import log_deprecated
+from log import log_exc
+from OFS.CopySupport import CopyError
+from OFS.CopySupport import eNotSupported
+from os.path import abspath
+from os.path import join
+from os.path import split
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ManageUsers
-from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.utils import ToolInit as CMFCoreToolInit
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from types import ClassType
+from urlparse import urlparse
 from webdav.interfaces import IWriteLock
 from zope import schema
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryUtility
 from zope.component.hooks import getSite
+from zope.component.interfaces import ISite
 from zope.deferredimport import deprecated as deprecated_import
 from zope.deprecation import deprecated
 from zope.i18n import translate
@@ -34,8 +46,10 @@ import json
 import OFS
 import pkg_resources
 import re
+import sys
 import transaction
 import zope.interface
+
 
 deprecated_import(
     "Import from Products.CMFPlone.defaultpage instead",
@@ -506,11 +520,6 @@ def webdav_enabled(obj, container):
 # Copied 'unrestricted_rename' from ATCT migrations to avoid
 # a dependency.
 
-from App.Dialogs import MessageDialog
-from OFS.CopySupport import CopyError
-from OFS.CopySupport import eNotSupported
-from cgi import escape
-import sys
 
 security.declarePrivate('sys')
 
@@ -557,7 +566,6 @@ def _unrestricted_rename(container, id, new_id):
 
 # Copied '_getSecurity' from Archetypes.utils to avoid a dependency.
 
-from AccessControl import ClassSecurityInfo
 security.declarePrivate('ClassSecurityInfo')
 
 
@@ -673,3 +681,42 @@ def getSiteLogo(site=None):
             site_url, filename)
     else:
         return '%s/logo.png' % site_url
+
+
+def get_top_site_from_url(context, request):
+    """Find the top-most site, which is still in the url path.
+
+    If the current context is within a subsite within a PloneSiteRoot and no
+    virtual hosting is in place, the PloneSiteRoot is returned.
+    When at the same context but in a virtual hosting environment with the
+    virtual host root pointing to the subsite, it returns the subsite instead
+    the PloneSiteRoot.
+
+    For this given content structure:
+
+    /Plone/Subsite
+
+    It should return the following in these cases:
+
+    - No virtual hosting, URL path: /Plone, Returns: Plone Site
+    - No virtual hosting, URL path: /Plone/Subsite, Returns: Plone
+    - Virtual hosting roots to Subsite, URL path: /, Returns: Subsite
+    """
+    url_path = urlparse(context.absolute_url()).path.split('/')
+
+    site = getSite()
+    try:
+        for idx in range(len(url_path)):
+            _path = '/'.join(url_path[:idx + 1]) or '/'
+            site_path = request.physicalPathFromURL(_path)
+            _site = context.restrictedTraverse('/'.join(site_path) or '/')
+            if ISite.providedBy(_site):
+                break
+        if _site:
+            site = _site
+    except (ValueError, AttributeError):
+        # On error, just return getSite.
+        # Refs: https://github.com/plone/plone.app.content/issues/103
+        # Also, TestRequest doesn't have physicalPathFromURL
+        pass
+    return site


### PR DESCRIPTION
 This function allows in virtual hosting environments to acquire the top most visible portal object to operate on.
 It is used for example to calculate the correct virtual root objects for Mockup's related items and structure pattern.

Related:
https://github.com/plone/Products.CMFPlone/pull/1818
https://github.com/plone/plone.app.content/pull/111
https://github.com/plone/plone.app.widgets/pull/148