### PR TITLE
Add async and defer attributes to bundles (5.2)

### DIFF
--- a/Products/CMFPlone/interfaces/resources.py
+++ b/Products/CMFPlone/interfaces/resources.py
@@ -130,3 +130,15 @@ class IBundleRegistry(zope.interface.Interface):
              SimpleTerm('logged-in', 'logged-in', 'logged-in')]),
         default=u"",
         required=False)
+
+    load_async = schema.Bool(
+        title=_(u"Load asynchronously"),
+        description=_("Load the JavaScript files asynchronously by adding an ``async`` attribute to the script tag."),
+        default=False,
+        required=False)
+
+    load_defer = schema.Bool(
+        title=_(u"Load deffered"),
+        description=_("Load the JavaScript files deffered after the document has been parsed but before ``DOMContentLoaded`` by adding a ``defer`` attribute to the script tag."),
+        default=False,
+        required=False)

--- a/Products/CMFPlone/profiles/dependencies/registry.xml
+++ b/Products/CMFPlone/profiles/dependencies/registry.xml
@@ -1171,7 +1171,9 @@
     <value key="enabled">True</value>
     <value key="jscompilation">++plone++static/plone-compiled.min.js</value>
     <value key="csscompilation">++plone++static/plone-compiled.css</value>
-    <value key="last_compilation">2018-09-26 16:00:00</value>
+    <value key="last_compilation">2018-10-04 12:00:00</value>
+    <value key="load_async">False</value>
+    <value key="load_defer">False</value>
     <value key="stub_js_modules">
       <element>jquery</element>
     </value>
@@ -1189,6 +1191,8 @@
     <value key="csscompilation">++plone++static/plone-logged-in-compiled.css</value>
     <value key="last_compilation">2018-09-26 16:00:00</value>
     <value key="depends">plone</value>
+    <value key="load_async">False</value>
+    <value key="load_defer">False</value>
     <value key="stub_js_modules">
       <element>backbone</element>
       <element>bootstrap-dropdown</element>
@@ -1231,6 +1235,8 @@
     <value key="last_compilation">2018-09-26 16:00:00</value>
     <value key="compile">False</value>
     <value key="enabled">True</value>
+    <value key="load_async">False</value>
+    <value key="load_defer">False</value>
   </records>
 
   <records prefix="plone.bundles/resourceregistry"
@@ -1242,6 +1248,8 @@
     <value key="jscompilation">++plone++static/resourceregistry-compiled.min.js</value>
     <value key="csscompilation">++plone++static/resourceregistry-compiled.css</value>
     <value key="last_compilation">2018-09-26 16:00:00</value>
+    <value key="load_async">False</value>
+    <value key="load_defer">False</value>
     <value key="stub_js_modules">
       <element>jquery</element>
     </value>

--- a/Products/CMFPlone/resources/browser/scripts.pt
+++ b/Products/CMFPlone/resources/browser/scripts.pt
@@ -10,7 +10,12 @@
 </tal:if><tal:if condition="condcomment">
     <tal:opencc tal:replace="structure string:&lt;!--[if ${condcomment}]&gt;" />
 </tal:if>
-  <script tal:attributes="src script/src; data-bundle script/bundle"></script>
+  <script type="text/javascript"
+      tal:attributes="
+        src script/src;
+        data-bundle script/bundle;
+        async script/async|nothing;
+        defer script/defer|nothing"/>
 <tal:if condition="condcomment">
   <tal:closecc tal:condition="condcomment" tal:replace="structure string:&lt;![endif]--&gt;" />
 </tal:if><tal:if condition="resetrjs">

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -18,12 +18,14 @@ from Products.CMFPlone.resources.browser.styles import StylesView
 from Products.CMFPlone.resources.bundle import Bundle
 from Products.CMFPlone.resources.exportimport.resourceregistry import ResourceRegistryNodeAdapter  # noqa
 from Products.CMFPlone.tests import PloneTestCase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.GenericSetup.context import SetupEnviron
 from xml.dom.minidom import parseString
 from zope.component import getUtility
 
 import json
 import mock
+import os
 
 
 class TestResourceRegistries(PloneTestCase.PloneTestCase):
@@ -205,6 +207,91 @@ class TestResourceRegistries(PloneTestCase.PloneTestCase):
             )
         )
         self.assertIn(b'error cooking', resp.getBody())
+
+    def test_bundle_defer_async(self):
+        registry = getUtility(IRegistry)
+
+        bundles = registry.collectionOfInterface(
+            IBundleRegistry,
+            prefix="plone.bundles"
+        )
+        bundle = bundles.add('foobar')
+        bundle.name = 'foobar'
+        bundle.jscompilation = 'foobar.js'
+        bundle.csscompilation = 'foobar.css'
+        bundle.resources = ['foobar']
+
+        view = ScriptsView(self.app, self.app.REQUEST, None, None)
+        view.get_cooked_bundles = lambda: [('foobar', bundle)]
+
+        import Products.CMFPlone.resources.browser
+        path = os.path.dirname(Products.CMFPlone.resources.browser.__file__)
+        view.index = ViewPageTemplateFile('scripts.pt', path)
+        view.update()
+
+        self.assertTrue('async="async"' not in view.index(view))
+        self.assertTrue('defer="defer"' not in view.index(view))
+
+        bundle.load_async = True
+        bundle.load_defer = False
+        self.assertTrue('async="async"' in view.index(view))
+        self.assertTrue('defer="defer"' not in view.index(view))
+
+        bundle.load_async = False
+        bundle.load_defer = True
+        self.assertTrue('async="async"' not in view.index(view))
+        self.assertTrue('defer="defer"' in view.index(view))
+
+        bundle.load_async = True
+        bundle.load_defer = True
+
+        self.assertTrue('async="async"' in view.index(view))
+        self.assertTrue('defer="defer"' in view.index(view))
+
+        bundle.load_async = False
+        bundle.load_defer = False
+
+        self.assertTrue('async="async"' not in view.index(view))
+        self.assertTrue('defer="defer"' not in view.index(view))
+
+    def test_bundle_defer_async_production(self):
+        registry = getUtility(IRegistry)
+
+        bundles = registry.collectionOfInterface(
+            IBundleRegistry,
+            prefix="plone.bundles"
+        )
+        bundles['plone'].load_async = False
+        bundles['plone'].load_defer = False
+        bundles['plone-logged-in'].load_async = False
+        bundles['plone-logged-in'].load_defer = False
+
+        view = ScriptsView(self.app, self.app.REQUEST, None, None)
+
+        import Products.CMFPlone.resources.browser
+        path = os.path.dirname(Products.CMFPlone.resources.browser.__file__)
+        view.index = ViewPageTemplateFile('scripts.pt', path)
+        view.update()
+
+        self.assertTrue('async="async"' not in view.index(view))
+        self.assertTrue('defer="defer"' not in view.index(view))
+
+        bundles['plone'].load_async = True
+        bundles['plone'].load_defer = False
+        self.assertEqual(view.index(view).count('async="async"'), 1)
+        self.assertEqual(view.index(view).count('defer="defer"'), 0)
+
+        bundles['plone'].load_async = False
+        bundles['plone'].load_defer = True
+        self.assertEqual(view.index(view).count('async="async"'), 0)
+        self.assertEqual(view.index(view).count('defer="defer"'), 1)
+
+        bundles['plone'].load_async = True
+        bundles['plone'].load_defer = True
+        bundles['plone-logged-in'].load_async = True
+        bundles['plone-logged-in'].load_defer = True
+        self.assertEqual(view.index(view).count('async="async"'), 2)
+        self.assertEqual(view.index(view).count('defer="defer"'), 2)
 
 
 class TestResourceNodeImporter(PloneTestCase.PloneTestCase):
@@ -530,14 +617,26 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertTrue(scripts.development)
 
         scripts.update()
-        results = scripts.scripts()
+        result = scripts.scripts()[-1]
         self.assertEqual(
-            results[-1],
-            {
-                'src': 'http://nohost/plone/++resource++foo.js?version=123',
-                'conditionalcomment': None,
-                'bundle': 'foo'
-            }
+            result['src'],
+            'http://nohost/plone/++resource++foo.js?version=123'
+        )
+        self.assertEqual(
+             result['conditionalcomment'],
+             None
+        )
+        self.assertEqual(
+            result['bundle'],
+            'foo',
+        )
+        self.assertEqual(
+            result['async'],
+            None
+        )
+        self.assertEqual(
+            result['defer'],
+            None
         )
 
     @mock.patch.object(

--- a/news/2649.feature
+++ b/news/2649.feature
@@ -1,0 +1,4 @@
+- Add ``load_async`` and ``load_defer`` attributes to resource registries bundle settings.
+  When set, ``<script>`` tags are rendered with ``async="async"`` resp. ``defer="defer"`` attributes.
+  In production mode, the setting from the ``plone`` resp. ``plone-logged-in`` bundles are used for the ``default`` resp. ``logged-in`` meta bundles (``merge_with`` setting). 
+  [thet]


### PR DESCRIPTION
Add ``load_async`` and ``load_defer`` attributes to resource registries bundle settings.
When set, ``<script>`` tags are rendered with ``async="async"`` resp. ``defer="defer"`` attributes.
In production mode, the setting from the ``plone`` resp. ``plone-logged-in`` bundles are used for the ``default`` resp. ``logged-in`` meta bundles (``merge_with`` setting).