### PR TITLE
Do not include too new upgrades when upgrading Plone Site. [4.3]

### DIFF
--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -230,8 +230,8 @@ class AddPloneSite(BrowserView):
 class Upgrade(BrowserView):
 
     def upgrades(self):
-        ps = getattr(self.context, 'portal_setup')
-        return ps.listUpgrades(_DEFAULT_PROFILE)
+        pm = getattr(self.context, 'portal_migration')
+        return pm.listUpgrades()
 
     def versions(self):
         pm = getattr(self.context, 'portal_migration')

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -19,6 +19,12 @@ New features:
 
 Bug fixes:
 
+- Do not include too new upgrades when upgrading Plone Site.
+  Otherwise the Plone Site ends up at a newer version that the filesystem code supports,
+  giving an error when upgrading, and resulting in possibly missed upgrades later.
+  Fixes `issue 2377 <https://github.com/plone/Products.CMFPlone/issues/2377>`_.
+  [maurits]
+
 - Unflakied a unit test.
   [Rotonen]
 


### PR DESCRIPTION
Backport of #2411 to Plone 4.3.