### PR TITLE
Fix issue where catalog search with path failed when path had inaccessible (private) levels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ New features:
 
 Bug fixes:
 
+- Fix issue where catalog search with path failed when path had inaccessible
+  (private) levels
+  [datakurre]
+
 - Add constraint to avoid filling ``twitter_username`` field with strings starting with a "@" character.
   [hvelarde]
   

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -409,7 +409,9 @@ class CatalogTool(PloneBaseTool, BaseTool):
         for path in list(paths):
             path = path.encode('utf-8')  # paths must not be unicode
             try:
-                objs.append(site.restrictedTraverse(path))
+                parts = path.split('/')
+                parent = site.unrestrictedTraverse('/'.join(parts[:-1]))
+                objs.append(parent.restrictedTraverse(parts[-1]))
             except (KeyError, AttributeError):
                 # When no object is found don't raise an error
                 pass


### PR DESCRIPTION
restrictedTraverse from the navigation root should be used with care, because there might be inaccessible levels for the current user between the root and target.

Please, see how catalog brains do their restricted getObject by doing unrestrictedTraverse to the parent of the target and then restrictedTraverse to the target: 

https://github.com/zopefoundation/Products.ZCatalog/blob/master/src/Products/ZCatalog/CatalogBrains.py#L66