### PR TITLE
Do not include too new upgrades when upgrading Plone Site. [5.2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ New Features:
 
 - Provide an utility ``dump_json_to_text`` that works both on Python 2.7 an Python 3.
   [ale-rt]
+
 - Prepare for Python 2 / 3 compatibility.
   [pbauer]
 
@@ -55,11 +56,17 @@ New Features:
 
 - Mockup update.
   [thet]
-  
+
 - add link to Plone.org VPAT accessibility statement
   [tkimnguyen]
 
 Bug Fixes:
+
+- Do not include too new upgrades when upgrading Plone Site.
+  Otherwise the Plone Site ends up at a newer version that the filesystem code supports,
+  giving an error when upgrading, and resulting in possibly missed upgrades later.
+  Fixes `issue 2377 <https://github.com/plone/Products.CMFPlone/issues/2377>`_.
+  [maurits]
 
 - After site creation, do not render the add-site template: we redirect anyway.
   [maurits]

--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -231,6 +231,32 @@ class MigrationTool(PloneBaseTool, UniqueObject, SimpleItem):
         # Does this thing now need recataloging?
         return self._needRecatalog
 
+    security.declareProtected(ManagePortal, 'listUpgrades')
+
+    def listUpgrades(self):
+        # List available upgrade steps for our default profile.
+        # Do not include upgrade steps for too new versions:
+        # using a newer plone.app.upgrade version should not give problems.
+        setup = getToolByName(self, 'portal_setup')
+        fs_version = self.getFileSystemVersion()
+        steps = setup.listUpgrades(_DEFAULT_PROFILE)
+        upgrades = []
+        for upgrade_step in steps:
+            if isinstance(upgrade_step, list):
+                # This is a nested list of upgrade steps,
+                # which must have the same destination.
+                # So take the first one.
+                if not upgrade_step:
+                    # Empty list, not sure if this can happen in practice.
+                    continue
+                dest = upgrade_step[0].get('sdest')
+            else:
+                dest = upgrade_step.get('sdest')
+            if dest > fs_version and dest != 'all':
+                break
+            upgrades.append(upgrade_step)
+        return upgrades
+
     security.declareProtected(ManagePortal, 'upgrade')
 
     def upgrade(self, REQUEST=None, dry_run=None, swallow_errors=True):
@@ -239,7 +265,7 @@ class MigrationTool(PloneBaseTool, UniqueObject, SimpleItem):
 
         # This sets the profile version if it wasn't set yet
         version = self.getInstanceVersion()
-        upgrades = setup.listUpgrades(_DEFAULT_PROFILE)
+        upgrades = self.listUpgrades()
         steps = []
         for u in upgrades:
             if isinstance(u, list):

--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -279,8 +279,8 @@ class AddPloneSite(BrowserView):
 class Upgrade(BrowserView):
 
     def upgrades(self):
-        ps = getattr(self.context, 'portal_setup')
-        return ps.listUpgrades(_DEFAULT_PROFILE)
+        pm = getattr(self.context, 'portal_migration')
+        return pm.listUpgrades()
 
     def versions(self):
         pm = getattr(self.context, 'portal_migration')

--- a/Products/CMFPlone/tests/testMigrationTool.py
+++ b/Products/CMFPlone/tests/testMigrationTool.py
@@ -28,17 +28,22 @@ class TestMigrationTool(PloneTestCase.PloneTestCase):
         self.assertFalse(self.migration.needRecatalog(),
                          'Migration needs recataloging')
 
-    def testListUpgradeSteps(self):
+    def testListSetupUpgradeSteps(self):
         # There should be no upgrade steps from the current version
         upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
-        self.assertTrue(len(upgrades) == 0)
+        self.assertEqual(len(upgrades), 0)
+
+    def testListOwnUpgradeSteps(self):
+        # There should be no upgrade steps from the current version
+        upgrades = self.migration.listUpgrades()
+        self.assertEqual(len(upgrades), 0)
 
     def testDoUpgrades(self):
         self.setRoles(['Manager'])
 
         self.setup.setLastVersionForProfile(_DEFAULT_PROFILE, '2.5')
-        upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
-        self.assertTrue(len(upgrades) > 0)
+        upgrades = self.migration.listUpgrades()
+        self.assertGreater(len(upgrades), 0)
 
         request = self.portal.REQUEST
         request.form['profile_id'] = _DEFAULT_PROFILE
@@ -60,8 +65,8 @@ class TestMigrationTool(PloneTestCase.PloneTestCase):
         self.assertEqual(last, current)
 
         # There are no more upgrade steps available
-        upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
-        self.assertTrue(len(upgrades) == 0)
+        upgrades = self.migration.listUpgrades()
+        self.assertEqual(len(upgrades), 0)
 
     def testUpgrade(self):
         self.setRoles(['Manager'])
@@ -75,8 +80,69 @@ class TestMigrationTool(PloneTestCase.PloneTestCase):
         self.assertEqual(last, current)
 
         # There are no more upgrade steps available
+        upgrades = self.migration.listUpgrades()
+        self.assertEqual(len(upgrades), 0)
+
+
+class TestMigrationWithExtraUpgrades(PloneTestCase.PloneTestCase):
+    """Test a migration with a too new upgrade available.
+
+    There should be no upgrade steps newer than the current version.
+    If our FS profile version is 5, and there is an upgrade to 6,
+    we do not want to see it.  This just means we have a newer
+    plone.app.upgrade, which is fine.
+    """
+
+    def afterSetUp(self):
+        from Products.GenericSetup.upgrade import _registerUpgradeStep
+        from Products.GenericSetup.upgrade import UpgradeStep
+
+        self.migration = getToolByName(self.portal, "portal_migration")
+        self.setup = getToolByName(self.portal, "portal_setup")
+
+        def failing_upgrade(context):
+            raise AssertionError('Too new upgrade should not be run!')
+
+        # Register a too new upgrade.
+        fs_version = self.migration.getFileSystemVersion()
+        new_version = unicode(int(fs_version) + 1)
+        new_step = UpgradeStep(
+            'Too new upgrade', _DEFAULT_PROFILE,
+            fs_version, new_version,
+            '', failing_upgrade, None, '1')
+        self.step_id = new_step.id
+        _registerUpgradeStep(new_step)
+
+    def beforeTearDown(self):
+        # Remove the extra step from the upgrade registry,
+        # otherwise this bleeds over into other tests.
+        from Products.GenericSetup.upgrade import _upgrade_registry
+        profile_steps = _upgrade_registry.getUpgradeStepsForProfile(
+            _DEFAULT_PROFILE)
+        profile_steps.pop(self.step_id, None)
+
+    def testListUpgradeStepsNotTooNew(self):
+        # portal_setup happily reports the newer upgrade
         upgrades = self.setup.listUpgrades(_DEFAULT_PROFILE)
-        self.assertTrue(len(upgrades) == 0)
+        self.assertGreater(len(upgrades), 0)
+        # Our migration tool no longer shows it.
+        upgrades = self.migration.listUpgrades()
+        self.assertEqual(len(upgrades), 0)
+
+    def testUpgrade(self):
+        self.setRoles(['Manager'])
+        self.setup.setLastVersionForProfile(_DEFAULT_PROFILE, '2.5')
+        self.migration.upgrade()
+
+        # And we have reached our current profile version
+        current = self.setup.getVersionForProfile(_DEFAULT_PROFILE)
+        current = tuple(current.split('.'))
+        last = self.setup.getLastVersionForProfile(_DEFAULT_PROFILE)
+        self.assertEqual(last, current)
+
+        # There are no more upgrade steps available
+        upgrades = self.migration.listUpgrades()
+        self.assertEqual(len(upgrades), 0)
 
 
 class TestAddonList(PloneTestCase.PloneTestCase):


### PR DESCRIPTION
Otherwise the Plone Site ends up at a newer version that the filesystem code supports,
giving an error when upgrading, and resulting in possibly missed upgrades later.

Forward port of #2411 to Plone 5.2.