### PR TITLE
Load legacy resources like comments.js

### DIFF
--- a/Products/CMFPlone/resources/browser/cook.py
+++ b/Products/CMFPlone/resources/browser/cook.py
@@ -88,7 +88,7 @@ def cookWhenChangingSettings(context, bundle=None):
 
         if css_path:
             for css_resource in resource.css:
-                css_url = '/' + css_resource
+                css_url = css_resource
                 response = subrequest(css_url)
                 if response.status == 200:
                     logger.info('Cooking css %s', css_resource)
@@ -107,7 +107,7 @@ def cookWhenChangingSettings(context, bundle=None):
                     logger.warn('Could not find resource: %s' , css_resource)
         if not resource.js or not js_path:
             continue
-        js_url = '/' + resource.js
+        js_url = resource.js
         response = subrequest(js_url)
         if response.status == 200:
             js = response.getBody()

--- a/Products/CMFPlone/resources/browser/cook.py
+++ b/Products/CMFPlone/resources/browser/cook.py
@@ -88,7 +88,7 @@ def cookWhenChangingSettings(context, bundle=None):
 
         if css_path:
             for css_resource in resource.css:
-                css_url = siteUrl + '/' + css_resource
+                css_url = '/' + css_resource
                 response = subrequest(css_url)
                 if response.status == 200:
                     logger.info('Cooking css %s', css_resource)
@@ -107,7 +107,7 @@ def cookWhenChangingSettings(context, bundle=None):
                     logger.warn('Could not find resource: %s' , css_resource)
         if not resource.js or not js_path:
             continue
-        js_url = siteUrl + '/' + resource.js
+        js_url = '/' + resource.js
         response = subrequest(js_url)
         if response.status == 200:
             js = response.getBody()

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -73,6 +73,17 @@ class TestResourceRegistries(PloneTestCase.PloneTestCase):
         )
         self.assertTrue('body{color:blue}' in resp_css.getBody())
 
+        resp_js = subrequest(
+            '{0}/++plone++static/plone-legacy-compiled.js'.format(
+                self.portal.absolute_url()
+            )
+        )
+        body = resp_js.getBody()
+        self.assertTrue(
+            'resource: ++resource++plone.app.discussion.javascripts/comments.js'
+            in body)
+        self.assertFalse('Could not find resource' in body)
+
     def test_dont_minify_already_minified(self):
         registry = getUtility(IRegistry)
         bundles = registry.collectionOfInterface(IBundleRegistry,

--- a/news/2627.bugfix
+++ b/news/2627.bugfix
@@ -1,0 +1,3 @@
+Load legacy resources like comments.js
+Compile ++plone++static/plone-legacy-compiled.js with correct resource url of comments.js and others, use relative path instead of site url.
+[ksuess]


### PR DESCRIPTION
Compile ++plone++static/plone-legacy-compiled.js with correct resource url of comments.js and others.
see #2626