### PR TITLE
Restore the possibility to sort catalog query results with multiple indexes [5.2.x]

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -437,10 +437,20 @@ class CatalogTool(PloneBaseTool, BaseTool):
         if not show_inactive and not self.allow_inactive(kw):
             kw['effectiveRange'] = DateTime()
 
-        sort_on = kw.get('sort_on')
-        if sort_on and sort_on not in self.indexes():
-            # I get crazy sort_ons like '194' or 'null'.
-            kw.pop('sort_on')
+        # filter out invalid sort_on indexes
+        sort_on = kw.get('sort_on') or []
+        if isinstance(sort_on, six.string_types):
+            sort_on = [sort_on]
+        valid_indexes = self.indexes()
+        try:
+            sort_on = [idx for idx in sort_on if idx in valid_indexes]
+        except TypeError:
+            # sort_on is not iterable
+            sort_on = []
+        if not sort_on:
+            kw.pop('sort_on', None)
+        else:
+            kw['sort_on'] = sort_on
 
         return ZCatalog.searchResults(self, query, **kw)
 

--- a/Products/CMFPlone/tests/testCatalogTool.py
+++ b/Products/CMFPlone/tests/testCatalogTool.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 from Acquisition import aq_base
 from DateTime import DateTime
+from functools import partial
 from OFS.ObjectManager import REPLACEABLE
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -11,20 +12,22 @@ from plone.dexterity.content import CEILING_DATE
 from plone.indexer.wrapper import IndexableObjectWrapper
 from plone.uuid.interfaces import IAttributeUUID
 from plone.uuid.interfaces import IUUID
-from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFCore.indexing import processQueue
+from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFPlone.CatalogTool import CatalogTool
 from Products.CMFPlone.CatalogTool import is_folderish
 from Products.CMFPlone.tests import dummy
 from Products.CMFPlone.tests.PloneTestCase import PloneTestCase
 from Products.CMFPlone.tests.utils import folder_position
+from z3c.form.interfaces import IFormLayer
 from zope.event import notify
 from zope.interface import alsoProvides
 from zope.lifecycleevent import ObjectCreatedEvent
-from z3c.form.interfaces import IFormLayer
+
 import transaction
 import unittest
 import zope.interface
+
 
 user2 = 'u2'
 group2 = 'g2'
@@ -551,6 +554,36 @@ class TestCatalogSorting(PloneTestCase):
         self.folder.doc4.reindexObject()
         self.folder.doc5.reindexObject()
         self.folder.doc6.reindexObject()
+
+    def testSortMultipleColumns(self):
+        path = '/'.join(self.folder.getPhysicalPath())
+        query = partial(self.catalog, path=path)
+        brains = query(sort_on=['portal_type', 'sortable_title'])
+        self.assertListEqual(
+            [brain.getPath() for brain in brains],
+            [
+                '/plone/Members/test_user_1_/doc2',
+                '/plone/Members/test_user_1_/doc3',
+                '/plone/Members/test_user_1_/doc',
+                '/plone/Members/test_user_1_/doc5',
+                '/plone/Members/test_user_1_/doc6',
+                '/plone/Members/test_user_1_/doc4',
+                '/plone/Members/test_user_1_'
+            ],
+        )
+        brains = query(sort_on=['portal_type', 'getId'])
+        self.assertListEqual(
+            [brain.getPath() for brain in brains],
+            [
+                '/plone/Members/test_user_1_/doc',
+                '/plone/Members/test_user_1_/doc2',
+                '/plone/Members/test_user_1_/doc3',
+                '/plone/Members/test_user_1_/doc4',
+                '/plone/Members/test_user_1_/doc5',
+                '/plone/Members/test_user_1_/doc6',
+                '/plone/Members/test_user_1_',
+            ]
+        )
 
     def testUnknownSortOnIsIgnored(self):
         # You should not get a CatalogError when an invalid sort_on is passed.

--- a/news/2464.fixed
+++ b/news/2464.fixed
@@ -1,0 +1,1 @@
+Restore the possibility to sort catalog query results with multiple indexes


### PR DESCRIPTION
Fixes #2464