### PR TITLE
Moved getToolByName early patch to the later patches.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,12 @@ New features:
 
 Bug fixes:
 
+
+- Moved getToolByName early patch to the later patches.
+  This fixes a circular import.
+  See `issue #1950 <https://github.com/plone/Products.CMFPlone/issues/1950>`_.
+  [maurits]
+
 - Include JS Patterns when loading a page via ajax or an iframe [displacedaussie]
 
 - Restore ability to include head when loading via ajax [displacedaussie]

--- a/Products/CMFPlone/earlypatches/security.py
+++ b/Products/CMFPlone/earlypatches/security.py
@@ -49,44 +49,7 @@ def require(self, *args, **kw):
 ClassDirective.require = require
 
 # 5. Check return value of getToolByName
-# This is an unusual sort of monkey patching...we replace just the func_code
-# rather than the entire function, to make sure that aliases to the function
-# that were imported prior to this patch will still run the patched code.
-code = """
-from persistent.interfaces import IPersistent
-from OFS.interfaces import IItem
-try:
-    from Products.ATContentTypes.tool.factory import FauxArchetypeTool
-except ImportError:
-    FauxArchetypeTool = type('FauxArchetypeTool')
-
-def _getToolByName(self, name, default=_marker):
-    pass
-
-def check_getToolByName(obj, name, default=_marker):
-    result = _getToolByName(obj, name, default)
-    if IPersistent.providedBy(result) or \
-            IItem.providedBy(result) or \
-            name in _tool_interface_registry or \
-            (isinstance(result, FauxArchetypeTool)) or \
-            '.test' in result.__class__.__module__ or \
-            result.__class__.__module__ == 'mock' or \
-            result is _marker or \
-            result is default:
-        return result
-    else:
-        raise TypeError("Object found is not a portal tool (%s)" % (name,))
-    return result
-"""
-from Products.CMFCore import utils
-if '_marker' not in utils.getToolByName.func_globals:
-    raise Exception("This Version of Products.CMFPlone is not compatible "
-                    "with Products.PloneHotfix20121106, the fixes are "
-                    "included already in Products.CMFPlone, please remove "
-                    "the hotfix")
-exec code in utils.getToolByName.func_globals
-utils._getToolByName.func_code = utils.getToolByName.func_code
-utils.getToolByName.func_code = utils.check_getToolByName.func_code
+# Moved to patches/gtbn.py due to circular imports.
 
 # 6. Protect some methods in ZCatalog
 from Products.ZCatalog.ZCatalog import ZCatalog

--- a/Products/CMFPlone/patches/__init__.py
+++ b/Products/CMFPlone/patches/__init__.py
@@ -27,3 +27,5 @@ import templatecookcheck        # Make sure templates aren't re-read in
 import publishing
 
 import z3c_form
+
+import gtbn

--- a/Products/CMFPlone/patches/gtbn.py
+++ b/Products/CMFPlone/patches/gtbn.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore import utils
+
+# Check return value of getToolByName
+# this used to be step 5 in earlypatches, but was moved to avoid
+# circular imports.
+# This is an unusual sort of monkey patching...we replace just the func_code
+# rather than the entire function, to make sure that aliases to the function
+# that were imported prior to this patch will still run the patched code.
+code = """
+from persistent.interfaces import IPersistent
+from OFS.interfaces import IItem
+try:
+    from Products.ATContentTypes.tool.factory import FauxArchetypeTool
+except ImportError:
+    FauxArchetypeTool = type('FauxArchetypeTool')
+
+def _getToolByName(self, name, default=_marker):
+    pass
+
+def check_getToolByName(obj, name, default=_marker):
+    result = _getToolByName(obj, name, default)
+    if IPersistent.providedBy(result) or \
+            IItem.providedBy(result) or \
+            name in _tool_interface_registry or \
+            (isinstance(result, FauxArchetypeTool)) or \
+            '.test' in result.__class__.__module__ or \
+            result.__class__.__module__ == 'mock' or \
+            result is _marker or \
+            result is default:
+        return result
+    else:
+        raise TypeError("Object found is not a portal tool (%s)" % (name,))
+    return result
+"""
+if '_marker' not in utils.getToolByName.func_globals:
+    raise Exception("This Version of Products.CMFPlone is not compatible "
+                    "with Products.PloneHotfix20121106, the fixes are "
+                    "included already in Products.CMFPlone, please remove "
+                    "the hotfix")
+exec code in utils.getToolByName.func_globals
+utils._getToolByName.func_code = utils.getToolByName.func_code
+utils.getToolByName.func_code = utils.check_getToolByName.func_code


### PR DESCRIPTION
This fixes a circular import.
See #1950.