### PR TITLE
test_controlpanel_social.robot: sleep before clicking save.

### DIFF
--- a/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
@@ -42,6 +42,7 @@ the social control panel
 
 I disable social
   UnSelect Checkbox  form.widgets.share_social_data:list
+  Sleep  2
   Click Button  Save
   Wait until page contains  Changes saved
 
@@ -49,6 +50,7 @@ I provide social settings
   Input Text  name=form.widgets.twitter_username  plonecms
   Input Text  name=form.widgets.facebook_app_id  123456
   Input Text  name=form.widgets.facebook_username  plonecms
+  Sleep  2
   Click Button  Save
   Wait until page contains  Changes saved
 


### PR DESCRIPTION
The two tests in here are unstable.  Let's see if this fixes it.
See https://github.com/plone/buildout.coredev/commit/2f8b37c314a3c33fffddbe6f5bc8760dd15a3927

It fails at `Wait Until Page Contains Changes saved`, after `Click Button Save`.
I wonder if the Save button is hidden behind an autocomplete suggestion so it is not clickable. But the robot does not complain about the click itself.
The screen shot from Jenkins indicates no problem, though it indeed does not contain `Changes saved`.

![robot_test_controlpanel_social_scenario_social_settings_are_provided_selenium-screenshot-1](https://cloud.githubusercontent.com/assets/210587/21933631/6e65b3e2-d9a6-11e6-87d9-f8b8cf6940ba.png)

Changelog entry intentionally not provided.
The Jenkins pull request tests may need to pass a couple of times before we merge.  *If* it helps...