### PR TITLE
Use canonical url instead of absolute url for RSS feed items.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,12 @@ New features:
 
 Bug fixes:
 
+- Use canonical url instead of absolute url for RSS feed items.
+  This code is used for the social viewlet too.
+  So default pages are reported with their parent url.
+  Fixes `layout issue 118 <https://github.com/plone/plone.app.layout/issues/118>`_.
+  [maurits]
+
 - Fix social media schema field types of ``twitter_username``, ``facebook_app_id`` and ``facebook_username`` to be ``ASCIILine`` instead of ``TextLine``.
   [hvelarde]
 

--- a/Products/CMFPlone/browser/syndication/adapters.py
+++ b/Products/CMFPlone/browser/syndication/adapters.py
@@ -3,6 +3,7 @@ from zope.component.hooks import getSite
 from zope.component import adapts
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.component import getUtility
 
@@ -54,11 +55,17 @@ class BaseFeedData(object):
 
     @property
     def link(self):
-        return self.base_url
+        return self.canonical_url
 
     @lazy_property
     def base_url(self):
         return self.context.absolute_url()
+
+    @lazy_property
+    def canonical_url(self):
+        pcs = getMultiAdapter(
+            (self.context, self.context.REQUEST), name='plone_context_state')
+        return pcs.canonical_object_url()
 
     @property
     def title(self):
@@ -241,6 +248,8 @@ class BaseItem(BaseFeedData):
         url = self.base_url
         if self.context.portal_type in self.feed.view_action_types:
             url = url + '/view'
+        else:
+            url = self.canonical_url
         return url
 
     guid = link

--- a/Products/CMFPlone/tests/testSyndication.py
+++ b/Products/CMFPlone/tests/testSyndication.py
@@ -167,6 +167,14 @@ class TestSyndicationFeedAdapter(BaseSyndicationTest):
         self.assertEqual(self.feeddatafile.link,
                          self.file.absolute_url() + '/view')
 
+    def test_link_on_document(self):
+        self.assertEqual(self.feeddatadoc.link, self.doc1.absolute_url())
+
+    def test_link_on_default_page(self):
+        self.folder._setProperty('default_page', 'doc2')
+        feeddatadoc2 = BaseItem(self.doc2, self.feed)
+        self.assertEqual(feeddatadoc2.link, self.folder.absolute_url())
+
     def test_items(self):
         self.assertEqual(len(self.feed._brains()), 3)
         self.assertEqual(len([i for i in self.feed.items]), 3)


### PR DESCRIPTION
This code is used for the social viewlet too.
So default pages are reported with their parent url.

Fixes https://github.com/plone/plone.app.layout/issues/118

Sample output for the news aggregator collection RSS then becomes this:

```
$ curl http://localhost:8080/Plone/news/aggregator/RSS
<?xml version="1.0" encoding="utf-8" ?>
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
xmlns:dc="http://purl.org/dc/elements/1.1/" 
xmlns:syn="http://purl.org/rss/1.0/modules/syndication/" 
xmlns="http://purl.org/rss/1.0/">

<channel rdf:about="http://localhost:8080/Plone/news/aggregator/RSS">
  <title>Nieuws</title>
  <link>http://localhost:8080/Plone/news</link>
  <description>Nieuwsberichten op deze website.</description>
  <image rdf:resource="http://localhost:8080/Plone/logo.png" />

  <items>
    <rdf:Seq>
      
        <rdf:li rdf:resource="http://localhost:8080/Plone/news/nieuws-1" />
      
    </rdf:Seq>
  </items>

</channel>

  <item rdf:about="http://localhost:8080/Plone/news/nieuws-1">
    ...
  </item>

</rdf:RDF>
```

Otherwise the link would have been `<link>http://localhost:8080/Plone/news/aggregator</link>`.

For the social viewlet, it results in a tag like:
```
<meta content="https://zestsoftware.nl/" property="og:url" />
```

instead of the current

```
<meta content="https://zestsoftware.nl/home" property="og:url" />
```
