### PR TITLE
Register the ``ExceptionView`` for the unspecific ``zope.interface.Interface``, to plone.rest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ New Features:
 
 Bug Fixes:
 
+- Register the ``ExceptionView`` for the unspecific ``zope.interface.Interface`` for easier overloading.
+  Fixes a problem, where plone.rest couldn't overload the ExceptionView with an adapter bound to ``plone.rest.interfaces.IAPIRequest``.
+  [thet]
+
 - Fixed linkintegrity robot tests.  [maurits]
 
 - Fixed flaky actions controlpanel tests by waiting longer.  [maurits]

--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -283,6 +283,7 @@
       class=".exceptions.ExceptionView"
       template="templates/error_message.pt"
       permission="zope.Public"
+      layer="zope.interface.Interface"
       />
 
 </configure>


### PR DESCRIPTION
adapters for requests providing a interface like ``plone.rest.interfaces.IAPIRequest``. This one isn't  a browser layer, and without this fix the ExceptionView would be registered for the base IBrowserLayer.
Before, there was a exception handling skin script, which could be overloaded by plone.rest.