### PR TITLE
change Security link title to "Security Settings"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,9 @@ New Features:
   [thet]
 
 Bug Fixes:
+- change Security control panel link title to "Security Settings"
+  [tkimnguyen]
+  
 - Do not show TinyMCE menu items with no subitems, Fixes #2245.
   [mrsaicharan1]
 

--- a/Products/CMFPlone/profiles/default/controlpanel.xml
+++ b/Products/CMFPlone/profiles/default/controlpanel.xml
@@ -91,7 +91,7 @@
     i18n:attributes="title">
   <permission>Plone Site Setup: Markup</permission>
  </configlet>
- <configlet title="Security" action_id="SecuritySettings"
+ <configlet title="Security Settings" action_id="SecuritySettings"
     appId="SecuritySettings" category="plone-security" condition_expr=""
     icon_expr="string:$portal_url/lock_icon.png"
     url_expr="string:${portal_url}/@@security-controlpanel" visible="True"


### PR DESCRIPTION
to be consistent with the control panel's title and to avoid having a "Security" link inside the "Security" category (seems repetitive)