### PR TITLE
Move the gtbn_funcglobals patch security test to functional tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Unflakied a unit test.
+  [Rotonen]
 
 
 5.1.2 (2018-04-08)

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -11,15 +11,6 @@ import unittest
 
 class TestAttackVectorsUnit(unittest.TestCase):
 
-    def test_gtbn_funcglobals(self):
-        from Products.CMFPlone.utils import getToolByName
-        try:
-            getToolByName(self.assertTrue, 'func_globals')['__builtins__']
-        except TypeError:
-            pass
-        else:
-            self.fail('getToolByName should block access to non CMF tools')
-
     def test_setHeader_drops_LF(self):
         from ZPublisher.HTTPResponse import HTTPResponse
         response = HTTPResponse()
@@ -61,6 +52,15 @@ allow_module('os')
 
 
 class TestAttackVectorsFunctional(PloneTestCase):
+
+    def test_gtbn_funcglobals(self):
+        from Products.CMFPlone.utils import getToolByName
+        try:
+            getToolByName(self.assertTrue, 'func_globals')['__builtins__']
+        except TypeError:
+            pass
+        else:
+            self.fail('getToolByName should block access to non CMF tools')
 
     def test_widget_traversal_1(self):
         res = self.publish(


### PR DESCRIPTION
Seems the patches having already been run in for the unit test layer actually depends upon a test layer leak. Moving to functional tests to make this test unflaky.