### PR TITLE
Move the gtbn_funcglobals patch security test to functional tests

### DIFF
--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -12,15 +12,6 @@ ptc.setupPloneSite()
 
 class TestAttackVectorsUnit(unittest.TestCase):
 
-    def test_gtbn_funcglobals(self):
-        from Products.CMFPlone.utils import getToolByName
-        try:
-            getToolByName(self.assertTrue,'func_globals')['__builtins__']
-        except TypeError:
-            pass
-        else:
-            self.fail('getToolByName should block access to non CMF tools')
-
     def test_setHeader_drops_LF(self):
         from ZPublisher.HTTPResponse import HTTPResponse
         response = HTTPResponse()
@@ -61,6 +52,15 @@ allow_module('os')
 
 
 class TestAttackVectorsFunctional(ptc.FunctionalTestCase):
+
+    def test_gtbn_funcglobals(self):
+        from Products.CMFPlone.utils import getToolByName
+        try:
+            getToolByName(self.assertTrue,'func_globals')['__builtins__']
+        except TypeError:
+            pass
+        else:
+            self.fail('getToolByName should block access to non CMF tools')
 
     def test_widget_traversal_1(self):
         res = self.publish('/plone/@@discussion-settings/++widget++moderator_email')

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,7 +19,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Unflakied a unit test.
+  [Rotonen]
 
 
 4.3.17 (2018-03-07)


### PR DESCRIPTION
Seems the patches having already been run in for the unit test layer actually depends upon a test layer leak. Moving to functional tests to make this test unflaky.