### PR TITLE
Link reset text not translated in password reset mails.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ New features:
 
 Bug fixes:
 
+- Fix bad domain for translating password reset mails.
+  [allusa]
+
 - Ignore invalid ``sort_on`` parameters in catalog ``searchResults``.
   Otherwise you get a ``CatalogError``.
   I get crazy sort_ons like '194' or 'null'.

--- a/Products/CMFPlone/browser/templates/mail_password_template.pt
+++ b/Products/CMFPlone/browser/templates/mail_password_template.pt
@@ -16,12 +16,12 @@ The site administrator asks you to reset your password for '<span i18n:name="use
           tal:content="member/id" />' userid. Your old password doesn't work anymore.
 </tal:i18n>
 
-<tal:i18n i18n:domain="passwordresettool"
-     i18n:translate="mailtemplate_text_linkreset">
+<tal:i18n i18n:translate="mailtemplate_text_linkreset">
 The following link will take you to a page where you can reset your password for <tal:i18n i18n:name="site_name"
           tal:content="portal_state/navigation_root_title" /> site:
 
-<tal:i18n tal:content="python:view.construct_url(reset['randomstring'])" i18n:name="reset_url" /></tal:i18n>
+<tal:i18n tal:content="python:view.construct_url(reset['randomstring'])" i18n:name="reset_url" />
+</tal:i18n>
 
 <tal:i18n
      i18n:translate="mailtemplate_text_expirationdate_linkreset">


### PR DESCRIPTION
https://github.com/plone/Products.CMFPlone/issues/2293

Needs to be in 5.1.x for resyncing Plone 5.1 translations