### PR TITLE
Add required plone.app.imaging as direct dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ New features:
 
 Bug fixes:
 
+- Add required ``plone.app.imaging`` as direct dependency.
+  Note, in Plone 5.1 plone.app.imaging is no dependency anymore.
+  [thet]
+
 - Ignore invalid ``sort_on`` parameters in catalog ``searchResults``.
   Otherwise you get a ``CatalogError``.
   I get crazy sort_ons like '194' or 'null'.

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'plone.app.discussion',
         'plone.app.folder',
         'plone.app.i18n',
+        'plone.app.imaging',
         'plone.app.multilingual',
         'plone.app.layout >=1.1.7dev-r23744',
         'plone.app.linkintegrity >=1.0.3',


### PR DESCRIPTION
Just got an error when doing a travis build of collective.lineage:
https://travis-ci.org/collective/collective.lineage/jobs/338999501

plone.app.imaging is a direct dependency of CMFPlone, so it must be declared.
In Plone 5.1 this dependency has gone.