### PR TITLE
Fix test

### DIFF
--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
@@ -98,7 +98,7 @@ class TestSiteAdministratorRoleFunctional(UserGroupsControlPanelTestCase):
         # make sure we can view the Site Setup page,
         # at both old and new URLs
         res = self.publish(
-            '/plone/@@overview-controlpanel', 'siteadmin:secret')
+            '/plone/plone_control_panel', 'siteadmin:secret')
         self.assertEqual(200, res.status)
         res = self.publish(
             '/plone/@@overview-controlpanel', 'siteadmin:secret'


### PR DESCRIPTION
Reverts https://github.com/plone/Products.CMFPlone/commit/bc138edd52daea42d321f2f1fa55b06e1c2107e6

The test states that it is ensuring that **both** URLs do work to get to the Plone's control panel, but since that commit, is actually testing twice the same URL :sweat_smile: 