### PR TITLE
Fixed inline validation for Archetypes content. [4.3]

### DIFF
--- a/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
@@ -29,6 +29,8 @@ jQuery(function ($) {
             $field = $input.closest('.field'),
             uid = $field.attr('data-uid'),
             fname = $field.attr('data-fieldname'),
+            url = '',
+            index = -1,
             value = $input.val();
 
         // value is null for empty multiSelection select, turn it into a [] instead
@@ -42,7 +44,14 @@ jQuery(function ($) {
         params = $.param({uid: uid, fname: fname, value: value}, traditional = true);
 
         if ($field && uid && fname) {
-            $.post($('base').attr('href') + '/at_validate_field', params, function (data) {
+            url = $('base').attr('href');
+            index = url.lastIndexOf('/');
+            if (index > -1 && url.lastIndexOf('edit') > index) {
+                // The url is for an edit page, so we strip the last part,
+                // otherwise we wrongly get context-url/edit/at_validate_field.
+                url = url.slice(0, index);
+            }
+            $.post(url + '/at_validate_field', params, function (data) {
                 render_error($field, data.errmsg);
             });
         }

--- a/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
+++ b/Products/CMFPlone/skins/plone_ecmascript/inline_validation.js
@@ -29,6 +29,7 @@ jQuery(function ($) {
             $field = $input.closest('.field'),
             uid = $field.attr('data-uid'),
             fname = $field.attr('data-fieldname'),
+            $form = $field.closest('form'),
             url = '',
             index = -1,
             value = $input.val();
@@ -44,14 +45,21 @@ jQuery(function ($) {
         params = $.param({uid: uid, fname: fname, value: value}, traditional = true);
 
         if ($field && uid && fname) {
-            url = $('base').attr('href');
+            url = $form.attr('action');
             index = url.lastIndexOf('/');
             if (index > -1 && url.lastIndexOf('edit') > index) {
                 // The url is for an edit page, so we strip the last part,
                 // otherwise we wrongly get context-url/edit/at_validate_field.
+                // 'edit' can be 'atct_edit' too.
                 url = url.slice(0, index);
             }
             $.post(url + '/at_validate_field', params, function (data) {
+                if (data.errmsg === undefined) {
+                  // If we ask at the wrong url, like edit/at_validate_field,
+                  // we get the html of the edit page back.
+                  // It is best not to do anything then.
+                  return;
+                };
                 render_error($field, data.errmsg);
             });
         }

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,7 +19,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed inline validation for Archetypes content.
+  Every field was shown as having an error, without showing an error message.
+  Fixes `issue 1982 <https://github.com/plone/Products.CMFPlone/issues/1982>`_.
+  [maurits]
 
 
 4.3.13 (2017-03-27)


### PR DESCRIPTION
Every field was shown as having an error, without showing an error message.
Fixes https://github.com/plone/Products.CMFPlone/issues/1982

The wrong behavior was a side effect of the base tag changes in Plone 4.3.12.

Notes:
- dexterity is not affected, because it uses z3c form inline validation
- I did not see errors when viewing PloneFormGen forms, it does not have the `blurrable` class that would be needed for inline validation to kick in.