### PR TITLE
Fix default value for "robotx.txt" to avoid issues with content containing "search" in the id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,9 +23,12 @@ New features:
 
 Bug fixes:
 
+- Fix default value for ``robots.txt`` to avoid issues with content containing "search" in the id.
+  [hvelarde]
+
 - Remove references to Products.CMFDefault on meta.zcml
   [gforcada]
-  
+
 - Adapt tests to render social metadata only if you are anonymous.
   [bsuttor]
 

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -39,7 +39,7 @@ Disallow: /*folder_factories$
 Disallow: /*folder_summary_view$
 Disallow: /*login_form$
 Disallow: /*mail_password_form$
-Disallow: /*search
+Disallow: /@@search
 Disallow: /*search_rss$
 Disallow: /*sendto_form$
 Disallow: /*summary_view$


### PR DESCRIPTION
fixes #1994 