### PR TITLE
Load patterns when using AJAX/iframe, improve AJAX template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,7 @@ New features:
 
 Bug fixes:
 
+- Include JS Patterns when loading a page via ajax or an iframe [displacedaussie]
 
 - Restore ability to include head when loading via ajax [displacedaussie]
 

--- a/Products/CMFPlone/browser/templates/ajax_main_template.pt
+++ b/Products/CMFPlone/browser/templates/ajax_main_template.pt
@@ -2,6 +2,9 @@
 <tal:doctype tal:replace="structure string:&lt;!DOCTYPE html&gt;" />
 
 <html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
     tal:define="portal_state context/@@plone_portal_state;
         context_state context/@@plone_context_state;
         plone_view context/@@plone;
@@ -46,10 +49,14 @@
                   sr python:plone_layout.have_portlets('plone.rightcolumn', view);
                   body_class python:plone_layout.bodyClass(template, view);"
     tal:attributes="class string: ${body_class} ajax_load;
-                    dir python:isRTL and 'rtl' or 'ltr'">
+                    dir python:isRTL and 'rtl' or 'ltr';
+                    python:plone_view.patterns_settings()"
+    id="visual-portal-wrapper">
+
+    <header id="portal-top" i18n:domain="plone"/>
 
     <aside id="global_statusmessage">
-      <tal:message tal:content="provider:plone.globalstatusmessage"/>
+      <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
       <div metal:define-slot="global_statusmessage">
       </div>
     </aside>

--- a/Products/CMFPlone/static/plone.js
+++ b/Products/CMFPlone/static/plone.js
@@ -45,7 +45,8 @@ require([
   'use strict';
 
   // initialize only if we are in top frame
-  if (window.parent === window) {
+  if ((window.parent === window) ||
+      (window.frameElement.nodeName === 'IFRAME')) {
     $(document).ready(function() {
       $('body').addClass('pat-plone');
       if (!registry.initialized) {


### PR DESCRIPTION
This pull request follows on from https://github.com/plone/Products.CMFPlone/pull/1792/ which restored the ability to include the `<head>` block when loading a page via AJAX.

The following issues are fixed with this change:

 * JS Patterns are now loaded when a page is loaded via AJAX
 * JS Patterns are now loaded when a page is loaded in an iframe
 * The `<header>` tag is now included in the AJAX template
 * The `visual_portal_wrapper` id is now included in the AJAX template
 * `structure` is now used when loading global status messages (as in main_template.pt)
