### PR TITLE
Don't raise unauthorized on show_inactive check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Don't raise Unauthorized on show_inactive check in catalog search
+  [tomgross]
 
 
 5.1rc1 (2017-09-10)

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -29,6 +29,7 @@ from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_callable
 from Products.CMFPlone.utils import safe_unicode
 from Products.ZCatalog.ZCatalog import ZCatalog
+from zExceptions import Unauthorized
 from zope.annotation.interfaces import IAnnotations
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
@@ -417,7 +418,7 @@ class CatalogTool(PloneBaseTool, BaseTool):
                 parts = path.split('/')
                 parent = site.unrestrictedTraverse('/'.join(parts[:-1]))
                 objs.append(parent.restrictedTraverse(parts[-1]))
-            except (KeyError, AttributeError):
+            except (KeyError, AttributeError, Unauthorized):
                 # When no object is found don't raise an error
                 pass
 


### PR DESCRIPTION
This PR solves an issue with catalog queries containing paths with unaccessible folders in the traversing chain. Without this patch a query to path /Plone/a/b fails with a traceback, if a user has access to folder `b` but not `a`. With this PR merged, `b` is found as it should be.