### PR TITLE
AccessInactivePortalContent in catalog queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Check for ``AccessInactivePortalContent`` for each path in a catalog query.
+  This solves a problem, where Editors couldn't see inactive content, even though they had the required permission on a subpath of the portal (e.g. a subsite).
+  [thet]
+  
+  *add item here*
 
 
 5.1b2 (2017-02-20)


### PR DESCRIPTION
Checked for ``AccessInactivePortalContent`` for each path in a catalog query.
This solves a problem, where Editors couldn't see inactive content, even though they had the required permission on a subpath of the portal (e.g. a subsite).