### PR TITLE
Show example for expression in actions control panel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ New features:
 
 Bug fixes:
 
+- Show example for expression in actions control panel.
+  [maurits]
+
 - Fixed add-on listed as uninstalled when the default profile is not the first alphabetically.
   Fixes `issue 2166 <https://github.com/plone/Products.CMFPlone/issues/2166>`_.
   [maurits]

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -1741,7 +1741,8 @@ class IActionSchema(Interface):
         title=_(u'action_url_heading', default=u'Action URL'),
         description=_(
             u'action_url_description',
-            default=u'An expression producing the called URL'
+            default=u'An expression producing the called URL. '
+            u'Example: string:${globals_view/navigationRootUrl}/page'
         ),
         required=True)
 


### PR DESCRIPTION
If you add http://maurits.vanrees.org you only get a general message:
`There was an error submitting the form.`
On the backend you see a clearer error:
CompilerError: Unrecognized expression type "http".
So give an example with `string:`.

(I suggest to skip Jenkins testing for this text-only fix, to not flood an already busy Jenkins.)