### PR TITLE
Load Products.CMFPlone.patches earlier [5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New features:
 
 Bug fixes:
 
+- Load Products.CMFPlone.patches earlier, instead of in our initialize method.
+  This is part of PloneHotfix20161129.
+  [maurits]
+
 - Fix Search RSS link condition to use search_rss_enabled option and use
   rss.png instead of rss.gif that doesn't exist anymore.
   [vincentfretin]

--- a/Products/CMFPlone/__init__.py
+++ b/Products/CMFPlone/__init__.py
@@ -114,9 +114,6 @@ def initialize(context):
     # Make cgi.escape available TTW
     ModuleSecurityInfo('cgi').declarePublic('escape')
 
-    # Apply monkey patches
-    from Products.CMFPlone import patches  # noqa
-
     # Register unicode splitter w/ ZCTextIndex
     # pipeline registry
     from Products.CMFPlone import UnicodeSplitter  # noqa
@@ -209,3 +206,7 @@ PloneMessageFactory = MessageFactory('plone')
 # plonelocales domain
 from zope.i18nmessageid import MessageFactory
 PloneLocalesMessageFactory = MessageFactory('plonelocales')
+
+# Apply monkey patches.  If we do this in the initialize method,
+# it is too late for some of them.
+from Products.CMFPlone import patches  # noqa


### PR DESCRIPTION
This is part of PloneHotfix20161129.
It is also subtly related to our removal of the SecureMailHost patch.