### PR TITLE
Move the gtbn_funcglobals patch security test to functional tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ New features:
 
 Bug fixes:
 
+- Unflakied a unit test.
+  [Rotonen]
+
 - Add required ``plone.app.imaging`` as direct dependency.
   Note, in Plone 5.1 plone.app.imaging is no dependency anymore.
   [thet]

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -10,15 +10,6 @@ import unittest
 
 class TestAttackVectorsUnit(unittest.TestCase):
 
-    def test_gtbn_funcglobals(self):
-        from Products.CMFPlone.utils import getToolByName
-        try:
-            getToolByName(self.assertTrue, 'func_globals')['__builtins__']
-        except TypeError:
-            pass
-        else:
-            self.fail('getToolByName should block access to non CMF tools')
-
     def test_setHeader_drops_LF(self):
         from ZPublisher.HTTPResponse import HTTPResponse
         response = HTTPResponse()
@@ -60,6 +51,15 @@ allow_module('os')
 
 
 class TestAttackVectorsFunctional(PloneTestCase):
+
+    def test_gtbn_funcglobals(self):
+        from Products.CMFPlone.utils import getToolByName
+        try:
+            getToolByName(self.assertTrue, 'func_globals')['__builtins__']
+        except TypeError:
+            pass
+        else:
+            self.fail('getToolByName should block access to non CMF tools')
 
     def test_widget_traversal_1(self):
         res = self.publish(


### PR DESCRIPTION
Seems the patches having already been run in for the unit test layer actually depends upon a test layer leak. Moving to functional tests to make this test unflaky.