### PR TITLE
Fixed bug in ajax standard_error_message.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,9 @@ New features:
 
 Bug fixes:
 
-- Fix controlpanel quickinstaller view: 
+- Fixed bug in ajax standard_error_message.  [djay, maurits]
+
+- Fix controlpanel quickinstaller view:
   A not yet installed product must not return any upgrade info.
   [jensens]
 

--- a/Products/CMFPlone/skins/plone_templates/standard_error_message.py
+++ b/Products/CMFPlone/skins/plone_templates/standard_error_message.py
@@ -31,7 +31,7 @@ if "text/html" not in context.REQUEST.getHeader('Accept', ''):
     context.REQUEST.RESPONSE.setHeader("Content-Type", "application/json")
     # Note: using %s instead of .format to avoid possibly expensive guarded
     # attribute check.
-    return '{{"error_type": "%s"}}' % error_type
+    return '{"error_type": "%s"}' % error_type
 
 if error_log_url:
     error_log_id = error_log_url.split('?id=')[1]


### PR DESCRIPTION
Already done on 5.0 last year: 9ead65cbc88445fe2f91a268dc8c2afcb6caf657.