### PR TITLE
fix: Remove site path from path in show_inactive in catalog search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ New features:
 
 Bug fixes:
 
+- Remove site path from path in show_inactive in catalog search
+  [Gagaro]
+
 - Don't raise Unauthorized on show_inactive check in catalog search
   [tomgross]
 

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -415,7 +415,8 @@ class CatalogTool(PloneBaseTool, BaseTool):
         for path in list(paths):
             path = path.encode('utf-8')  # paths must not be unicode
             try:
-                parts = path.split('/')
+                site_path = '/'.join(site.getPhysicalPath())
+                parts = path[len(site_path) + 1:].split('/')
                 parent = site.unrestrictedTraverse('/'.join(parts[:-1]))
                 objs.append(parent.restrictedTraverse(parts[-1]))
             except (KeyError, AttributeError, Unauthorized):


### PR DESCRIPTION
If I have a content named `plone` inside a `plone` site, and I search with a path of `/plone`, the content will be used instead of the site because of the traversing.

We shouldn't include the path of the site if we start from it.