### PR TITLE
Modernize robot keywords that use "Get Element Attribute" (5.1)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Bug fixes:
 - Fix profile version.
   [esteele]
 
+- Modernize robot keywords that use "Get Element Attribute"
+  [ale-rt]
+
 
 5.1.4.rc4 (2018-10-10)
 ----------------------

--- a/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -89,7 +89,7 @@ With the label
 
 label "${title}"
     [Return]  ${for}
-    ${for}=  Get Element Attribute  xpath=//label[contains(., "${title}")]@for
+    ${for}=  Get Element Attribute  xpath=//label[contains(., "${title}")]  for
 
 label2 "${title}"
     [Return]  ${for}


### PR DESCRIPTION
See: http://robotframework.org/Selenium2Library/Selenium2Library.html#Get%20Element%20Attribute