### PR TITLE
Remove backward compatibility for Products.PlacelessTranslationService

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Breaking changes:
 - Render exceptions using an exception view instead of standard_error_message.
   [davisagli]
 
+- Remove backward compatibility for Products.PlacelessTranslationService 
+  [ksuess]
+
+
 New Features:
 
 - Fix imports to work with Python 3.

--- a/Products/CMFPlone/overrides.zcml
+++ b/Products/CMFPlone/overrides.zcml
@@ -4,7 +4,6 @@
            i18n_domain="plone">
 
     <include package="Products.CMFCore" file="overrides.zcml" />
-    <include package="Products.PlacelessTranslationService" file="overrides.zcml" />
     <include package="plone.app.portlets" file="overrides.zcml" />
 
     <utility

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -28,32 +28,6 @@ class TestAttackVectorsUnit(unittest.TestCase):
         self.assertEqual(response.headers['location'],
                          'http://www.ietf.org/rfc/rfc2616.txt')
 
-    def test_PT_allow_module_not_available_in_RestrictedPython_1(self):
-        src = '''
-from AccessControl import Unauthorized
-try:
-    import Products.PlacelessTranslationService
-except (ImportError, Unauthorized):
-    raise AssertionError("Failed to import Products.PTS")
-Products.PlacelessTranslationService.allow_module('os')
-'''
-        from Products.PythonScripts.PythonScript import PythonScript
-        script = makerequest(PythonScript('fooscript'))
-        script._filepath = 'fooscript'
-        script.write(src)
-        self.assertRaises((ImportError, Unauthorized), script)
-
-    def test_PT_allow_module_not_available_in_RestrictedPython_2(self):
-        src = '''
-from Products.PlacelessTranslationService import allow_module
-allow_module('os')
-'''
-        from Products.PythonScripts.PythonScript import PythonScript
-        script = makerequest(PythonScript('barscript'))
-        script._filepath = 'barscript'
-        script.write(src)
-        self.assertRaises((ImportError, Unauthorized), script)
-
     def test_get_request_var_or_attr_disallowed(self):
         import App.Undo
         self.assertFalse(hasattr(App.Undo.UndoSupport,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Products.ExternalEditor',
         'Products.GenericSetup >= 1.8.2',
         'Products.MimetypesRegistry',
-        'Products.PlacelessTranslationService',
         # 'Products.PloneLanguageTool',
         'Products.PlonePAS',
         'Products.PluggableAuthService',


### PR DESCRIPTION
Last thing used from PTS was an adapter for IUserPreferredLanguages. It is replaced in zope.publisher.

Related pull requests: https://github.com/plone/plone.i18n/pull/20 and https://github.com/plone/plone.app.testing/pull/44