### PR TITLE
Fixed tests when IRichText behavior is used.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed tests when IRichText behavior is used.
+  IRichText -> IRichTextBehavior
+  This is a follow up to `issue 476 <https://github.com/plone/plone.app.contenttypes/issues/476>`_.
+  [iham]
 
 
 5.1.3 (2018-06-22)

--- a/Products/CMFPlone/profiles/default/metadata.xml
+++ b/Products/CMFPlone/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>5113</version>
+  <version>5114</version>
 </metadata>

--- a/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
+++ b/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
@@ -51,7 +51,7 @@ browser.
 Now that the document has been added, we can edit it, but we pretend
 we don't know better and forget to type in a Title:
 
-    >>> browser.getControl(name='form.widgets.IRichText.text').value = 'About me'
+    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = 'About me'
     >>> browser.getControl('Save').click()
     >>> 'Required input is missing.' in browser.contents
     True
@@ -186,7 +186,7 @@ between cut and paste, the page should say so and not give a stacktrace.
 
     >>> browser.open('http://nohost/plone')
     >>> browser.getLink('Page').click()
-    >>> browser.getControl(name='form.widgets.IRichText.text').value = ''
+    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = ''
     >>> browser.getControl('Title').value = 'Op een dag'
     >>> browser.getControl('Save').click()
     >>> 'Op een dag' in browser.contents

--- a/Products/CMFPlone/tests/browser_collection_views.txt
+++ b/Products/CMFPlone/tests/browser_collection_views.txt
@@ -35,8 +35,8 @@ First create a folder and a demo collection:
     >>> collection_description = 'Description. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod.'
     >>> browser.getControl(name='form.widgets.IDublinCore.description').value = collection_description
     >>> collection_text = '<p>Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>'
-    >>> browser.getControl(name='form.widgets.IRichText.text').value = collection_text
-    >>> browser.getControl(name='form.widgets.IRichText.text.mimeType').value = ['text/html']
+    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = collection_text
+    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text.mimeType').value = ['text/html']
     >>> browser.getControl('Save').click()
 
 Now let's login and visit the collection in the test browser:


### PR DESCRIPTION
this is a follow up test fix for [issue 476](https://github.com/plone/plone.app.contenttypes/issues/476) in plone.app.contenttypes

this pr will break as the fix in p.a.ct is not used by default right now and i don't know how to enforce that - i guess: no chance