### PR TITLE
Fixed NotFound error when adding controlpanel action through the ZMI. [4.3]

### DIFF
--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -227,7 +227,12 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
                   description='',
                   REQUEST=None,
                   ):
-        # Add an action to our list.
+        """Add an action to our list.
+
+        Note: the form in the ZMI points to this when adding an action,
+        so it must be available at the addAction url,
+        so it must have a docstring.
+        """
         if not name:
             raise ValueError('A name is required.')
 

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -72,9 +72,15 @@ class TestAttackVectorsFunctional(ptc.FunctionalTestCase):
         self.assertEqual(404, res.status)
 
     def test_registerConfiglet_1(self):
+        # A permission check was missing, fixed in PloneHotfix20121106.
         VECTOR = "/plone/portal_controlpanel/registerConfiglet?id=cake&name=Cakey&action=woo&permission=View&icon_expr="
         res = self.publish(VECTOR)
-        self.assertEqual(404, res.status)
+        # The docstring for addAction, which is an alias of registerConfiglet,
+        # was removed, resulting in a 404.  But that is wrong, because it
+        # means that you cannot add an action/configlet in the ZMI.
+        # So we want a 302 instead, redirecting to the login form.
+        # See https://github.com/plone/Products.CMFPlone/issues/1959
+        self.assertEqual(302, res.status)
 
     def test_registerConfiglet_2(self):
         VECTOR = "/plone/portal_controlpanel/registerConfiglet?id=cake&name=Cakey&action=woo&permission=View&icon_expr="

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -9,7 +9,9 @@ Changelog
 4.3.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed ``NotFound`` error when adding controlpanel action through the ZMI.
+  See `issue 1959 <https://github.com/plone/Products.CMFPlone/issues/1959>`_.
+  [maurits]
 
 
 4.3.12 (2017-02-20)


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/1959.