### PR TITLE
Fixed KeyError productname for broken add-on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ New features:
 
 Bug fixes:
 
+- Fixed KeyError ``productname`` when there is a broken add-on in the add-ons control panel.
+  Fixes `issue 2065 <https://github.com/plone/Products.CMFPlone/issues/2065>`_.
+  [maurits]
+
 - Fix ``test_tinymce.robot`` test to work with latest related items changes.
   [thet]
 

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -207,7 +207,7 @@
             <ul class="configlets">
               <li tal:repeat="product products">
                 <h3>
-                  <span tal:replace="product/productname" i18n:translate="">
+                  <span tal:replace="product/product_id" i18n:translate="">
                     Add-on Name
                   </span>
                 </h3>

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.py
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.py
@@ -617,7 +617,7 @@ class ManageProductsView(InstallerView):
         if apply_filter == 'broken':
             all_broken = self.errors.values()
             for broken in all_broken:
-                filtered[broken['productname']] = broken
+                filtered[broken['product_id']] = broken
         else:
             for product_id, addon in addons.items():
                 if product_name and addon['id'] != product_name:


### PR DESCRIPTION
In add-ons control panel in Plone 5.1 only.

Fixes https://github.com/plone/Products.CMFPlone/issues/2065.