### PR TITLE
Adapt tests to `Products.GenericSetup >= 2.0`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 
 Breaking changes:
 
+- Adapt tests to `Products.GenericSetup >= 2.0` thus requiring at least that
+  version.
+  [icemac]
+
 - Some tools from CMFCore are now utilities
   [pbauer]
 

--- a/Products/CMFPlone/exportimport/tests/testControlPanel.py
+++ b/Products/CMFPlone/exportimport/tests/testControlPanel.py
@@ -7,7 +7,7 @@ from zope.component import provideUtility
 from zope.component import provideAdapter
 
 _CONTROLPANEL_XML = """\
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <object name="portal_controlpanel" meta_type="Plone Control Panel Tool">
  <configlet title="Add/Remove Products" action_id="QuickInstaller"
     appId="QuickInstaller" category="Plone" condition_expr=""

--- a/Products/CMFPlone/exportimport/tests/testPropertiesTool.py
+++ b/Products/CMFPlone/exportimport/tests/testPropertiesTool.py
@@ -5,7 +5,7 @@ from Products.CMFPlone.PropertiesTool import SimpleItemWithProperties
 from zope.component import provideAdapter
 
 _PROPERTYSHEET_XML = """\
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <object name="site_properties" meta_type="Plone Property Sheet">
  <property name="title">Site wide properties</property>
  <property name="displayPublicationDateInByline"
@@ -14,7 +14,7 @@ _PROPERTYSHEET_XML = """\
 """
 
 _PROPERTIESTOOL_XML = """\
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <object name="portal_properties" meta_type="Plone Properties Tool">
  <object name="site_properties" meta_type="Plone Property Sheet">
   <property name="title">Site wide properties</property>

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
     'Products.CMFUid',
     'Products.DCWorkflow',
     'Products.ExtendedPathIndex',
-    'Products.GenericSetup >= 1.8.2',
+    'Products.GenericSetup >= 2.0.dev0',
     'Products.MimetypesRegistry',
     'Products.PlonePAS',
     'Products.PluggableAuthService',


### PR DESCRIPTION
This is needed to get Plone 5.2 coredev buildout green again. After the Python 3 changes of `Products.GenericSetup` have been merged to master.