### PR TITLE
Supported 'remove' keyword for configlets in controlpanel.xml.

### DIFF
--- a/Products/CMFPlone/exportimport/controlpanel.py
+++ b/Products/CMFPlone/exportimport/controlpanel.py
@@ -113,6 +113,12 @@ class ControlPanelXMLAdapter(XMLAdapterBase):
                 domain = default_domain
 
             action_id = str(child.getAttribute('action_id'))
+            # Remove previous action with same id and category.
+            controlpanel.unregisterConfiglet(action_id)
+            remove = str(child.getAttribute('remove'))
+            if remove.lower() == 'true':
+                continue
+
             title = Message(str(child.getAttribute('title')), domain=domain)
             url_expr = str(child.getAttribute('url_expr'))
             condition_expr = str(child.getAttribute('condition_expr'))
@@ -136,9 +142,6 @@ class ControlPanelXMLAdapter(XMLAdapterBase):
                         break  # only one permission is allowed
                     if permission:
                         break
-
-            # Remove previous action with same id and category.
-            controlpanel.unregisterConfiglet(action_id)
 
             controlpanel.registerConfiglet(id=action_id,
                                            name=title,

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
 
 Bug fixes:
 
+- Support 'remove' keyword for configlets in controlpanel.xml.
+  [maurits]
+
 - Add data-base-url attribute in body tag.
   Closes `issue 2051 <https://github.com/plone/Products.CMFPlone/issues/2051>`_
   [rodfersou]


### PR DESCRIPTION
Backported from master, see https://github.com/plone/Products.CMFPlone/pull/1372

That was from earlier last year. I expected I had backported it sooner, but apparently not.