### PR TITLE
Don't minify already minified resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Breaking changes:
 
 New features:
 
+- Don't minify CSS or JavaScript resources if they end with ``.min.css`` resp. ``.min.js``.
+  [thet]
+
 - Add ``safe_encode`` utility function to ``utils`` to safely encode unicode to a specified encoding.
   The encoding defaults to ``utf-8``.
   [thet]

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -60,8 +60,7 @@ class ScriptsView(ResourceView):
             ) and
             bundle.resources
         ):
-            # Its a legacy css bundle OR compiling is happening outside of
-            # plone
+            # Its a legacy bundle OR compiling is happening outside of plone
 
             # We need to combine files. It's possible no resources are
             # defined because the compiling is done outside of plone


### PR DESCRIPTION
Don't minify CSS or JavaScript resources if they end with .min.css resp. .min.js.

I think it's safe to assume, that resources with the ending .min.css or .min.js are already minified. There is no need to minify them again. Also, this could be a way to add resources, which cannot be successfully minified, like AngularJS.

Speaking of Angular 1.5.x, slimit minifies the expression
``(0).constructor;`` to ``0.constructor;``, which is nonsense and leads to runtime errors.
So this is a way to include the already minified version of AngularJS without getting this minification error.