### PR TITLE
Added `ok` view.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,11 @@ Breaking changes:
 
 New features:
 
+- Added ``ok`` view.  This is useful for automated checks, for example
+  httpok, to see if the site is still available.  It returns the text
+  ``OK`` and sets headers to avoid caching.
+  [maurits]
+
 - Make contact form extensible. This fixes https://github.com/plone/Products.CMFPlone/issues/1879.
   [timo]
 

--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -165,6 +165,13 @@
       permission="zope.Public"
       />
 
+  <browser:page
+      for="*"
+      name="ok"
+      class=".okay.OK"
+      permission="zope.Public"
+      />
+
   <!-- Useful for cross domain iframe proxying -->
   <browser:resource
       file="static/blank.html"

--- a/Products/CMFPlone/browser/okay.py
+++ b/Products/CMFPlone/browser/okay.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from Products.Five.browser import BrowserView
+
+
+class OK(BrowserView):
+    """Returns OK.
+
+    Useful for automated checks, for example httpok, to see if the site
+    is still available.  For this you don't want to query a possibly
+    expensive page.  And you don't want to query anything that may be
+    stored in an intermediate caching server.
+
+    Calling /ZopeTime can work too.  But if you use
+    experimental.publishtraverse, this will either give you a NotFound,
+    or log a warning each time it is called, due to lacking
+    permissions.  And this may happen in core Plone in the future too.
+    """
+
+    def __call__(self):
+        # Make really sure this response is not cached.  This is what
+        # plone/app/caching/operations/utils.py does in the doNotCache
+        # function.
+        set_header = self.request.response.setHeader
+        set_header('Expires', 'Sat, 1 Jan 2000 00:00:00 GMT')
+        set_header('Cache-Control', 'max-age=0, must-revalidate, private')
+        # Return a short and simple message.
+        return u'OK'

--- a/Products/CMFPlone/tests/test_okay.py
+++ b/Products/CMFPlone/tests/test_okay.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from plone.testing.z2 import Browser
+from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+
+import unittest
+
+
+class OkayTest(unittest.TestCase):
+    """Test the OK simple status view."""
+
+    layer = PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+
+    def test_okay_browser(self):
+        browser = Browser(self.app)
+        app_url = self.app.absolute_url()
+        portal_url = self.portal.absolute_url()
+        # Try a couple of urls that should return the same.
+        urls = (
+            app_url + '/@@ok',
+            app_url + '/ok?hello=1',
+            portal_url + '/@@ok',
+            portal_url + '/ok?hello=1',
+        )
+        for url in urls:
+            browser.open(url)
+            self.assertEqual(browser.contents, u'OK')
+            get_header = browser.headers.getheader
+            self.assertEqual(
+                get_header('Expires'), 'Sat, 1 Jan 2000 00:00:00 GMT')
+            self.assertEqual(
+                get_header('Cache-Control'),
+                'max-age=0, must-revalidate, private')
+            # Getting it with a browser gives some more headings than accessing
+            # the view directly.
+            self.assertEqual(get_header('content-length'), '2')
+            # content-type has a charset, but we don't really care about that.
+            self.assertTrue(
+                get_header('content-type').startswith('text/plain'))
+
+    def test_okay_view(self):
+        for page in (self.app, self.portal):
+            view = page.restrictedTraverse('@@ok')
+            self.assertEqual(view(), u'OK')
+            get_header = view.request.response.getHeader
+            self.assertEqual(
+                get_header('Expires'), 'Sat, 1 Jan 2000 00:00:00 GMT')
+            self.assertEqual(
+                get_header('Cache-Control'),
+                'max-age=0, must-revalidate, private')


### PR DESCRIPTION
This is useful for automated checks, for example `httpok`, to see if the site is still available.  It returns the text `OK` and sets headers to avoid caching.

Calling `/ZopeTime` can work too, which is what I currently do as a simple status check, instead of calling the homepage, which could be expensive or could get a cached response even when the Plone Site is down.  But if you use `experimental.publishtraverse`, this will either give you a `NotFound` error, or log a warning each time it is called, due to lacking permissions.  And this may happen in core Plone in the future too.

If this is accepted: would this be acceptable for 5.0 and 4.3 too?