### PR TITLE
Use `guarded_getitem` in `SafeFormatter`.

### DIFF
--- a/Products/CMFPlone/tests/test_safe_formatter.py
+++ b/Products/CMFPlone/tests/test_safe_formatter.py
@@ -143,6 +143,8 @@ class TestSafeFormatter(PloneTestCase):
             self.portal.portal_workflow.getInfoFor(foobar, 'review_state'),
             'private')
         # We could logout(), but that is not even needed.
+        from AccessControl.ZopeGuards import guarded_getattr
+        self.assertRaises(Unauthorized, guarded_getattr, self.portal.foobar.text, 'output')
         TEMPLATE = '<p tal:content="structure python:%s" />'
         pt = ZopePageTemplate(
             'mytemplate', TEMPLATE %
@@ -154,6 +156,7 @@ class TestSafeFormatter(PloneTestCase):
             'mytemplate', TEMPLATE %
             "context.foobar.text.output")
         hack_pt(pt, context=self.portal)
+        pt.pt_render()
         self.assertRaises(Unauthorized, pt.pt_render)
         logout()
         self.assertRaises(Unauthorized, pt.pt_render)

--- a/Products/CMFPlone/tests/using_format_zope3_page_template.pt
+++ b/Products/CMFPlone/tests/using_format_zope3_page_template.pt
@@ -1,2 +1,6 @@
 <p tal:content="python:'class of {0} is {0.__class__}'.format(context).lower()" />
 <p tal:content="python:u'class of {0} is {0.__class__}'.format(context).upper()" />
+<p tal:content="python:'{0} has foo={0[foo]}'.format({'foo': 42})" />
+<p tal:content="python:u'{0} has foo={0[foo]}'.format({'foo': 42})" />
+<p tal:content="python:'{0} has first item {0[0]}'.format(['ni'])" />
+<p tal:content="python:'{0} has first item {0[0]}'.format(['ni'])" />

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,6 +19,9 @@ New features:
 
 Bug fixes:
 
+- Use ``guarded_getitem`` in ``SafeFormatter``.
+  Part of PloneHotfix20171128.  Copied from ``AccessControl``.  [maurits]
+
 - Improved isURLInPortal according to PloneHotfix20171128.
   Accept only http/https, and doubly check escaped urls.  [maurits]
 


### PR DESCRIPTION
Part of PloneHotfix20171128.  Copied from `AccessControl`.
Tests copied from PloneHotfix20171128 internal tests.

Note that we have our own internal copy of the safe formatter from AccessControl. Originally, this was because last year it took long before the January 2017 hotfix got merged into AccessControl. For Plone 5 our copy can probably be removed, but for Plone 4.3, we need it: coredev 4.3 used AccessControl 3.0.11 and cannot update to a more recent version, because this would require too new versions of ExtensionClass and Acquisition.