### PR TITLE
Update RSS views content type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ New Features:
 
 Bug Fixes:
 
+- Update RSS content type.
+  [Gagaro]
+
 - Fixed linkintegrity robot tests.  [maurits]
 
 - Fixed flaky actions controlpanel tests by waiting longer.  [maurits]

--- a/Products/CMFPlone/browser/syndication/configure.zcml
+++ b/Products/CMFPlone/browser/syndication/configure.zcml
@@ -55,14 +55,14 @@
 
   <browser:page
     for="Products.CMFPlone.interfaces.syndication.ISyndicatable"
-    class=".views.FeedView"
+    class=".views.RSSView"
     name="rss.xml"
     permission="zope2.View"
     template="templates/rss.xml.pt"
     />
   <browser:page
     for="Products.CMFPlone.interfaces.syndication.ISyndicatable"
-    class=".views.FeedView"
+    class=".views.RSSView"
     name="RSS"
     permission="zope2.View"
     template="templates/RSS.pt"
@@ -70,7 +70,7 @@
 
   <browser:page
     for="Products.CMFPlone.interfaces.syndication.ISyndicatable"
-    class=".views.FeedView"
+    class=".views.RSSView"
     name="itunes.xml"
     permission="zope2.View"
     template="templates/itunes.xml.pt"

--- a/Products/CMFPlone/browser/syndication/views.py
+++ b/Products/CMFPlone/browser/syndication/views.py
@@ -40,6 +40,11 @@ class FeedView(BrowserView):
             return self.index()
 
 
+class RSSView(FeedView):
+
+    content_type = 'application/rss+xml'
+
+
 class SearchFeedView(FeedView):
 
     def feed(self):
@@ -53,7 +58,7 @@ class SearchFeedView(FeedView):
                                name='syndication-util')
         if util.search_rss_enabled(raise404=True):
             self.request.response.setHeader('Content-Type',
-                                            'application/atom+xml')
+                                            'application/rss+xml')
             return self.index()
 
 


### PR DESCRIPTION
itunes podcast feeds are RSS 2.0 feeds. The search rss view is RSS 1.0. The content type for these feeds should be `application/rss+xml`.