### PR TITLE
Fix Folder layout fallback to default view if not existing

### DIFF
--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -688,7 +688,10 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
         else:
             browserDefault = queryAdapter(obj, IBrowserDefault)
         if browserDefault is not None:
-            layout = browserDefault.getLayout(check_exists=True)
+            default_view_fallback = False
+            if base_hasattr(obj, 'getTypeInfo'):
+                default_view_fallback = obj.getTypeInfo().default_view_fallback
+            layout = browserDefault.getLayout(check_exists=default_view_fallback)
             if layout is None:
                 raise AttributeError(
                     "%s has no assigned layout, perhaps it needs an FTI" % obj)

--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -688,7 +688,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
         else:
             browserDefault = queryAdapter(obj, IBrowserDefault)
         if browserDefault is not None:
-            layout = browserDefault.getLayout()
+            layout = browserDefault.getLayout(check_exists=True)
             if layout is None:
                 raise AttributeError(
                     "%s has no assigned layout, perhaps it needs an FTI" % obj)

--- a/news/2645.bugfix
+++ b/news/2645.bugfix
@@ -1,0 +1,1 @@
+Fixed fallback to default view when selected layout does not exist for Folder. [gbastien]


### PR DESCRIPTION
Call browserDefault.getLayout() with parameter check_exists=True to fallback to default view in case layout selected for Folder does not exist.

This is related to https://github.com/plone/Products.CMFDynamicViewFTI/issues/16

A test for this issue is added to Products.CMFDynamicViewFTI, a PR is waiting there (https://github.com/plone/Products.CMFDynamicViewFTI/pull/17).

Thank you,

Gauthier