### PR TITLE
Add support for TinyMCE content CSS set by theme to point to a remote site

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,7 +142,12 @@ Bug fixes:
 - Style display menu headings differently from actions [alecm]
 
 - Avoid dependency on plone.app.imaging. [davisagli]
+
 - Fix TinyMCE table styles [vangheem]
+
+- Fix TinyMCE content CSS support to allow themes to define
+  external content CSS URLs (as with CDN like setup).
+  [datakurre]
 
 - Add utf8 headers to all Python source files. [jensens]
 

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -42,10 +42,11 @@ class TinyMCESettingsGenerator(object):
         theme = self.get_theme()
         tinymce_content_css = getattr(theme, 'tinymce_content_css', None)
         if tinymce_content_css is not None:
-            files.extend([
-                self.nav_root_url + _
-                for _ in theme.tinymce_content_css.split(',')
-            ])
+            for path in theme.tinymce_content_css.split(','):
+                if path.startswith('http://') or path.startswith('https://'):
+                    files.append(path)
+                else:
+                    files.append(self.nav_root_url + path)
 
         return ','.join(files)
 


### PR DESCRIPTION
Fixes issue where it was not possible to configure tinymce-content-css to remote (e.g. CDN) resource.