### PR TITLE
Revert "Some nested `section id="edit-bar"` tag in folder_contents pa…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Bug fixes:
 - Unflakied a unit test.
   [Rotonen]
 
+- *add item here*
 
 5.1.2 (2018-04-08)
 ------------------

--- a/Products/CMFPlone/static/patterns/toolbar/src/toolbar.js
+++ b/Products/CMFPlone/static/patterns/toolbar/src/toolbar.js
@@ -390,7 +390,7 @@ define([
           url: $('body').attr('data-portal-url') + path + '/@@render-toolbar'
         }).done(function(data) {
           var $el = $(utils.parseBodyTag(data));
-          that.$el.parent.replaceWith($el);
+          that.$el.replaceWith($el);
           Registry.scan($el);
         });
       });


### PR DESCRIPTION
…ge #2322"

This reverts commit a3fb0199a187ebde022b059a9605060ca3067e60.

See: https://github.com/plone/Products.CMFPlone/pull/2398

Fixes: https://github.com/plone/Products.CMFPlone/issues/2395