### PR TITLE
Factored out format_size method for replacing getObjSize.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Breaking changes:
 
 New features:
 
+- Factored out format_size method for replacing getObjSize.py. #1801
+  [reinhardt]
+
 - Update TinyMCE to 4.7.13
   [erral]
 

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -219,16 +219,9 @@ SIZE_CONST = {'KB': 1024, 'MB': 1024 * 1024, 'GB': 1024 * 1024 * 1024}
 SIZE_ORDER = ('GB', 'MB', 'KB')
 
 
-@indexer(Interface)
-def getObjSize(obj):
-    """ Helper method for catalog based folder contents.
-    """
+def format_size(size):
+    """ Get a human readable size string. """
     smaller = SIZE_ORDER[-1]
-
-    if base_hasattr(obj, 'get_size'):
-        size = obj.get_size()
-    else:
-        size = 0
 
     # if the size is a float, then make it an int
     # happens for large files
@@ -248,6 +241,18 @@ def getObjSize(obj):
                 break
         return '%.1f %s' % (float(size / float(SIZE_CONST[c])), c)
     return size
+
+
+@indexer(Interface)
+def getObjSize(obj):
+    """ Helper method for catalog based folder contents.
+    """
+    if base_hasattr(obj, 'get_size'):
+        size = obj.get_size()
+    else:
+        size = 0
+
+    return format_size(size)
 
 
 @indexer(Interface)


### PR DESCRIPTION
The only difference I can see between the skin script getObjSize.py and the indexer method getObjSize is that the former takes a ```size``` parameter as an alternative to getting the size from an object. I've factored out a format_size() method that can easily be used instead of the skin script in places where it is used that way (i.e. with the ```size``` parameter).

See #1801
