### PR TITLE
Add Plone Site: do a transaction commit before profiles [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,13 +18,18 @@ New features:
 
 Bug fixes:
 
+- When adding a Plone Site, do a transaction commit before applying extra profiles.
+  This avoids errors in some cases when selecting add-ons in the advanced Plone Site add form,
+  where installing them right after site creation in the add-ons control panel goes fine.
+  Fixes `issue 2316 <https://github.com/plone/Products.CMFPlone/issues/2316>`_.
+  [maurits]
+
 - Move forgotten 'registered' template from skins to plone.app.users, were it belongs to.
   [jensens]
 
 - Unflakied a unit test.
   [Rotonen]
 
-- *add item here*
 
 5.1.2 (2018-04-08)
 ------------------

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -9,6 +9,9 @@ from zope.event import notify
 from zope.interface import implementer
 from zope.site.hooks import setSite
 
+import transaction
+
+
 _TOOL_ID = 'portal_setup'
 _DEFAULT_PROFILE = 'Products.CMFPlone:plone'
 _CONTENT_PROFILE = 'plone.app.contenttypes:plone-content'
@@ -162,6 +165,14 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     # Do this before applying extension profiles, so the settings from a
     # properties.xml file are applied and not overwritten by this
     site.manage_changeProperties(**props)
+
+    # In some cases we can get errors when add-ons are installed immediately.
+    # Installing the add-ons separately within the Add-ons control panel
+    # goes fine.
+    # One example is https://github.com/plone/Products.CMFPlone/issues/2316
+    # So it seems helpful to do a transaction commit here.
+    if extension_ids:
+        transaction.commit()
 
     for extension_id in extension_ids:
         setup_tool.runAllImportStepsFromProfile(


### PR DESCRIPTION
This is a backport of #2410 to Plone 5.1.

When adding a Plone Site, do a transaction commit before applying extra profiles.
This avoids errors in some cases when selecting add-ons in the advanced Plone Site add form, where installing them right after site creation in the add-ons control panel goes fine.

Fixes https://github.com/plone/Products.CMFPlone/issues/2316 for Plone 5.1.