### PR TITLE
Fix expiration date when displaying in registered form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ New features:
 
 Bug fixes:
 
+- Fix expiration date when displaying in registered form.
+  [allusa]
+
 - Remove TinyMCE pattern options from the body, as these are always set on the richtext fields mimetype selector or - if not there - on the textfield itself.
   Refs: https://github.com/plone/Products.CMFPlone/pull/2059
   [thet]

--- a/Products/CMFPlone/skins/plone_login/registered.pt
+++ b/Products/CMFPlone/skins/plone_login/registered.pt
@@ -31,7 +31,7 @@
             <p tal:condition="not: enable_user_pwd_choice"
                tal:define="expire_length context/portal_password_reset/getExpirationTimeout;
                            toLocalizedTime nocall:context/@@plone/toLocalizedTime;
-                           expire_date python:toLocalizedTime(DateTime() + expire_length / 24.0, long_format=1)"
+                           expire_date python:toLocalizedTime(DateTime() + expire_length, long_format=1)"
                i18n:translate="description_password_reset_or_registered">
                 You will receive an e-mail shortly containing a URL that will allow you to
                 set your password. When you receive this e-mail, please follow the link to


### PR DESCRIPTION
After completing ``@@register`` without modal mode, a success message is displayed in web with a bad expiration date. This fixes the expiration date according to the expiration date that is sent by mail.