### PR TITLE
make passwordreset templates use content-core macros

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,12 @@ Breaking changes:
 
 New features:
 
+- The password reset templates were changed to make use of ``content-core`` macros.
+  [thet]
+
 - Add utility method to retrieve the top most parent request from a sub request.
+  [thet]
+
 - Add ``mockup-patterns-relateditems-upload`` resource, which can be used in custom bundles to add the upload feature in the related items widget.
   [thet]
 
@@ -66,8 +71,7 @@ New features:
 - Include mockup 2.4.0.
   [thet]
 
-- PasswordResetTool moved from its own package to here
-  (includes cleanup and removal of ``getStats``).
+- PasswordResetTool moved from its own package to here (includes cleanup and removal of ``getStats``).
   [tomgross]
 
 - Prevent workflow menu overflowing in toolbar [MatthewWilkes]

--- a/Products/CMFPlone/browser/templates/mail_password_form.pt
+++ b/Products/CMFPlone/browser/templates/mail_password_form.pt
@@ -1,7 +1,11 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
-      lang="en-US"
-      metal:use-macro="here/main_template/macros/master"
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
+<body>
 
 <head>
     <metal:block fill-slot="top_slot"
@@ -9,21 +13,23 @@
                              disable_column_one python:request.set('disable_plone.leftcolumn',1);
                              disable_column_two python:request.set('disable_plone.rightcolumn',1);" />
 </head>
-<body>
-<metal:main fill-slot="main"
-     tal:define="use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
 
+<metal:custom_title fill-slot="content-title">
     <h1 class="documentFirstHeading"
         i18n:translate="heading_lost_password">Lost Password</h1>
+</metal:custom_title>
 
+<metal:custom_desc fill-slot="content-description">
     <div class="documentDescription" i18n:translate="description_lost_password">
         For security reasons, we store your password encrypted, and cannot mail
         it to you. If you would like to reset your password, fill out the form
         below and we will send you an email at the address you gave when you
         registered to start the process of resetting your password.
     </div>
+</metal:custom_desc>
 
-    <div id="content-core">
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core" tal:define="use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
 
         <form name="mail_password"
               class="enableAutoFocus"
@@ -82,8 +88,8 @@
                tal:attributes="href string:${portal_url}/contact-info">site administration</a></span>.
         </p>
 
-    </div>
-</metal:main>
+</metal:content-core>
+</metal:content-core>
 
 </body>
 </html>

--- a/Products/CMFPlone/browser/templates/mail_password_response.pt
+++ b/Products/CMFPlone/browser/templates/mail_password_response.pt
@@ -1,21 +1,31 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
-      lang="en-US"
-      metal:use-macro="here/main_template/macros/master"
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
 
-<metal:main fill-slot="main">
-
+<metal:custom_title fill-slot="content-title">
     <h1 class="documentFirstHeading"
         i18n:translate="heading_sent_password">Password reset confirmation sent</h1>
+</metal:custom_title>
 
+<metal:custom_desc fill-slot="content-description">
     <div class="documentDescription" i18n:translate="description_sent_password">
         Your password reset request has been mailed. It should arrive in your
         mailbox shortly. When you receive the message, visit the address it
         contains to reset your password.
     </div>
+</metal:custom_desc>
 
-</metal:main>
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core">
+
+
+</metal:content-core>
+</metal:content-core>
 
 </body>
 </html>

--- a/Products/CMFPlone/browser/templates/pwreset_expired.pt
+++ b/Products/CMFPlone/browser/templates/pwreset_expired.pt
@@ -1,12 +1,23 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
-      lang="en-US"
-      metal:use-macro="here/main_template/macros/master"
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
-    <metal:main fill-slot="main">
+
+<metal:custom_title fill-slot="content-title">
         <h1 class="documentFirstHeading"
             i18n:translate="heading_pwreset_expired">Password request expired</h1>
-        <div id="content-core">
+</metal:custom_title>
+
+<metal:custom_desc fill-slot="content-description">
+</metal:custom_desc>
+
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core">
+
             <p i18n:translate="message_pwreset_expired">
                 For your security, password reset URLs are only valid for
                 <span i18n:name="hours" tal:replace="here/portal_password_reset/getExpirationTimeout" />
@@ -15,7 +26,9 @@
                    <a href="/mail_password_form" tal:attributes="href string:$portal_url/mail_password_form"
                       i18n:translate="message_request_new">request a new one</a></span>.
             </p>
-        </div>
-    </metal:main>
+
+</metal:content-core>
+</metal:content-core>
+
 </body>
 </html>

--- a/Products/CMFPlone/browser/templates/pwreset_finish.pt
+++ b/Products/CMFPlone/browser/templates/pwreset_finish.pt
@@ -1,12 +1,22 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
-      lang="en-US"
-      metal:use-macro="here/main_template/macros/master"
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
 
-<metal:main fill-slot="main">
+<metal:custom_title fill-slot="content-title">
     <h1 class="documentFirstHeading"
         i18n:translate="heading_pwreset_success">Password set</h1>
+</metal:custom_title>
+
+<metal:custom_desc fill-slot="content-description">
+</metal:custom_desc>
+
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core">
 
     <div class="documentDescription" i18n:translate="message_pwreset_success">
         Your password has been set successfully. You may now
@@ -15,7 +25,8 @@
         new password.
     </div>
 
-</metal:main>
+</metal:content-core>
+</metal:content-core>
 
 </body>
 </html>

--- a/Products/CMFPlone/browser/templates/pwreset_form.pt
+++ b/Products/CMFPlone/browser/templates/pwreset_form.pt
@@ -1,20 +1,27 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="here/main_template/macros/master"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
-    <metal:main fill-slot="main"
-         tal:define="errors view/getErrors">
 
+<metal:custom_title fill-slot="content-title">
         <h1 class="documentFirstHeading"
             i18n:translate="heading_reset_password">Set your password</h1>
+</metal:custom_title>
 
+<metal:custom_desc fill-slot="content-description">
         <div class="documentDescription"
            i18n:translate="description_reset_password">
             Please fill out the form below to set your password.
         </div>
+</metal:custom_desc>
 
-        <div id="content-core">
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core" tal:define="errors view/getErrors">
+
             <form class="enableAutoFocus"
                   name="pwreset_action"
                   method="post"
@@ -105,7 +112,9 @@
                     <input type="hidden" name="form.submitted" value="1" />
                 </fieldset>
             </form>
-        </div>
-    </metal:main>
+
+</metal:content-core>
+</metal:content-core>
+
 </body>
 </html>

--- a/Products/CMFPlone/browser/templates/pwreset_invalid.pt
+++ b/Products/CMFPlone/browser/templates/pwreset_invalid.pt
@@ -1,15 +1,22 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="here/main_template/macros/master"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
 
-<metal:main fill-slot="main"
-     tal:define="use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
-
+<metal:custom_title fill-slot="content-title">
     <h1 class="documentFirstHeading" i18n:translate="heading_pwreset_invalid">Error setting password</h1>
+</metal:custom_title>
 
-    <div id="content-core">
+<metal:custom_desc fill-slot="content-description">
+</metal:custom_desc>
+
+<metal:content-core fill-slot="content-core">
+<metal:content-core define-macro="content-core" tal:define="use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
+
         <p i18n:translate="message_pwreset_invalid"
            tal:condition="not:use_email_as_login">
            Sorry, this appears to be an invalid request. Please make sure you copied
@@ -22,9 +29,9 @@
            the URL exactly as it appears in your email and that you entered your
            email address correctly.
         </p>
-    </div>
 
-</metal:main>
+</metal:content-core>
+</metal:content-core>
 
 </body>
 </html>


### PR DESCRIPTION
The password reset templates were changed to make use of content-core macros.

This change is needed when plone.app.mosaic global site layouts are enabled. Otherwise some of the templates are not rendered properlly.

Refs: https://github.com/plone/Products.CMFPlone/pull/1809

Should be merged together with this:
https://github.com/plone/Products.CMFPlone/pull/1826
https://github.com/plone/plone.app.testing/pull/37
https://github.com/plone/plone.api/pull/332
https://github.com/plone/buildout.coredev/pull/272

/cc @tomgross