### PR TITLE
Fix registration of robots.txt browser view to avoid AttributeError on Zope's root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ New features:
 
 Bug fixes:
 
+- Fix registration of ``robots.txt`` browser view to avoid ``AttributeError`` on Zope's root (fixes `#2052 <https://github.com/plone/Products.CMFPlone/issues/2052>`_).
+  [hvelarde]
+
 - Fix plone.app.redirector support for JSON/unspecified requests.
   [rpatterson]
 

--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -159,7 +159,7 @@
       />
 
   <browser:page
-      for="*"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
       name="robots.txt"
       class=".robots.Robots"
       permission="zope.Public"


### PR DESCRIPTION
refs. #2052 