### PR TITLE
Revert "Fixed tests when IRichText behavior is used."

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Reverted test fix for richtext behavior.
+  [maurits]
 
 
 5.1.4.rc3 (2018-10-08)

--- a/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
+++ b/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
@@ -51,7 +51,7 @@ browser.
 Now that the document has been added, we can edit it, but we pretend
 we don't know better and forget to type in a Title:
 
-    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = 'About me'
+    >>> browser.getControl(name='form.widgets.IRichText.text').value = 'About me'
     >>> browser.getControl('Save').click()
     >>> 'Required input is missing.' in browser.contents
     True
@@ -186,7 +186,7 @@ between cut and paste, the page should say so and not give a stacktrace.
 
     >>> browser.open('http://nohost/plone')
     >>> browser.getLink('Page').click()
-    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = ''
+    >>> browser.getControl(name='form.widgets.IRichText.text').value = ''
     >>> browser.getControl('Title').value = 'Op een dag'
     >>> browser.getControl('Save').click()
     >>> 'Op een dag' in browser.contents

--- a/Products/CMFPlone/tests/browser_collection_views.txt
+++ b/Products/CMFPlone/tests/browser_collection_views.txt
@@ -35,8 +35,8 @@ First create a folder and a demo collection:
     >>> collection_description = 'Description. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod.'
     >>> browser.getControl(name='form.widgets.IDublinCore.description').value = collection_description
     >>> collection_text = '<p>Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>'
-    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = collection_text
-    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text.mimeType').value = ['text/html']
+    >>> browser.getControl(name='form.widgets.IRichText.text').value = collection_text
+    >>> browser.getControl(name='form.widgets.IRichText.text.mimeType').value = ['text/html']
     >>> browser.getControl('Save').click()
 
 Now let's login and visit the collection in the test browser:


### PR DESCRIPTION
This reverts commit 45ceb3b9a6c77e0c9d964a49110ddbec87c5a3e6.
The related change was reverted in Plone 5.1.
See discussion at https://github.com/plone/plone.app.contenttypes/pull/480

Test this in combination with https://github.com/plone/plone.app.contenttypes/pull/496