### PR TITLE
Fixed flaky actions controlpanel tests by waiting longer. [5.2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ New Features:
 
 Bug Fixes:
 
+- Fixed flaky actions controlpanel tests by waiting longer.  [maurits]
+
 - Require AccessControl 4.0b1 so ``guarded_getitem`` is used.
   Part of PloneHotfix20171128.  [maurits]
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -18,34 +18,40 @@ Scenario: Modify an existing action in Actions Control Panel
   Given a logged-in administrator
     and the actions control panel
    When I modify an action title
+   Sleep  1
    Then anonymous users can see the new action title
 
 Scenario: Reorder in Actions Control Panel
   Given a logged-in administrator
     and the actions control panel
    When I change the actions order
+   Sleep  1
    Then anonymous users can see the actions new ordering
 
 Scenario: Create a new action in Actions Control Panel
   Given a logged-in administrator
     and the actions control panel
    When I add a new action
+   Sleep  1
    Then logged-in users can see the new action
 
 Scenario: Hide/show an action in Actions Control Panel
   Given a logged-in administrator
     and the actions control panel
    When I hide an action
+   Sleep  1
    Then anonymous users cannot see the action anymore
   Given a logged-in administrator
     and the actions control panel
    When I unhide the action
+   Sleep  1
    Then anonymous users can see the action again
 
 Scenario: Delete an action in Actions Control Panel
   Given a logged-in administrator
     and the actions control panel
    When I delete an action
+   Sleep  1
    Then anonymous users cannot see the action anymore
 
 *** Keywords *****************************************************************


### PR DESCRIPTION
Several actions controlpanel robot tests are flaky on Jenkins. Locally, the 'Delete an action in Actions Control Panel' scenario wasn't flaky but actually *always* failed.

I first added `Capture Page Screenshot` to see if I could figure out what was wrong, but making the screen shot fixed the problem. So it seems we simply need to wait a bit longer, probably to let Plone write the change to the database before checking with an anonymous user.