### PR TITLE
Ignore invalid `sort_on` parameters in catalog `searchResults`.

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -386,6 +386,11 @@ class CatalogTool(PloneBaseTool, BaseTool):
 
             kw['effectiveRange'] = DateTime()
 
+        sort_on = kw.get('sort_on')
+        if sort_on and sort_on not in self.indexes():
+            # I get crazy sort_ons like '194' or 'null'.
+            kw.pop('sort_on')
+
         return ZCatalog.searchResults(self, REQUEST, **kw)
 
     __call__ = searchResults

--- a/Products/CMFPlone/tests/testCatalogTool.py
+++ b/Products/CMFPlone/tests/testCatalogTool.py
@@ -403,7 +403,7 @@ class TestCatalogSearching(PloneTestCase.PloneTestCase):
         # using OR
         results = self.catalog(SearchableText='aaa OR bbb')
         self.assertEqual(len(results), 2)
-    
+
     def testSearchIgnoresAccents(self):
         #plip 12110
         self.folder.invokeFactory('Document', id='docwithaccents1', description='Econométrie')
@@ -515,6 +515,16 @@ class TestCatalogSorting(PloneTestCase.PloneTestCase):
         self.folder.doc4.reindexObject()
         self.folder.doc5.reindexObject()
         self.folder.doc6.reindexObject()
+
+    def testUnknownSortOnIsIgnored(self):
+        # You should not get a CatalogError when an invalid sort_on is passed.
+        # I get crazy sort_ons like '194' or 'null'.
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='194')) > 0)
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='null')) > 0)
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='relevance')) > 0)
 
     def testSortTitleReturnsProperOrderForNumbers(self):
         # Documents should be returned in proper numeric order

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,6 +19,11 @@ New features:
 
 Bug fixes:
 
+- Ignore invalid ``sort_on`` parameters in catalog ``searchResults``.
+  Otherwise you get a ``CatalogError``.
+  I get crazy sort_ons like '194' or 'null'.
+  [maurits]
+
 - Use ``guarded_getitem`` in ``SafeFormatter``.
   Part of PloneHotfix20171128.  Copied from ``AccessControl``.  [maurits]
 


### PR DESCRIPTION
Otherwise you get a `CatalogError`, for example when visiting `http://127.0.0.1:8080/Plone/search_rss?sort_on=abcde`.
I get crazy sort_ons like '194' or 'null'.