### PR TITLE
Fixed SafeFormatter import in mixins.py. [5.1]

### DIFF
--- a/Products/CMFPlone/__init__.py
+++ b/Products/CMFPlone/__init__.py
@@ -118,14 +118,14 @@ def initialize(context):
 
     # We want to allow all methods on string type except 'format'.
     # That one needs special handling to avoid access to attributes.
-    from Products.CMFPlone.utils import safe_format
+    from Products.CMFPlone.utils import _safe_format
     rules = dict([(m, True) for m in dir(str) if not m.startswith('_')])
-    rules['format'] = safe_format
+    rules['format'] = _safe_format
     allow_type(str, rules)
 
     # Same for unicode instead of str.
     rules = dict([(m, True) for m in dir(unicode) if not m.startswith('_')])
-    rules['format'] = safe_format
+    rules['format'] = _safe_format
     allow_type(unicode, rules)
 
     # Apply monkey patches

--- a/Products/CMFPlone/resources/browser/mixins.py
+++ b/Products/CMFPlone/resources/browser/mixins.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces import IResourceRegistry
-from Products.CMFPlone.utils import safe_format
 from Products.CMFPlone.utils import SafeFormatter
 from Products.Five.browser import BrowserView
 from urlparse import urlparse

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -847,8 +847,10 @@ class SafeFormatter(string.Formatter):
         return self.vformat(self.value, args, kwargs)
 
 
-def safe_format(inst, method):
-    """
-    Use our SafeFormatter that uses guarded_getattr for attribute access
+def _safe_format(inst, method):
+    """Use our SafeFormatter that uses guarded_getattr for attribute access.
+
+    This is for use with AccessControl.allow_type,
+    as we do in CMFPlone/__init__.py.
     """
     return SafeFormatter(inst).safe_format


### PR DESCRIPTION
Clarified safe_format, which is renamed to _safe_format to discourage importing it outside CMFPlone.

Same as #1944 but now for 5.1.