### PR TITLE
Fix social media schema field types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ New features:
 
 Bug fixes:
 
+- Fix social media schema field types of ``twitter_username``, ``facebook_app_id`` and ``facebook_username`` to be ``ASCIILine`` instead of ``TextLine``.
+  [hvelarde]
+
 - Show version of products in Add-ons control panel configlet.
   This fixes https://github.com/plone/Products.CMFPlone/issues/1472.
   [hvelarde]

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -1466,24 +1466,24 @@ class ISocialMediaSchema(Interface):
                       u'when shared'),
         default=True)
 
-    twitter_username = schema.TextLine(
+    twitter_username = schema.ASCIILine(
         title=_(u'Twitter Username'),
         description=_(u'To identify things like Twitter Cards. Do not include the \'@\' prefix character.'),
         required=False,
-        default=u'')
+        default='')
 
-    facebook_app_id = schema.TextLine(
+    facebook_app_id = schema.ASCIILine(
         title=_(u'Facebook App ID'),
         description=_(
             u'To be used with some integrations like Open Graph data'),
         required=False,
-        default=u'')
+        default='')
 
-    facebook_username = schema.TextLine(
+    facebook_username = schema.ASCIILine(
         title=_(u'Facebook username'),
         description=_(u'For linking Open Graph data to a Facebook account'),
         required=False,
-        default=u'')
+        default='')
 
 
 class IImagingSchema(Interface):


### PR DESCRIPTION
`twitter_username`, `facebook_app_id` and `facebook_username` should be `ASCIILine` instead of `TextLine`.

refs. https://github.com/plone/plone.app.upgrade/pull/107
refs. https://github.com/plone/plone.app.layout/pull/121