### PR TITLE
Fix registration of robots.txt browser view to avoid AttributeError on Zope's root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Breaking changes:
 
 Bug fixes:
 
+- Fix registration of ``robots.txt`` browser view to avoid ``AttributeError`` on Zope's root (fixes `#2052 <https://github.com/plone/Products.CMFPlone/issues/2052>`_).
+  [hvelarde]
+
 - Get rid of obsolete ``X-UA-Compatible`` header.
   [hvelarde]
 

--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -160,7 +160,7 @@
       />
 
   <browser:page
-      for="*"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
       name="robots.txt"
       class=".robots.Robots"
       permission="zope.Public"


### PR DESCRIPTION
closes #2052 