### PR TITLE
fix wrong portal_url in TinyMCE in multilingual sites. Refs #1513

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ New features:
 
 Bug fixes:
 
+- Fix wrong TinyMCE configuration for multilingual sites [erral]
+
 - Added security checks for ``str.format``.  Part of PloneHotfix20170117.  [maurits]
 
 - Load some patches earlier, instead of in our initialize method.  [maurits]

--- a/Products/CMFPlone/patterns/__init__.py
+++ b/Products/CMFPlone/patterns/__init__.py
@@ -26,7 +26,7 @@ class TinyMCESettingsGenerator(object):
         registry = getUtility(IRegistry)
         self.settings = registry.forInterface(
             ITinyMCESchema, prefix="plone", check=False)
-        self.portal_url = get_portal_url(self.portal)
+        self.portal_url = get_portal_url(self.context)
 
     def get_theme(self):
         return theming_policy().get_theme()


### PR DESCRIPTION
This pull request fixes the #1513 issue for Plone 5.0.x. The fix is already included for 5.1 but was not ported to 5.0.x