### PR TITLE
Ignore invalid `sort_on` parameters in catalog `searchResults`. [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ New features:
 
 Bug fixes:
 
+- Ignore invalid ``sort_on`` parameters in catalog ``searchResults``.
+  Otherwise you get a ``CatalogError``.
+  I get crazy sort_ons like '194' or 'null'.
+  [maurits]
+
 - Fixed linkintegrity robot tests.  [maurits]
 
 - Fixed flaky actions controlpanel tests by waiting longer.  [maurits]

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -458,6 +458,11 @@ class CatalogTool(PloneBaseTool, BaseTool):
         if not show_inactive and not self.allow_inactive(kw):
             kw['effectiveRange'] = DateTime()
 
+        sort_on = kw.get('sort_on')
+        if sort_on and sort_on not in self.indexes():
+            # I get crazy sort_ons like '194' or 'null'.
+            kw.pop('sort_on')
+
         return ZCatalog.searchResults(self, REQUEST, **kw)
 
     __call__ = searchResults

--- a/Products/CMFPlone/tests/testCatalogTool.py
+++ b/Products/CMFPlone/tests/testCatalogTool.py
@@ -528,6 +528,16 @@ class TestCatalogSorting(PloneTestCase):
         self.folder.doc5.reindexObject()
         self.folder.doc6.reindexObject()
 
+    def testUnknownSortOnIsIgnored(self):
+        # You should not get a CatalogError when an invalid sort_on is passed.
+        # I get crazy sort_ons like '194' or 'null'.
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='194')) > 0)
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='null')) > 0)
+        self.assertTrue(len(
+            self.catalog(SearchableText='foo', sort_on='relevance')) > 0)
+
     def testSortTitleReturnsProperOrderForNumbers(self):
         # Documents should be returned in proper numeric order
         results = self.catalog(SearchableText='foo', sort_on='sortable_title')


### PR DESCRIPTION
Otherwise you get a `CatalogError`.
I get crazy sort_ons like '194' or 'null'.