### PR TITLE
Hide plone.app.querystring from add-ons control panel. [5.2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,10 @@ New Features:
 
 Bug Fixes:
 
+- Hide ``plone.app.querystring`` from add-ons control panel.
+  Fixes `issue 2426 <https://github.com/plone/Products.CMFPlone/issues/2426>`_.
+  [maurits]
+
 - Fix tests after changes in disallowed object ids in Zope.
   [pbauer]
 

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -49,6 +49,7 @@ class NonInstallable(object):
             'plone.app.imaging',
             'plone.app.intid',
             'plone.app.linkintegrity',
+            'plone.app.querystring',
             'plone.app.registry',
             'plone.app.referenceablebehavior',
             'plone.app.relationfield',


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2426