### PR TITLE
After site creation, do not render a template: we redirect anyway [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,13 +18,15 @@ New features:
 
 Bug fixes:
 
+- After site creation, do not render the add-site template: we redirect anyway.
+  [maurits]
+
 - Move forgotten 'registered' template from skins to plone.app.users, were it belongs to.
   [jensens]
 
 - Unflakied a unit test.
   [Rotonen]
 
-- *add item here*
 
 5.1.2 (2018-04-08)
 ------------------

--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -272,6 +272,7 @@ class AddPloneSite(BrowserView):
                 portal_timezone=form.get('portal_timezone', 'UTC')
             )
             self.request.response.redirect(site.absolute_url())
+            return u''
 
         return self.index()
 


### PR DESCRIPTION
Backport of #2413 to Plone 5.1.