### PR TITLE
Show version of products in Add-ons control panel configlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ New features:
 
 Bug fixes:
 
+- Show version of products in Add-ons control panel configlet.
+  This fixes https://github.com/plone/Products.CMFPlone/issues/1472.
+  [hvelarde]
+
 - Resource registry legacy bundle cooking: Exit early with a warning, if preconditions to build are not given (no compilation paths).
   Allow cooking CSS, even if no JS is defined.
   Log all important steps of the cooking process.

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -64,7 +64,7 @@
                 </h3>
                 <p class="configletDescription discreet">
                   <tal:span tal:condition="product/description" tal:content="product/description" i18n:translate="">add-on description</tal:span>
-                  <em class="discreet"> – (<tal:span tal:content="string:${pid}"> plugin.app.name </tal:span>)</em>
+                  <em class="discreet"> – (<span tal:replace="pid">plugin.app.name</span> <span tal:replace="product/version">1.0</span>)</em>
                 </p>
                 <ul class="configletDetails">
                   <li tal:define="upgrade_info product/upgrade_info">
@@ -144,7 +144,7 @@
                   <tal:span tal:condition="product/description"
                     i18n:translate=""
                     tal:content="product/description">add-on description</tal:span>
-                  <em class="discreet"> – (<tal:span tal:content="string:${pid}"> plugin.app.name </tal:span>)</em>
+                  <em class="discreet"> – (<span tal:replace="pid">plugin.app.name</span> <span tal:replace="product/version">1.0</span>)</em>
                 </p>
                 <dl class="portalMessage warning"
                    tal:condition="not:product/uninstall_profile">
@@ -185,7 +185,7 @@
                       <tal:span tal:condition="product/description"
                         i18n:translate=""
                         tal:content="product/description">add-on description</tal:span>
-                      <em class="discreet"> – (<tal:span tal:content="string:${pid}"> plugin.app.name </tal:span>)</em>
+                      <em class="discreet"> – (<span tal:replace="pid">plugin.app.name</span> <span tal:replace="product/version">1.0</span>)</em>
                     </p>
                     <dl class="portalMessage info"
                         tal:condition="not:product/uninstall_profile">

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.py
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.py
@@ -556,6 +556,7 @@ class ManageProductsView(InstallerView):
                     continue
                 addons[product_id] = {
                     'id': product_id,
+                    'version': self.get_product_version(product_id),
                     'title': product_id,
                     'description': '',
                     'upgrade_profiles': {},


### PR DESCRIPTION
Fixes #1472 

Looks like this now:

![screen shot 2017-03-08 at 16 52 39](https://cloud.githubusercontent.com/assets/341393/23721226/dd7cc308-041f-11e7-8d38-871c7421d6bb.png)
