### PR TITLE
WorkflowTool: Include Inactive Content In Worklists

### DIFF
--- a/Products/CMFPlone/WorkflowTool.py
+++ b/Products/CMFPlone/WorkflowTool.py
@@ -228,6 +228,10 @@ class WorkflowTool(PloneBaseTool, BaseTool):
                     # content in *all* languages
                     if 'Language' not in catalog_vars:
                         catalog_vars['Language'] = 'all'
+                    # Include inactive content in result list. This is
+                    # especially important for content scheduled to go public
+                    # in the future, but needs to be reviewed before this.
+                    catalog_vars['show_inactive'] = True
                     for result in catalog.searchResults(catalog_vars):
                         o = result.getObject()
                         if o \

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -32,6 +32,7 @@ Bug fixes:
 
 - Apply security hotfix 20160830 for ``isURLInPortal``.  [maurits]
 
+- Include inactive content in worklists.  [sebasgo]
 
 4.3.11 (2016-08-15)
 -------------------


### PR DESCRIPTION
`WorkflowTool.getWorklistsResults` uses the catalog to gather its results.
By default the catalog tool excludes inactive content from the search
results if the current user lacks the permission to view inactive
content in the current context. This can result in incomplete results,
since the method is supposed to return the work list results for the
whole site.

This commit bypasses the the catalog's inactive content filter.