### PR TITLE
[Hold merge][5.1] Test that we do not have pending upgrades

### DIFF
--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -885,6 +885,9 @@ class TestPortalCreation(PloneTestCase.PloneTestCase):
         view = ExportStepsView(self.setup, None)
         self.assertEqual([i['id'] for i in view.invalidSteps()], [])
 
+    def testNoPendingUpgrades(self):
+        self.assertListEqual(self.setup.listProfilesWithPendingUpgrades(), [])
+
 
 class TestPortalBugs(PloneTestCase.PloneTestCase):
 

--- a/news/2637.bugfix
+++ b/news/2637.bugfix
@@ -1,0 +1,1 @@
+Test that we do not have pending upgrades


### PR DESCRIPTION
Add a test that verifies that we do not have any pending upgrade after the site creation.

This one maybe needs some modification in https://github.com/zopefoundation/Products.GenericSetup/blob/fe1292f808cdad8df6a3701fdf2ddc30513fbc12/Products/GenericSetup/tool.py#L1038

Refs. #2637 