### PR TITLE
Fix toolbar word break

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,10 @@ New features:
 
 Bug fixes:
 
-- Fix toolbar menu on mobile #2333.
+-- Fix wrong CSS property to allow correct word-break.
+  [tmassman]
+
+ Fix toolbar menu on mobile #2333.
   [tmassman]
 
 - Removed the ``raiseUnauthorized`` skin script.

--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -12,9 +12,10 @@
   left: 0;
   width: @plone-left-toolbar;
   height: 100%;
-  hyphens: auto;
   color: @plone-toolbar-text-color;
   background: @plone-toolbar-bg;
+  word-wrap: break-word;
+  hyphens: auto;
 
   a {
     display: block;
@@ -507,9 +508,8 @@
 
   nav > ul a > span + span {
     width: @plone-left-toolbar-expanded - 40px;
+    max-width: @plone-left-toolbar-expanded - 40px;  // needed fixed size for word-wrap to work properly.
     text-align: left;
-    word-wrap: break-word;
-    word-break: break-word;
     background: none;
   }
 


### PR DESCRIPTION
Fix wrong CSS selector which prevents correct word break of too long toolbar titles.