### PR TITLE
Hide plone.app.querystring from add-ons control panel. [5.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New features:
 
 Bug fixes:
 
+- Hide ``plone.app.querystring`` from add-ons control panel.
+  Fixes `issue 2426 <https://github.com/plone/Products.CMFPlone/issues/2426>`_.
+  [maurits]
+
 - Fix https://github.com/plone/Products.CMFPlone/issues/2394, error on login after password reset.
   [jensens, agitator]
 

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -49,6 +49,7 @@ class NonInstallable(object):
             'plone.app.imaging',
             'plone.app.intid',
             'plone.app.linkintegrity',
+            'plone.app.querystring',
             'plone.app.registry',
             'plone.app.referenceablebehavior',
             'plone.app.relationfield',


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2426