### PR TITLE
[WIP] - Correctly handle excluded from nav items in navigation portlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,3 +76,7 @@ Bug Fixes:
   Completly removed ``came_from`` on ``@@register`` link.
   It does not make much sense anyway and we test nowhere if there is a came_from on that link.
   [jensens]
+
+- Fix regression in SitemapNavtreeStrategy. Now contents omitted from navigation are skipped in
+  navigation portlet if show_excluded_items flag is set to False.
+  [cekk]

--- a/Products/CMFPlone/browser/navtree.py
+++ b/Products/CMFPlone/browser/navtree.py
@@ -114,8 +114,9 @@ class SitemapNavtreeStrategy(NavtreeStrategyBase):
             'plone.parent_types_not_to_query', [])
         self.viewActionTypes = registry.get(
             'plone.types_use_view_action_in_listings', [])
+        self.showAllParents = registry.get(
+           'plone.show_excluded_items', False)
 
-        self.showAllParents = True
         self.rootPath = getNavigationRoot(context)
 
         membership = getToolByName(context, 'portal_membership')


### PR DESCRIPTION
I think that this is a regression in porting from properties to registry.
In the previous version, showAllParents was correctly set from properties, and now is always set to True.

This is wrong because in this case omitted contents are always showed in the portlet, and the flag in control panel is ignored.

I've found also a [test](https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/tests/testNavigationView.py#L85) for this case, but it seems disabled or ignored when i run

    bin/test -s Products.CMFPlone

Is it correct?