### PR TITLE
Add jqtree contextmenu and js shortcuts for Plone 5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog
 
 Breaking changes:
 
-- Replaced cssmin with PyScss to ensure Python 3 compatibility and maintainability. 
+- Replaced cssmin with PyScss to ensure Python 3 compatibility and maintainability.
   Removed dependency to cssmin, so could break dependency for third party addons that depend on it.
   Introduced PyScss as a drop in replacement that could also do more things.
   Discussion on that at https://github.com/plone/Products.CMFPlone/issues/1800
@@ -28,6 +28,9 @@ New features:
   [datakurre, polyester]
 
 Bug fixes:
+
+- Do not open links on a new tab as this is against basic usability guidelines.
+  [hvelarde]
 
 - add :focus class on toolbar for keyboard users  (https://github.com/plone/Products.CMFPlone/issues/1620)
   [polyester]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Bug fixes:
 - Fix empty DX add_forms if formlib is also installed thru addon dependencies
   [MrTango]
 
+- Fix ``utils.get_top_site_from_url`` to work with non-OFS contexts.
+  [thet]
+
 
 5.1b4 (2017-07-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ New features:
 
 Bug fixes:
 
+- Fixed accidentally removing permissions when saving the ``portal_controlpanel`` settings in the ZMI.
+  Fixes `issue 1376 <https://github.com/plone/Products.CMFPlone/issues/1376>`_.  [maurits]
+
 - Do not open links on a new tab as this is against basic usability guidelines.
   [hvelarde]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ New features:
 - Add RobotFramework screenshot tests for the Plone documentation.
   [datakurre, polyester]
 
+- Add jqtree-contextual-menu js-shortcuts package for keyboard shortcuts
+  [b4oshany]
+
 Bug fixes:
 
 - Fixed accidentally removing permissions when saving the ``portal_controlpanel`` settings in the ZMI.

--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -195,7 +195,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             except ValueError:
                 visible = 0
 
-        if not isinstance(permissions, basestring):
+        if isinstance(permissions, basestring):
             permissions = (permissions, )
 
         return PloneConfiglet(id=id,

--- a/Products/CMFPlone/browser/templates/plone-overview.pt
+++ b/Products/CMFPlone/browser/templates/plone-overview.pt
@@ -152,7 +152,6 @@
       <span i18n:translate="label_plone_org_description"> For documentation, add-ons, support, community, visit</span>
       <a href="http://plone.org"
         title="Plone Community Home"
-        target="_new"
         i18n:attributes="title label_plone_org_title;">plone.org</a>.
     </p>
   </footer>

--- a/Products/CMFPlone/browser/templates/plone-upgrade.pt
+++ b/Products/CMFPlone/browser/templates/plone-upgrade.pt
@@ -31,7 +31,6 @@
   <h1 i18n:translate="">Upgrade this site</h1>
   <h1>
       <a href="#"
-         target="_new"
          tal:attributes="href context/absolute_url;
                          title context/Title;"
          tal:content="context/Title">
@@ -44,7 +43,6 @@
     More information about the upgrade procedure can be found in the
     documentation section of plone.org in the
     <a href="http://docs.plone.org/manage/upgrading"
-       target="_new"
        i18n:name="upgrade_guide"
        i18n:translate="">Upgrade Guide</a>.
   </p>

--- a/Products/CMFPlone/profiles/default/metadata.xml
+++ b/Products/CMFPlone/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>5108</version>
+  <version>5109</version>
 </metadata>

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -310,6 +310,18 @@
       </value>
   </records>
 
+  <records prefix="plone.resources/jqtree-contextmenu"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/cs-jqtree-contextmenu/src/jqTreeContextMenu.js</value>
+      <value key="deps">jqtree</value>
+  </records>
+
+  <records prefix="plone.resources/js-shortcuts"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/js-shortcuts/js-shortcuts.js</value>
+      <value key="deps">jquery</value>
+  </records>
+
   <records prefix="plone.resources/jquery.form"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
       <value key="js">++plone++static/components/jquery-form/jquery.form.js</value>

--- a/Products/CMFPlone/static/bower.json
+++ b/Products/CMFPlone/static/bower.json
@@ -27,7 +27,9 @@
     "tinymce-builded": "4.5.6",
     "requirejs": "",
     "less": "2.1.2",
-    "r.js": "2.1.15"
+    "r.js": "2.1.15",
+    "cs-jqtree-contextmenu": "^0.1.0",
+    "js-shortcuts": "^1.0.1"
   },
   "devDependencies": {
     "expect": "0.3.1",

--- a/Products/CMFPlone/static/components/cs-jqtree-contextmenu/src/jqTreeContextMenu.js
+++ b/Products/CMFPlone/static/components/cs-jqtree-contextmenu/src/jqTreeContextMenu.js
@@ -1,0 +1,97 @@
+(function ($) {
+    if (!$.fn.tree) {
+        throw "Error jqTree is not loaded.";
+    }
+
+    $.fn.jqTreeContextMenu = function (options) {
+        var defaults = {
+            menuFadeDuration: 250,
+            selectClickedNode: true,
+            onContextMenuItem: null,
+            contextMenuDecider: null
+        };
+        var settings = $.extend({}, defaults, options);
+        var $el = this;
+        var $menuEl;
+
+        // Check if useContextMenu option is set
+        var jqTree = $el.data('simple_widget_tree');
+        if(!jqTree || !jqTree.options.useContextMenu){
+            throw 'Either jqTree was not found or useContextMenu in jqTree is set to false.';
+        }
+
+        // Check if the parameter is a jquery object
+        if(settings.menu instanceof jQuery) {
+            $menuEl = settings.menu;
+        } else if (typeof settings.menu == "string") {
+            $menuEl = $(settings.menu);
+        } else {
+            throw 'You must pass a menu selector string or jquery element to the jqTreeContextMenu.';
+        }
+        $menuEl.hide();
+        if (settings.onContextMenuItem) {
+            this.bind('cm-jqtree.item.click', settings.onContextMenuItem);
+        }
+
+        // Handle the contextmenu event sent from jqTree when user clicks right mouse button.
+        $el.bind('tree.contextmenu', function (event) {
+            var menu = $menuEl;
+            if (typeof(settings.contextMenuDecider) == "function") {
+                var menuChoice = settings.contextMenuDecider(event.node);
+                menu = (typeof menuChoice == "string") ? $(menuChoice) : $menuEl;
+            }
+            var x = event.click_event.pageX;
+            var y = event.click_event.pageY;
+            var yPadding = 5;
+            var xPadding = 5;
+
+            var menuHeight = menu.height();
+            var menuWidth = menu.width();
+            var windowHeight = $(window).height();
+            var windowWidth = $(window).width();
+
+            // Make sure the whole menu is rendered within the viewport.
+            if (menuHeight + y + yPadding > windowHeight) {
+                y = y - menuHeight;
+            }
+            if (menuWidth + x + xPadding > windowWidth) {
+                x = x - menuWidth;
+            }
+
+            // Must call show before we set the offset (offset can not be set on display: none elements).
+            menu.fadeIn(settings.menuFadeDuration);
+            menu.offset({ left: x, top: y });
+
+            var dismissContextMenu = function () {
+                $(document).unbind('click.jqtreecontextmenu');
+                $el.unbind('tree.click.jqtreecontextmenu');
+                menu.fadeOut(settings.menuFadeDuration);
+            };
+
+            // Make it possible to dismiss context menu by clicking somewhere in the document.
+            $(document).bind('click.jqtreecontextmenu', function (e) {
+                if (x != e.pageX || y != e.pageY) {
+                    dismissContextMenu();
+                }
+            });
+            // Dismiss context menu if another node in the tree is clicked.
+            $el.bind('tree.click.jqtreecontextmenu', function () {
+                dismissContextMenu();
+            });
+
+            // Make the selection follow the node that was right clicked on (if desired).
+            if (settings.selectClickedNode && $el.tree('getSelectedNode') !== event.node) {
+                $el.tree('selectNode', event.node);
+            }
+
+            // Handle click on menu items, if it's not disabled.
+            menu.find('li').off('click.contextmenu').on('click.contextmenu', function (e) {
+                e.stopImmediatePropagation();
+                dismissContextMenu();
+                $el.trigger('cm-jqtree.item.click', [event.node, $(this)]);
+            });
+        });
+
+        return this;
+    };
+} (jQuery));

--- a/Products/CMFPlone/static/components/js-shortcuts/LICENSE
+++ b/Products/CMFPlone/static/components/js-shortcuts/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2015, Saneem
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of js-shortcuts nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/Products/CMFPlone/static/components/js-shortcuts/js-shortcuts-angular.js
+++ b/Products/CMFPlone/static/components/js-shortcuts/js-shortcuts-angular.js
@@ -1,0 +1,300 @@
+/**
+ @license 
+ Adapted for Angular by Saneem
+ Original version by Binny V A
+ License: MIT
+ */
+(function () {
+  'use strict';
+
+  angular.module('js-shortcuts', []).provider('jsShortcuts', function () {
+
+    this.$get = function () {
+      var all_shortcuts = {};
+
+      return {
+        add: function (shortcut_combination, callback, opt) {
+          //Provide a set of default options
+          var default_options = {
+            'type': 'keydown',
+            'propagate': false,
+            'disable_in_input': false,
+            'target': document,
+            'keycode': false
+          };
+
+          if (!opt) {
+            opt = default_options;
+          } else {
+            for (var dfo in default_options) {
+              if (typeof opt[dfo] === 'undefined') {
+                opt[dfo] = default_options[dfo];
+              }
+            }
+          }
+
+          var ele = opt.target;
+          if (typeof opt.target === 'string') {
+            ele = document.getElementById(opt.target);
+          }
+
+          shortcut_combination = shortcut_combination.toLowerCase();
+
+          //The function to be called at keypress
+          var func = function (e) {
+            var code;
+            e = e || window.event;
+
+            if (opt.disable_in_input) { //Don't enable shortcut keys in Input, Textarea fields
+              var element;
+              if (e.target) {
+                element = e.target;
+              } else if (e.srcElement) {
+                element = e.srcElement;
+              }
+              if (element.nodeType === 3) {
+                element = element.parentNode;
+              }
+
+              if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') {
+                return;
+              }
+            }
+
+            //Find Which key is pressed
+            if (e.keyCode) {
+              code = e.keyCode;
+            } else if (e.which) {
+              code = e.which;
+            }
+
+            var character = String.fromCharCode(code).toLowerCase();
+
+            if (code === 188) {
+              character = ","; //If the user presses , when the type is onkeydown
+            }
+            if (code === 190) {
+              character = "."; //If the user presses , when the type is onkeydown
+            }
+
+            var keys = shortcut_combination.split("+");
+            //Key Pressed - counts the number of valid keypresses - if it is same as the number of keys, the shortcut function is invoked
+            var kp = 0;
+
+            //Work around for stupid Shift key bug created by using lowercase - as a result the shift+num combination was broken
+            var shift_nums = {
+              "`": "~",
+              "1": "!",
+              "2": "@",
+              "3": "#",
+              "4": "$",
+              "5": "%",
+              "6": "^",
+              "7": "&",
+              "8": "*",
+              "9": "(",
+              "0": ")",
+              "-": "_",
+              "=": "+",
+              ";": ":",
+              "'": "\"",
+              ",": "<",
+              ".": ">",
+              "/": "?",
+              "\\": "|"
+            };
+
+            //Special Keys - and their codes
+            var special_keys = {
+              'esc': 27,
+              'escape': 27,
+              'tab': 9,
+              'space': 32,
+              'return': 13,
+              'enter': 13,
+              'backspace': 8,
+
+              'scrolllock': 145,
+              'scroll_lock': 145,
+              'scroll': 145,
+              'capslock': 20,
+              'caps_lock': 20,
+              'caps': 20,
+              'numlock': 144,
+              'num_lock': 144,
+              'num': 144,
+
+              'pause': 19,
+              'break': 19,
+
+              'insert': 45,
+              'home': 36,
+              'delete': 46,
+              'end': 35,
+
+              'pageup': 33,
+              'page_up': 33,
+              'pu': 33,
+
+              'pagedown': 34,
+              'page_down': 34,
+              'pd': 34,
+
+              'left': 37,
+              'up': 38,
+              'right': 39,
+              'down': 40,
+
+              'f1': 112,
+              'f2': 113,
+              'f3': 114,
+              'f4': 115,
+              'f5': 116,
+              'f6': 117,
+              'f7': 118,
+              'f8': 119,
+              'f9': 120,
+              'f10': 121,
+              'f11': 122,
+              'f12': 123
+            };
+
+            var modifiers = {
+              shift: {
+                wanted: false,
+                pressed: false
+              },
+              ctrl: {
+                wanted: false,
+                pressed: false
+              },
+              alt: {
+                wanted: false,
+                pressed: false
+              },
+              meta: {
+                wanted: false,
+                pressed: false
+              } //Meta is Mac specific
+            };
+
+            if (e.ctrlKey) {
+              modifiers.ctrl.pressed = true;
+            }
+            if (e.shiftKey) {
+              modifiers.shift.pressed = true;
+            }
+            if (e.altKey) {
+              modifiers.alt.pressed = true;
+            }
+            if (e.metaKey) {
+              modifiers.meta.pressed = true;
+            }
+
+            var k;
+
+            for (var i = 0; k = keys[i], i < keys.length; i++) {
+              //Modifiers
+              if (k === 'ctrl' || k === 'control') {
+                kp++;
+                modifiers.ctrl.wanted = true;
+
+              } else if (k === 'shift') {
+                kp++;
+                modifiers.shift.wanted = true;
+
+              } else if (k === 'alt') {
+                kp++;
+                modifiers.alt.wanted = true;
+              } else if (k === 'meta') {
+                kp++;
+                modifiers.meta.wanted = true;
+              } else if (k.length > 1) { //If it is a special key
+                if (special_keys[k] === code) {
+                  kp++;
+                }
+
+              } else if (opt.keycode) {
+                if (opt.keycode === code) {
+                  kp++;
+                }
+
+              } else { //The special keys did not match
+                if (character === k) {
+                  kp++;
+                } else {
+                  if (shift_nums[character] && e.shiftKey) { //Stupid Shift key bug created by using lowercase
+                    character = shift_nums[character];
+                    if (character === k) {
+                      kp++;
+                    }
+                  }
+                }
+              }
+            }
+
+            if (kp === keys.length &&
+              modifiers.ctrl.pressed === modifiers.ctrl.wanted &&
+              modifiers.shift.pressed === modifiers.shift.wanted &&
+              modifiers.alt.pressed === modifiers.alt.wanted &&
+              modifiers.meta.pressed === modifiers.meta.wanted) {
+              callback(e);
+
+              if (!opt.propagate) { //Stop the event
+                //e.cancelBubble is supported by IE - this will kill the bubbling process.
+                e.cancelBubble = true;
+                e.returnValue = false;
+
+                //e.stopPropagation works in Firefox.
+                if (e.stopPropagation) {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }
+                return false;
+              }
+            }
+          };
+
+          all_shortcuts[shortcut_combination] = {
+            'callback': func,
+            'target': ele,
+            'event': opt.type
+          };
+          //Attach the function with the event
+          if (ele.addEventListener) {
+            ele.addEventListener(opt.type, func, false);
+          } else if (ele.attachEvent) {
+            ele.attachEvent('on' + opt.type, func);
+          } else {
+            ele['on' + opt.type] = func;
+          }
+        },
+
+        remove: function (shortcut_combination) {
+          shortcut_combination = shortcut_combination.toLowerCase();
+          var binding = all_shortcuts[shortcut_combination];
+          delete(all_shortcuts[shortcut_combination]);
+          if (!binding) {
+            return;
+          }
+          var type = binding.event;
+          var ele = binding.target;
+          var callback = binding.callback;
+
+          if (ele.detachEvent) {
+            ele.detachEvent('on' + type, callback);
+          } else if (ele.removeEventListener) {
+            ele.removeEventListener(type, callback, false);
+          } else {
+            ele['on' + type] = false;
+          }
+        }
+
+
+      };
+    };
+
+  });
+
+
+}).call(this);

--- a/Products/CMFPlone/static/components/js-shortcuts/js-shortcuts.js
+++ b/Products/CMFPlone/static/components/js-shortcuts/js-shortcuts.js
@@ -1,0 +1,223 @@
+/**
+ * http://www.openjs.com/scripts/events/keyboard_shortcuts/
+ * Version : 2.01.B
+ * By Binny V A
+ * License : BSD
+ */
+shortcut = {
+	'all_shortcuts':{},//All the shortcuts are stored in this array
+	'add': function(shortcut_combination,callback,opt) {
+		//Provide a set of default options
+		var default_options = {
+			'type':'keydown',
+			'propagate':false,
+			'disable_in_input':false,
+			'target':document,
+			'keycode':false
+		}
+		if(!opt) opt = default_options;
+		else {
+			for(var dfo in default_options) {
+				if(typeof opt[dfo] == 'undefined') opt[dfo] = default_options[dfo];
+			}
+		}
+
+		var ele = opt.target;
+		if(typeof opt.target == 'string') ele = document.getElementById(opt.target);
+		var ths = this;
+		shortcut_combination = shortcut_combination.toLowerCase();
+
+		//The function to be called at keypress
+		var func = function(e) {
+			e = e || window.event;
+			
+			if(opt['disable_in_input']) { //Don't enable shortcut keys in Input, Textarea fields
+				var element;
+				if(e.target) element=e.target;
+				else if(e.srcElement) element=e.srcElement;
+				if(element.nodeType==3) element=element.parentNode;
+
+				if(element.tagName == 'INPUT' || element.tagName == 'TEXTAREA') return;
+			}
+	
+			//Find Which key is pressed
+			if (e.keyCode) code = e.keyCode;
+			else if (e.which) code = e.which;
+			var character = String.fromCharCode(code).toLowerCase();
+			
+			if(code == 188) character=","; //If the user presses , when the type is onkeydown
+			if(code == 190) character="."; //If the user presses , when the type is onkeydown
+
+			var keys = shortcut_combination.split("+");
+			//Key Pressed - counts the number of valid keypresses - if it is same as the number of keys, the shortcut function is invoked
+			var kp = 0;
+			
+			//Work around for stupid Shift key bug created by using lowercase - as a result the shift+num combination was broken
+			var shift_nums = {
+				"`":"~",
+				"1":"!",
+				"2":"@",
+				"3":"#",
+				"4":"$",
+				"5":"%",
+				"6":"^",
+				"7":"&",
+				"8":"*",
+				"9":"(",
+				"0":")",
+				"-":"_",
+				"=":"+",
+				";":":",
+				"'":"\"",
+				",":"<",
+				".":">",
+				"/":"?",
+				"\\":"|"
+			}
+			//Special Keys - and their codes
+			var special_keys = {
+				'esc':27,
+				'escape':27,
+				'tab':9,
+				'space':32,
+				'return':13,
+				'enter':13,
+				'backspace':8,
+	
+				'scrolllock':145,
+				'scroll_lock':145,
+				'scroll':145,
+				'capslock':20,
+				'caps_lock':20,
+				'caps':20,
+				'numlock':144,
+				'num_lock':144,
+				'num':144,
+				
+				'pause':19,
+				'break':19,
+				
+				'insert':45,
+				'home':36,
+				'delete':46,
+				'end':35,
+				
+				'pageup':33,
+				'page_up':33,
+				'pu':33,
+	
+				'pagedown':34,
+				'page_down':34,
+				'pd':34,
+	
+				'left':37,
+				'up':38,
+				'right':39,
+				'down':40,
+	
+				'f1':112,
+				'f2':113,
+				'f3':114,
+				'f4':115,
+				'f5':116,
+				'f6':117,
+				'f7':118,
+				'f8':119,
+				'f9':120,
+				'f10':121,
+				'f11':122,
+				'f12':123
+			}
+	
+			var modifiers = { 
+				shift: { wanted:false, pressed:false},
+				ctrl : { wanted:false, pressed:false},
+				alt  : { wanted:false, pressed:false},
+				meta : { wanted:false, pressed:false}	//Meta is Mac specific
+			};
+                        
+			if(e.ctrlKey)	modifiers.ctrl.pressed = true;
+			if(e.shiftKey)	modifiers.shift.pressed = true;
+			if(e.altKey)	modifiers.alt.pressed = true;
+			if(e.metaKey)   modifiers.meta.pressed = true;
+                        
+			for(var i=0; k=keys[i],i<keys.length; i++) {
+				//Modifiers
+				if(k == 'ctrl' || k == 'control') {
+					kp++;
+					modifiers.ctrl.wanted = true;
+
+				} else if(k == 'shift') {
+					kp++;
+					modifiers.shift.wanted = true;
+
+				} else if(k == 'alt') {
+					kp++;
+					modifiers.alt.wanted = true;
+				} else if(k == 'meta') {
+					kp++;
+					modifiers.meta.wanted = true;
+				} else if(k.length > 1) { //If it is a special key
+					if(special_keys[k] == code) kp++;
+					
+				} else if(opt['keycode']) {
+					if(opt['keycode'] == code) kp++;
+
+				} else { //The special keys did not match
+					if(character == k) kp++;
+					else {
+						if(shift_nums[character] && e.shiftKey) { //Stupid Shift key bug created by using lowercase
+							character = shift_nums[character]; 
+							if(character == k) kp++;
+						}
+					}
+				}
+			}
+			
+			if(kp == keys.length && 
+						modifiers.ctrl.pressed == modifiers.ctrl.wanted &&
+						modifiers.shift.pressed == modifiers.shift.wanted &&
+						modifiers.alt.pressed == modifiers.alt.wanted &&
+						modifiers.meta.pressed == modifiers.meta.wanted) {
+				callback(e);
+	
+				if(!opt['propagate']) { //Stop the event
+					//e.cancelBubble is supported by IE - this will kill the bubbling process.
+					e.cancelBubble = true;
+					e.returnValue = false;
+	
+					//e.stopPropagation works in Firefox.
+					if (e.stopPropagation) {
+						e.stopPropagation();
+						e.preventDefault();
+					}
+					return false;
+				}
+			}
+		}
+		this.all_shortcuts[shortcut_combination] = {
+			'callback':func, 
+			'target':ele, 
+			'event': opt['type']
+		};
+		//Attach the function with the event
+		if(ele.addEventListener) ele.addEventListener(opt['type'], func, false);
+		else if(ele.attachEvent) ele.attachEvent('on'+opt['type'], func);
+		else ele['on'+opt['type']] = func;
+	},
+
+	//Remove the shortcut - just specify the shortcut and I will remove the binding
+	'remove':function(shortcut_combination) {
+		shortcut_combination = shortcut_combination.toLowerCase();
+		var binding = this.all_shortcuts[shortcut_combination];
+		delete(this.all_shortcuts[shortcut_combination])
+		if(!binding) return;
+		var type = binding['event'];
+		var ele = binding['target'];
+		var callback = binding['callback'];
+
+		if(ele.detachEvent) ele.detachEvent('on'+type, callback);
+		else if(ele.removeEventListener) ele.removeEventListener(type, callback, false);
+		else ele['on'+type] = false;
+	}
+}

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -767,10 +767,9 @@ def get_top_site_from_url(context, request):
     - No virtual hosting, URL path: /Plone/Subsite, Returns: Plone
     - Virtual hosting roots to Subsite, URL path: /, Returns: Subsite
     """
-    url_path = urlparse(context.absolute_url()).path.split('/')
-
     site = getSite()
     try:
+        url_path = urlparse(context.absolute_url()).path.split('/')
         for idx in range(len(url_path)):
             _path = '/'.join(url_path[:idx + 1]) or '/'
             site_path = request.physicalPathFromURL(_path)


### PR DESCRIPTION
This is related to [pull request 2090](https://github.com/plone/Products.CMFPlone/pull/2090), which is for Plone 5.0.x