### PR TITLE
Do not load the production bundles with async or defer (Plone 5.2)

### DIFF
--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -154,11 +154,6 @@ class ScriptsView(ResourceView):
             result = self.default_resources()
             result.extend(self.ordered_bundles_result())
         else:
-            # Acquire load_async and load_defer bundle options from the plone
-            # bundle and use it for the ``default`` meta bundle.
-            bundles = self.get_bundles()
-            load_async = getattr(bundles.get('plone'), 'load_async', False)
-            load_defer = getattr(bundles.get('plone'), 'load_defer', False)
             result = [{
                 'src': '{0}/++plone++{1}'.format(
                     self.site_url,
@@ -166,15 +161,10 @@ class ScriptsView(ResourceView):
                 ),
                 'conditionalcomment': None,
                 'bundle': 'production',
-                'async': 'async' if load_async else None,
-                'defer': 'defer' if load_defer else None
-            }, ]
+                'async': None,  # Do not load ``async`` or
+                'defer': None   # ``defer`` for production bundles.
+            }]
             if not self.anonymous:
-                # Acquire load_async and load_defer bundle options from the
-                # plone-logged-in bundle and use it for the ``logged-in`` meta
-                # bundle.
-                load_async = getattr(bundles.get('plone-logged-in'), 'load_async', False)  # noqa
-                load_defer = getattr(bundles.get('plone-logged-in'), 'load_defer', False)  # noqa
                 result.append({
                     'src': '{0}/++plone++{1}'.format(
                         self.site_url,
@@ -182,8 +172,8 @@ class ScriptsView(ResourceView):
                     ),
                     'conditionalcomment': None,
                     'bundle': 'production',
-                    'async': 'async' if load_async else None,
-                    'defer': 'defer' if load_defer else None
+                    'async': None,  # Do not load ``async`` or
+                    'defer': None   # ``defer`` for production bundles.
                 })
             result.extend(self.ordered_bundles_result(production=True))
 

--- a/Products/CMFPlone/static/plone.js
+++ b/Products/CMFPlone/static/plone.js
@@ -94,6 +94,6 @@ require([
         var select = $('#form-widgets-highpixeldensity_scales');
         select.change(autohide_quality_fields);
     }
-});
+  });
 
 });

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -255,6 +255,10 @@ class TestResourceRegistries(PloneTestCase.PloneTestCase):
         self.assertTrue('defer="defer"' not in view.index(view))
 
     def test_bundle_defer_async_production(self):
+        """The default and logged-in production bundles should never be loaded
+        async or defered.
+        For bundles to be loaded async or defered, you need to empty merge_with
+        """
         registry = getUtility(IRegistry)
 
         bundles = registry.collectionOfInterface(
@@ -277,17 +281,20 @@ class TestResourceRegistries(PloneTestCase.PloneTestCase):
         self.assertTrue('defer="defer"' not in view.index(view))
 
         bundles['plone'].load_async = True
-        bundles['plone'].load_defer = False
-        self.assertEqual(view.index(view).count('async="async"'), 1)
-        self.assertEqual(view.index(view).count('defer="defer"'), 0)
-
-        bundles['plone'].load_async = False
         bundles['plone'].load_defer = True
         self.assertEqual(view.index(view).count('async="async"'), 0)
-        self.assertEqual(view.index(view).count('defer="defer"'), 1)
+        self.assertEqual(view.index(view).count('defer="defer"'), 0)
 
+        bundles['plone'].merge_with = ''
         bundles['plone'].load_async = True
         bundles['plone'].load_defer = True
+        self.assertEqual(view.index(view).count('async="async"'), 1)
+        self.assertEqual(view.index(view).count('defer="defer"'), 1)
+
+        bundles['plone'].merge_with = ''
+        bundles['plone'].load_async = True
+        bundles['plone'].load_defer = True
+        bundles['plone-logged-in'].merge_with = ''
         bundles['plone-logged-in'].load_async = True
         bundles['plone-logged-in'].load_defer = True
         self.assertEqual(view.index(view).count('async="async"'), 2)

--- a/news/2649.feature
+++ b/news/2649.feature
@@ -1,4 +1,6 @@
 - Add ``load_async`` and ``load_defer`` attributes to resource registries bundle settings.
   When set, ``<script>`` tags are rendered with ``async="async"`` resp. ``defer="defer"`` attributes.
-  In production mode, the setting from the ``plone`` resp. ``plone-logged-in`` bundles are used for the ``default`` resp. ``logged-in`` meta bundles (``merge_with`` setting). 
+  You also need to empty the ``merge_with`` property of your bundle, because production bundles (``default.js`` and ``logged-in.js``) are never loaded with async or defer.
+  The default.js includes jQuery and requirejs and those are needed at many places and therefore cannot be loaded asynchronously.
+  Refs: #2649, #2657.
   [thet]


### PR DESCRIPTION
Hotfix: default.js and logged-in.js are not loaded asynchronously.
You also need to empty the ``merge_with`` property of your bundle, because production bundles (``default.js`` and ``logged-in.js``) are never loaded with async or defer.
The default.js includes jQuery and requirejs and those are needed at many places and therefore cannot be loaded asynchronously.