### PR TITLE
Do not save type settings in "content-controlpanel" when switching between types.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,8 @@ Bug fixes:
 - Modernize robot keywords that use "Get Element Attribute" [ale-rt] (#2615)
 - Fix metabundle resource ordering to pay attention to depends setting
   [vangheem] (#2641)
-
+- Do not save type settings in "content-controlpanel" when switching between types.
+  [cekk]
 
 Changelog
 =========

--- a/Products/CMFPlone/controlpanel/browser/types.py
+++ b/Products/CMFPlone/controlpanel/browser/types.py
@@ -122,7 +122,7 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
         cancel_button = form.get('form.button.Cancel', None) is not None
         type_id = form.get('old_type_id', None)
 
-        if submitted and not cancel_button:
+        if save_button and submitted and not cancel_button:
             if type_id:
                 portal_types = getToolByName(self.context, 'portal_types')
                 portal_repository = getToolByName(self.context,

--- a/Products/CMFPlone/controlpanel/browser/types.py
+++ b/Products/CMFPlone/controlpanel/browser/types.py
@@ -200,9 +200,9 @@ class TypesControlPanel(AutoExtensibleForm, form.EditForm):
                 elif not default_page_type and type_id in default_page_types:
                     default_page_types.remove(type_id)
                 types_settings.default_page_types = default_page_types
-
-                redirect_links = form.get('redirect_links', False)
-                types_settings.redirect_links = redirect_links
+                if type_id == 'Link':
+                    redirect_links = form.get('redirect_links', False)
+                    types_settings.redirect_links = redirect_links
 
             # Update workflow
             if self.have_new_workflow() \

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
@@ -110,7 +110,7 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         self.browser.getControl(name='type_id').value = ['Document']
         self.browser.getForm(action=self.types_url).submit()
         self.browser.getControl(name='versionpolicy').value = ['off']
-        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(name="form.button.Save").click()
 
         portal_types = self.portal.portal_types
         doc_type = portal_types.Document
@@ -123,7 +123,7 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         self.browser.getControl(name='type_id').value = ['Document']
         self.browser.getForm(action=self.types_url).submit()
         self.browser.getControl(name='versionpolicy').value = ['off']
-        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(name="form.button.Save").click()
 
         portal_types = self.portal.portal_types
         doc_type = portal_types.Document
@@ -132,7 +132,7 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
             not in doc_type.behaviors)  # noqa
 
         self.browser.getControl(name='versionpolicy').value = ['manual']
-        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(name="form.button.Save").click()
 
         self.assertTrue(
             'plone.app.versioningbehavior.behaviors.IVersionable'
@@ -165,3 +165,33 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
         self.assertTrue(
             'plone.app.lockingbehavior.behaviors.ILocking'
             in file_type.behaviors)
+
+    def test_dont_update_settings_when_switch_types(self):
+        # First of all, set a default
+        self.browser.open(self.types_url)
+        self.browser.getControl(name='type_id').value = ['Link']
+        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(
+            'Redirect immediately to link target'
+        ).selected = True
+        self.browser.getControl('Save').click()
+
+        # Then switch the type
+        self.browser.getControl(name='type_id').value = ['Document']
+        self.browser.getForm(action=self.types_url).submit()
+        self.assertFalse(
+            'Redirect immediately to link target' in self.browser.contents
+        )
+
+        # Go back to the link, and check the value
+        self.browser.getControl(name='type_id').value = ['Link']
+        self.browser.getForm(action=self.types_url).submit()
+
+        self.assertTrue(
+            'Redirect immediately to link target' in self.browser.contents
+        )
+        self.assertEquals(
+            self.browser.getControl(
+                'Redirect immediately to link target').selected,
+            True
+        )

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
@@ -157,7 +157,7 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
             not in file_type.behaviors)  # noqa
 
         self.browser.getControl(name='versionpolicy').value = ['manual']
-        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl('Save').click()
 
         self.assertTrue(
             'plone.app.versioningbehavior.behaviors.IVersionable'

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_types.py
@@ -195,3 +195,34 @@ class TypesControlPanelFunctionalTest(unittest.TestCase):
                 'Redirect immediately to link target').selected,
             True
         )
+
+    def test_dont_update_redirect_links_when_not_in_link_settings(self):
+        # First of all, set a default
+        self.browser.open(self.types_url)
+        self.browser.getControl(name='type_id').value = ['Link']
+        self.browser.getForm(action=self.types_url).submit()
+        self.browser.getControl(
+            'Redirect immediately to link target'
+        ).selected = True
+        self.browser.getControl('Save').click()
+
+        # Then switch the type
+        self.browser.getControl(name='type_id').value = ['Document']
+        self.browser.getForm(action=self.types_url).submit()
+        self.assertFalse(
+            'Redirect immediately to link target' in self.browser.contents
+        )
+        self.browser.getControl('Save').click()
+
+        # Go back to the link, and check the value
+        self.browser.getControl(name='type_id').value = ['Link']
+        self.browser.getForm(action=self.types_url).submit()
+
+        self.assertTrue(
+            'Redirect immediately to link target' in self.browser.contents
+        )
+        self.assertEquals(
+            self.browser.getControl(
+                'Redirect immediately to link target').selected,
+            True
+        )


### PR DESCRIPTION
I've found two problems with previous implementation:
- every time you switch between types, settings are saved and we perform some unwanted db writes
- if we set "redirect_links" for Link type and save, and the switch to another type, this setting will be overwrite with a default (False) because the value isn't in the form.

With this change, we save settings only when the "Save" button is pressed.

This fix is for 5.1 branch, but i could fix it also on the master