### PR TITLE
FIX: adding resources on request when using tiles with subrequests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Breaking changes:
 
 New features:
 
+- Add utility method to retrieve the top most parent request from a sub request.
+  [thet]
+
 - Add sort_on field to search controlpanel.
   [rodfersou]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ New features:
 
 Bug fixes:
 
+- Support adding or removing bundles and resources on a request when working with resource tiles in a subrequest.
+  [thet]
+
 - Remove jquery.cookie from plone-logged-in bundle's stub_js_modules.
   The toolbar, which has a dependency on jquery.cookie,
   was moved from the plone bundle to plone-logged-in in CMPlone 5.1a2.

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -15,6 +15,7 @@ from zope.ramcache.interfaces import ram
 from Products.CMFCore.utils import _getAuthenticatedUser
 from plone.memoize.view import memoize
 from Products.CMFPlone.resources import RESOURCE_DEVELOPMENT_MODE
+from Products.CMFPlone.utils import get_top_request
 
 from .combine import get_production_resource_directory
 
@@ -134,13 +135,14 @@ class ResourceView(ViewletBase):
             disabled_diazo_bundles = self.themeObj.disabled_bundles
 
         # Request set bundles
+        request = get_top_request(self.request)  # might be a subrequest
         enabled_request_bundles = []
         disabled_request_bundles = []
-        if hasattr(self.request, 'enabled_bundles'):
-            enabled_request_bundles.extend(self.request.enabled_bundles)
+        if hasattr(request, 'enabled_bundles'):
+            enabled_request_bundles.extend(request.enabled_bundles)
 
-        if hasattr(self.request, 'disabled_bundles'):
-            disabled_request_bundles.extend(self.request.disabled_bundles)
+        if hasattr(request, 'disabled_bundles'):
+            disabled_request_bundles.extend(request.disabled_bundles)
 
         for key, bundle in bundles.items():
             # The diazo manifest and request bundles are more important than

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -4,6 +4,7 @@ from urllib import quote
 
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceView
+from Products.CMFPlone.utils import get_top_request
 from zope.component import getMultiAdapter
 
 
@@ -149,9 +150,10 @@ class ScriptsView(ResourceView):
             result.extend(self.ordered_bundles_result(production=True))
 
         # Add manual added resources
-        if hasattr(self.request, 'enabled_resources'):
+        request = get_top_request(self.request)  # might be a subrequest
+        if hasattr(request, 'enabled_resources'):
             resources = self.get_resources()
-            for resource in self.request.enabled_resources:
+            for resource in request.enabled_resources:
                 if resource in resources:
                     data = resources[resource]
                     if data.js:

--- a/Products/CMFPlone/resources/browser/styles.py
+++ b/Products/CMFPlone/resources/browser/styles.py
@@ -4,6 +4,7 @@ from urllib import quote
 
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceView
+from Products.CMFPlone.utils import get_top_request
 
 
 class StylesView(ResourceView):
@@ -116,8 +117,9 @@ class StylesView(ResourceView):
 
         # Add manual added resources
         resources = self.get_resources()
-        if hasattr(self.request, 'enabled_resources'):
-            for resource in self.request.enabled_resources:
+        request = get_top_request(self.request)  # might be a subrequest
+        if hasattr(request, 'enabled_resources'):
+            for resource in request.enabled_resources:
                 if resource in resources:
                     for data in self.get_urls(resources[resource], None):
                         result.append(data)

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -16,6 +16,7 @@ from log import log_exc
 from os.path import join, abspath, split
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
+from plone.subrequest.interfaces import ISubRequest
 from Products.CMFCore.permissions import ManageUsers
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.utils import ToolInit as CMFCoreToolInit
@@ -716,3 +717,13 @@ def get_installer(context, request=None):
         request = aq_get(context, 'REQUEST', None)
     view = getMultiAdapter((context, request), name='installer')
     return view
+
+
+def get_top_request(request):
+    """Get highest request from a subrequest.
+    """
+    def _top_request(req):
+        if ISubRequest.providedBy(req):
+            return _top_request(req.get('PARENT_REQUEST', None))
+        return req
+    return _top_request(request)

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -16,7 +16,6 @@ from log import log_exc
 from os.path import join, abspath, split
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
-from plone.subrequest.interfaces import ISubRequest
 from Products.CMFCore.permissions import ManageUsers
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.utils import ToolInit as CMFCoreToolInit
@@ -722,8 +721,8 @@ def get_installer(context, request=None):
 def get_top_request(request):
     """Get highest request from a subrequest.
     """
+
     def _top_request(req):
-        if ISubRequest.providedBy(req):
-            return _top_request(req.get('PARENT_REQUEST', None))
-        return req
+        parent_request = req.get('PARENT_REQUEST', None)
+        return _top_request(parent_request) if parent_request else req
     return _top_request(request)

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         'plone.registry',
         'plone.schema',
         'plone.session',
+        'plone.subrequest',
         'plone.theme',
         'plonetheme.barceloneta',
         'slimit',


### PR DESCRIPTION
When using plone.app.mosaic based site layouts, which use the tiles ``@@plone.app.standardtiles.stylesheets`` and ``@@plone.app.standardtiles.javascripts`` to render stylesheets and javascripts for the header and making use of ``add_resource_on_request``, ``add_bundle_on_request`` or ``remove_bundle_on_request`` on a view (which uses the main request), it won't work. The reason is, the tiles are rendered in a subrequest and the subrequest doesn't have the ``enable_resources``, ``enable_bundles`` or ``remove_bundles`` attributes, but the main request has.

This PR uses the top request to acquire these attributes when rendering scripts or style slots for the header.

This fixes rendering of ``@@resourceregistry-controlpanel`` when using global site layouts.

PLEASE NOTE:
This doesn't solve the problem when a tile in a subrequest uses any of the add/remove bundle/resource methods from ``Products.CMFPlone.resources.__init__``.

IMO it would be worth to fix these methods to add their attributes to the top request instead also.

This PR is ready for the original scope, fixing the resourceregistry rendering when using global site layouts.

Comments?
@datakurre @jensens