### PR TITLE
fix plone-compile-resources (overrides, barcelonetaPath)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,11 @@ Bug fixes:
 - Cleanup code of resource registry.
   [jensens]
 
+- Fix plone-compile-resources: 
+  Toolbar variable override only possible if prior defined.
+  Define ``barcelonetaPath`` if ``plonetheme.barceloneta`` is available (but not necessarily installed).
+  [jensens]
+
 5.1a2 (2016-08-19)
 ------------------
 

--- a/Products/CMFPlone/_scripts/_generate_gruntfile.py
+++ b/Products/CMFPlone/_scripts/_generate_gruntfile.py
@@ -14,7 +14,17 @@ from zope.site.hooks import setSite
 
 import json
 import os
+import pkg_resources
 import uuid
+
+
+try:
+    pkg_resources.get_distribution('plonetheme.barceloneta')
+except pkg_resources.DistributionNotFound:
+    HAS_BARCELONETA = False
+else:
+    HAS_BARCELONETA = True
+    import plonetheme.barceloneta
 
 # some initial script setup
 if 'SITE_ID' in os.environ:
@@ -82,11 +92,11 @@ module.exports = function(grunt) {{
 """
 
 SED_CONFIG_TEMPLATE = """
-    {name}: {{
-      path: "{path}",
-      pattern: "{pattern}",
-      replacement: "{destination}",
-    }},
+            {name}: {{
+              path: "{path}",
+              pattern: "{pattern}",
+              replacement: "{destination}",
+            }},
 """
 
 REQUIREJS_CONFIG_TEMPLATE = """
@@ -249,6 +259,11 @@ modify_vars['isMockup'] = 'false'
 modify_vars['staticPath'] = '\'' + os.path.join(
     os.path.dirname(CMFPlone.__file__),
     'static') + '\''
+if HAS_BARCELONETA:
+    modify_vars['barcelonetaPath'] = os.path.join(
+        os.path.dirname(plonetheme.barceloneta.__file__),
+        'theme',
+    )
 
 less_vars_params = {
     'site_url': 'LOCAL',
@@ -323,7 +338,7 @@ for name, value in resources.items():
             if '/'.join(local_file.split('/')[:-1]) not in less_paths:
                 less_paths.append('/'.join(local_file.split('/')[:-1]))
         else:
-            print "No file found: " + css
+            print 'No file found: ' + css
 
 # BUNDLE LOOP
 
@@ -386,7 +401,7 @@ for bkey, bundle in bundles.items():
                             rjs_paths[stub] = 'empty:'
                     rc = REQUIREJS_CONFIG_TEMPLATE.format(
                         bkey=resource,
-                        paths=json.dumps(rjs_paths),
+                        paths=json.dumps(rjs_paths, indent=22, sort_keys=True),
                         shims=json.dumps(shims),
                         name=main_js_path,
                         out=target_path + '/' + resource + '-compiled.js'
@@ -443,7 +458,7 @@ for bkey, bundle in bundles.items():
         if less_files:
             less_cfgs_final.append(LESS_CONFIG_TEMPLATE.format(
                 name=bkey,
-                files=json.dumps(less_files),
+                files=json.dumps(less_files, indent=16),
                 sourcemap_url=sourceMap_url,
                 base_path=os.getcwd()))
 

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -1,5 +1,8 @@
 //*// TOOLBAR EDIT ZONE PLONE //*//
 
+// might get overridden later by plone registry stored variables!
+@import url("variables.less");
+
 #edit-zone {
   font-family: @plone-toolbar-font-primary;
   font-weight: 400;


### PR DESCRIPTION
- Toolbar variable override only possible if prior defined.
- Define ``barcelonetaPath`` if ``plonetheme.barceloneta`` is available (but not necessarily installed).

Now ``plone-compile-resources`` again builds all less.