### PR TITLE
When allowing unicode ids in py3 Zope changes the regex for allowed i…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ New Features:
 
 Bug Fixes:
 
+- Fix tests after changes in disallowed object ids in Zope.
+  [pbauer]
+
 - Do not include too new upgrades when upgrading Plone Site.
   Otherwise the Plone Site ends up at a newer version that the filesystem code supports,
   giving an error when upgrading, and resulting in possibly missed upgrades later.

--- a/Products/CMFPlone/tests/testCheckId.py
+++ b/Products/CMFPlone/tests/testCheckId.py
@@ -64,14 +64,14 @@ class TestCheckId(PloneTestCase):
         self.assertEqual(r, None)   # success
 
     def testBadId(self):
+        # See https://github.com/zopefoundation/Zope/pull/181
         r = self.folder.check_id('=')
-        self.assertEqual(r, u'= is not a legal name. The following characters '
-                            u'are invalid: =')
+        self.assertEqual(r, None)
 
     def testDecodeId(self):
+        # See https://github.com/zopefoundation/Zope/pull/181
         r = self.folder.check_id('\xc3\xa4')
-        self.assertEqual(r, u'\xe4 is not a legal name. The following '
-                            u'characters are invalid: \xe4')
+        self.assertEqual(r, None)
 
     def testCatalogIndex(self):
         # TODO: Tripwire


### PR DESCRIPTION
…ds. See https://github.com/zopefoundation/Zope/pull/181