### PR TITLE
Use HTML5 meta charset

### DIFF
--- a/Products/CMFPlone/browser/templates/main_template.pt
+++ b/Products/CMFPlone/browser/templates/main_template.pt
@@ -23,7 +23,7 @@
     <metal:cache tal:replace="structure provider:plone.httpheaders" />
 
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="UTF-8" />
 
     <div tal:replace="structure provider:plone.htmlhead" />
 


### PR DESCRIPTION
Using http-equiv is no longer the only way to specify the character set of an HTML document.