### PR TITLE
Render exceptions as preformatted text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Bug Fixes:
 - Fix Exception-View when main_template can't be rendered. Fixes #2325.
   [pbauer]
 
+- Render exceptions as text, not html to fix format of infos after traceback.
+  [pbauer]
+
 - Removed extra methods and tests for CMFQuickInstallerTool.
   Moved those to the Products.CMFQuickInstallerTool package.
   [maurits]

--- a/Products/CMFPlone/browser/exceptions.py
+++ b/Products/CMFPlone/browser/exceptions.py
@@ -23,7 +23,7 @@ class ExceptionView(BrowserView):
         error_type = exception.__class__.__name__
         exc_type, value, traceback = sys.exc_info()
         error_tb = ''.join(
-            format_exception(exc_type, value, traceback, as_html=True))
+            format_exception(exc_type, value, traceback, as_html=False))
         request.response.setStatus(exc_type)
 
         # Indicate exception as JSON

--- a/Products/CMFPlone/browser/templates/error_message.pt
+++ b/Products/CMFPlone/browser/templates/error_message.pt
@@ -103,7 +103,7 @@
                    Here is the full error message:
                    </p>
 
-                   <div tal:replace="structure err_tb"/>
+                   <pre tal:content="err_tb"/>
                 </div>
 
                 <tal:noentry condition="not:isManager">


### PR DESCRIPTION
html-formatted exceptions ruin the infos after the traceback.

Before:
![bildschirmfoto 2018-03-02 um 15 17 09](https://user-images.githubusercontent.com/453208/36903068-ced3642e-1e2c-11e8-910e-04d899232ed9.png)

After:
![bildschirmfoto 2018-03-02 um 15 16 00](https://user-images.githubusercontent.com/453208/36903072-d25d2742-1e2c-11e8-94f2-9468b1db9203.png)