### PR TITLE
[Backport] contact-info form: do not encode reply-to address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Bug fixes:
 - Fix atom.xml feed not paying attention for setting to show about information
   [vangheem]
 
+- Do not encode reply-to email address for contact-info form
+  [tkimnguyen]
 
 5.0.6 (2016-09-23)
 ------------------

--- a/Products/CMFPlone/browser/contact_info.py
+++ b/Products/CMFPlone/browser/contact_info.py
@@ -68,7 +68,7 @@ class ContactForm(form.Form):
         data['url'] = portal.absolute_url()
         message = self.generate_mail(data, encoding)
         message = MIMEText(message, 'plain', encoding)
-        message['Reply-To'] = Header(data['sender_from_address'], encoding)
+        message['Reply-To'] = data['sender_from_address']
 
         try:
             # This actually sends out the mail


### PR DESCRIPTION
Backport fix from 5.1 branch.