### PR TITLE
WorkflowTool: Include Inactive Content In Worklists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,8 @@ Bug fixes:
   Define ``barcelonetaPath`` if ``plonetheme.barceloneta`` is available (but not necessarily installed).
   [jensens]
 
+- Include inactive content in worklists.  [sebasgo]
+
 5.1a2 (2016-08-19)
 ------------------
 

--- a/Products/CMFPlone/WorkflowTool.py
+++ b/Products/CMFPlone/WorkflowTool.py
@@ -232,6 +232,10 @@ class WorkflowTool(PloneBaseTool, BaseTool):
                     # content in *all* languages
                     if 'Language' not in catalog_vars:
                         catalog_vars['Language'] = 'all'
+                    # Include inactive content in result list. This is
+                    # especially important for content scheduled to go public
+                    # in the future, but needs to be reviewed before this.
+                    catalog_vars['show_inactive'] = True
                     for result in catalog.searchResults(catalog_vars):
                         o = result.getObject()
                         if o \


### PR DESCRIPTION
WorkflowTool.getWorklistsResults uses the catalog to gather its results.
By default the catalog tool excludes inactive content from the search
results if the current user lacks the permission to view inactive
content in the current context. This can result in incomplete results,
since the method is supposed to return the work list results for the
whole site.

This commit bypasses the the catalog's inactive content filter.