### PR TITLE
Fixed removing permissions when saving portal_controlpanel in ZMI. [5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed accidentally removing permissions when saving the ``portal_controlpanel`` settings in the ZMI.
+  Fixes `issue 1376 <https://github.com/plone/Products.CMFPlone/issues/1376>`_.  [maurits]
 
 
 5.0.8 (2017-06-04)

--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -194,7 +194,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             except ValueError:
                 visible = 0
 
-        if not isinstance(permissions, basestring):
+        if isinstance(permissions, basestring):
             permissions = (permissions, )
 
         return PloneConfiglet(id=id,


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/1376 for Plone 5.0.

(Plone 4.3 is not affected.)