### PR TITLE
After site creation, do not render a template: we redirect anyway [5.2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ New Features:
 
 Bug Fixes:
 
+- After site creation, do not render the add-site template: we redirect anyway.
+  [maurits]
+
 - Unflakied a unit test.
   [Rotonen]
 

--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -271,6 +271,7 @@ class AddPloneSite(BrowserView):
                 portal_timezone=form.get('portal_timezone', 'UTC')
             )
             self.request.response.redirect(site.absolute_url())
+            return u''
 
         return self.index()
 


### PR DESCRIPTION
Discovered in https://github.com/plone/Products.CMFPlone/pull/2410#issuecomment-388774551.
I don't think this solves any of the related errors, like a CSRF warning/error, but we should not render a template (the add-site form here) when we will not show it to the user anyway.