### PR TITLE
Use correct assertion methods in sitelogo tests.

### DIFF
--- a/Products/CMFPlone/tests/test_sitelogo.py
+++ b/Products/CMFPlone/tests/test_sitelogo.py
@@ -28,12 +28,12 @@ class SiteLogoFunctionalTest(unittest.TestCase):
         settings = registry.forInterface(ISiteSchema, prefix='plone')
         settings.site_logo = SITE_LOGO_BASE64
         view = self.portal.restrictedTraverse('@@site-logo')
-        self.assertTrue(view(), SITE_LOGO_HEX)
+        self.assertEqual(view(), SITE_LOGO_HEX)
         view.request.response
         headers = view.request.response
-        self.assertTrue(headers['content-type'], 'image/png')
-        self.assertTrue(headers['content-length'], '69')
-        self.assertTrue(
+        self.assertEqual(headers['content-type'], 'image/png')
+        self.assertEqual(headers['content-length'], '69')
+        self.assertEqual(
             headers['content-disposition'],
             "attachment; filename*=UTF-8''pixel.png"
         )


### PR DESCRIPTION
We were using assertTrue where assertEqual was obviously meant.

I didn't include a changelog entry, because that is irrelevant here I would say.