### PR TITLE
Fixed add-on listed as uninstalled when default profile is not the first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New features:
 
 Bug fixes:
 
+- Fixed add-on listed as uninstalled when the default profile is not the first alphabetically.
+  Fixes `issue 2166 <https://github.com/plone/Products.CMFPlone/issues/2166>`_.
+  [maurits]
+
 - Less variables: Fix calculation of screen max sizes.
   Max sizes were two pixels too high.
   [thet]

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.py
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.py
@@ -548,7 +548,7 @@ class ManageProductsView(InstallerView):
             profile_type = pid_parts[-1]
             if product_id not in addons:
                 # get some basic information on the product
-                installed = self.is_profile_installed(pid)
+                installed = self.is_product_installed(product_id)
                 upgrade_info = {}
                 if installed:
                     upgrade_info = self.upgrade_info(product_id)


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2166.