### PR TITLE
Update links to https in tinymce-controlpanel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Bug fixes:
 - Fix empty DX add_forms if formlib is also installed thru addon dependencies
   [MrTango]
 
+- Update TinyMCE links (tinymce-controlpanel) to https
+  [svx]
 
 5.1b4 (2017-07-03)
 ------------------

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -545,7 +545,7 @@ class ITinyMCELayoutSchema(Interface):
             u'Enter a JSON-formatted style format configuration. '
             u'A format is for example the style that get applied when '
             u'you press the bold button inside the editor. '
-            u'See http://www.tinymce.com/wiki.php/Configuration:formats'),
+            u'See https://www.tinymce.com/wiki.php/Configuration:formats'),
         constraint=validate_json,
         default=json.dumps({
             'discreet': {'inline': 'span', 'classes': 'discreet'},
@@ -653,7 +653,7 @@ class ITinyMCEPluginSchema(Interface):
             'help_tinymce_templates',
             default=(
                 u'Enter the list of templates in json format '
-                u'http://www.tinymce.com/wiki.php/Plugin:template'
+                u'https://www.tinymce.com/wiki.php/Plugin:template'
             )
         ),
         required=False,

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -653,7 +653,7 @@ class ITinyMCEPluginSchema(Interface):
             'help_tinymce_templates',
             default=(
                 u'Enter the list of templates in json format '
-                u'https://www.tinymce.com/wiki.php/Plugin:template'
+                u'https://www.tinymce.com/docs/plugins/template/'
             )
         ),
         required=False,

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -545,7 +545,7 @@ class ITinyMCELayoutSchema(Interface):
             u'Enter a JSON-formatted style format configuration. '
             u'A format is for example the style that get applied when '
             u'you press the bold button inside the editor. '
-            u'See https://www.tinymce.com/wiki.php/Configuration:formats'),
+            u'See https://www.tinymce.com/docs/configure/content-formatting/#formats'),  # NOQA: E501
         constraint=validate_json,
         default=json.dumps({
             'discreet': {'inline': 'span', 'classes': 'discreet'},


### PR DESCRIPTION
This updates the links shown in the tinymce-controlpanel to https e.g:

```
 Enter the list of templates in json format https://www.tinymce.com/wiki.php/Plugin:template
```
