### PR TITLE
Add Plone Site: do a transaction commit before profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,12 @@ New Features:
 
 Bug Fixes:
 
+- When adding a Plone Site, do a transaction commit before applying extra profiles.
+  This avoids errors in some cases when selecting add-ons in the advanced Plone Site add form,
+  where installing them right after site creation in the add-ons control panel goes fine.
+  Fixes `issue 2316 <https://github.com/plone/Products.CMFPlone/issues/2316>`_.
+  [maurits]
+
 - Unflakied a unit test.
   [Rotonen]
 

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -9,6 +9,9 @@ from zope.event import notify
 from zope.interface import implementer
 from zope.site.hooks import setSite
 
+import transaction
+
+
 _TOOL_ID = 'portal_setup'
 _DEFAULT_PROFILE = 'Products.CMFPlone:plone'
 _CONTENT_PROFILE = 'plone.app.contenttypes:plone-content'
@@ -162,6 +165,14 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     # Do this before applying extension profiles, so the settings from a
     # properties.xml file are applied and not overwritten by this
     site.manage_changeProperties(**props)
+
+    # In some cases we can get errors when add-ons are installed immediately.
+    # Installing the add-ons separately within the Add-ons control panel
+    # goes fine.
+    # One example is https://github.com/plone/Products.CMFPlone/issues/2316
+    # So it seems helpful to do a transaction commit here.
+    if extension_ids:
+        transaction.commit()
 
     for extension_id in extension_ids:
         setup_tool.runAllImportStepsFromProfile(


### PR DESCRIPTION
When adding a Plone Site, do a transaction commit before applying extra profiles. This avoids errors in some cases when selecting add-ons in the advanced Plone Site add form, where installing them right after site creation in the add-ons control panel goes fine.

It should certainly fix some CSRF autoprotection errors raised by the first view after creating a Plone Site.

Fixes https://github.com/plone/Products.CMFPlone/issues/2316.
And I think there was a similar issue raised recently, but I cannot find it.

Note for tests: since this does a transaction commit, any test code that calls `addPloneSite` should use a functional test layer, to avoid leakage into other tests. Case in point is an initial test failure in CMFPlone itself:

```
Error in test testPlonesiteWithoutUnicodeTitle
(Products.CMFPlone.tests.test_factory.TestFactoryPloneSite)
Traceback (most recent call last):
  File ".../unittest/case.py", line 329, in run
    testMethod()
  File ".../Products/CMFPlone/tests/test_factory.py", line 29,
 in testPlonesiteWithoutUnicodeTitle
    self.app, 'ploneFoo', title=TITLE, setup_content=False)
  File ".../Products/CMFPlone/factory.py", line 132, in addPloneSite
    context._setObject(site_id, PloneSite(site_id))
  File ".../OFS/ObjectManager.py", line 324, in _setObject
    v = self._checkId(id)
  File ".../OFS/ObjectManager.py", line 127, in checkValidId
    'The id "%s" is invalid - it is already in use.' % id)
BadRequest: The id "ploneFoo" is invalid - it is already in use.
```

I fixed that in the PR by adding a condition: when no extra profiles are selected, don't do a commit.
Only two test files in CMFPlone call `addPloneSite` directly, plus of course `plone.app.testing` in test layer setup, so this should not normally cause problems.

This PR is for master (5.2). I can port it to other versions once approved. I would say: only 5.1.