### PR TITLE
Fixed removing permissions when saving portal_controlpanel in ZMI. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ New features:
 
 Bug fixes:
 
+- Fixed accidentally removing permissions when saving the ``portal_controlpanel`` settings in the ZMI.
+  Fixes `issue 1376 <https://github.com/plone/Products.CMFPlone/issues/1376>`_.  [maurits]
+
 - Do not open links on a new tab as this is against basic usability guidelines.
   [hvelarde]
 

--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -195,7 +195,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             except ValueError:
                 visible = 0
 
-        if not isinstance(permissions, basestring):
+        if isinstance(permissions, basestring):
             permissions = (permissions, )
 
         return PloneConfiglet(id=id,


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/1376 for Plone 5.1.