### PR TITLE
Fixed sometimes failing search order tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,8 @@ New features:
 
 Bug fixes:
 
+- Fixed sometimes failing search order tests.  [maurits]
+
 - Load some Products.CMFPlone.patches earlier, instead of in our initialize method.
   This is part of PloneHotfix20161129.
   [maurits]

--- a/Products/CMFPlone/tests/testSearch.py
+++ b/Products/CMFPlone/tests/testSearch.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
+import time
 import unittest2 as unittest
 
 from DateTime import DateTime
@@ -65,12 +66,15 @@ class SearchLayer(PloneSandboxLayer):
             applyProfile(portal, 'Products.ATContentTypes:default')
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
-        for i in range(0, 100):
+        for i in range(0, 12):
             portal.invokeFactory(
                 'Document',
                 'my-page' + str(i),
                 text='spam spam ham eggs'
             )
+            # Sleep before creating the next one, otherwise ordering by date is
+            # not deterministic.
+            time.sleep(0.1)
         setRoles(portal, TEST_USER_ID, ['Member'])
 
         # Commit so that the test browser sees these objects
@@ -164,8 +168,8 @@ class TestSection(SearchTestCase):
         res = portal.restrictedTraverse('@@search').results(query=q)
         ids = [r.getId() for r in res]
         expected = [
-            'my-page99', 'my-page98', 'my-page97', 'my-page96', 'my-page95',
-            'my-page94', 'my-page93', 'my-page92', 'my-page91', 'my-page90'
+            'my-page11', 'my-page10', 'my-page9', 'my-page8', 'my-page7',
+            'my-page6', 'my-page5', 'my-page4', 'my-page3', 'my-page2'
         ]
         self.assertEqual(ids, expected)
 
@@ -185,8 +189,8 @@ class TestSection(SearchTestCase):
         res = portal.restrictedTraverse('@@search').results(query=q)
         ids = [r.getId() for r in res]
         expected = [
-            'my-page10', 'my-page9', 'my-page8', 'my-page7', 'my-page6',
-            'my-page4', 'my-page3', 'my-page2', 'my-page1', 'my-page0'
+            'my-page11', 'my-page10', 'my-page9', 'my-page8', 'my-page7',
+            'my-page6', 'my-page4', 'my-page3', 'my-page2', 'my-page1'
         ]
         self.assertEqual(ids, expected)
 


### PR DESCRIPTION
See discussion at https://github.com/plone/Products.CMFPlone/pull/1783

We had another [failing test on Jenkins 5.1](http://jenkins.plone.org/job/plone-5.1-python-2.7/1161/testReport/junit/Products.CMFPlone.tests.testSearch/TestSection/). Let's see if this fixes it.
