### PR TITLE
[a11y] Added role attribute for portalMessage (5.1.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Bug fixes:
   [vangheem] (#2641)
 - Do not save type settings in "content-controlpanel" when switching between types.
   [cekk]
+- a11y: Added role attribute for portalMessage
+  [nzambello]
 
 Changelog
 =========

--- a/Products/CMFPlone/browser/templates/author.pt
+++ b/Products/CMFPlone/browser/templates/author.pt
@@ -32,7 +32,7 @@
                                 username view/username">
 
         <tal:noAuthor condition="not: author">
-            <dl class="portalMessage error">
+            <dl class="portalMessage error" role="alert">
                 <dt i18n:translate="">
                     Error
                 </dt>

--- a/Products/CMFPlone/controlpanel/browser/maintenance.pt
+++ b/Products/CMFPlone/controlpanel/browser/maintenance.pt
@@ -15,8 +15,9 @@
          <metal:block define-macro="header">
 
              <dl tal:define="status view/status"
-                  tal:condition="status"
-                  class="portalMessage info">
+                 tal:condition="status"
+                 role="status"
+                 class="portalMessage info">
                  <dt i18n:translate="">
                      Info
                  </dt>

--- a/Products/CMFPlone/controlpanel/browser/overview.pt
+++ b/Products/CMFPlone/controlpanel/browser/overview.pt
@@ -22,7 +22,8 @@
     </p>
 
     <div class="portalMessage warning"
-        tal:condition="view/upgrade_warning">
+         role="status"
+         tal:condition="view/upgrade_warning">
         <strong i18n:translate="">
             Warning
         </strong>
@@ -41,7 +42,8 @@
     </div>
 
     <div class="portalMessage warning"
-        tal:condition="view/mailhost_warning">
+         role="status"
+         tal:condition="view/mailhost_warning">
         <strong i18n:translate="">
             Warning
         </strong>
@@ -60,7 +62,8 @@
     </div>
 
     <div class="portalMessage warning"
-        tal:condition="view/timezone_warning">
+         role="status"
+         tal:condition="view/timezone_warning">
         <strong i18n:translate="">
             Warning
         </strong>
@@ -80,7 +83,8 @@
     </div>
 
     <div class="portalMessage warning"
-        tal:condition="not:view/pil">
+         role="status"
+         tal:condition="not:view/pil">
         <strong i18n:translate="">
             Warning
         </strong>

--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -43,7 +43,7 @@
              id="upgrade-products" class="portlet">
           <header class="portletHeader" i18n:translate="">Upgrades</header>
           <section tal:condition="not:products" class="portletContent">
-            <div id="up-to-date-message" class="portalMessage info">
+            <div id="up-to-date-message" class="portalMessage info" role="status">
                  <strong i18n:translate="">No upgrades in this corner</strong>
                  <span i18n:translate="">You are up to date. High fives.</span>
              </div>
@@ -153,7 +153,8 @@
                   <em class="discreet"> – (<span tal:replace="pid">plugin.app.name</span> <span tal:replace="product/version">1.0</span>)</em>
                 </p>
                 <dl class="portalMessage warning"
-                   tal:condition="not:product/uninstall_profile">
+                    role="status"
+                    tal:condition="not:product/uninstall_profile">
                   <dt i18n:translate="">Warning</dt>
                   <dd i18n:translate="">This product cannot be uninstalled!</dd>
                 </dl>
@@ -194,6 +195,7 @@
                       <em class="discreet"> – (<span tal:replace="pid">plugin.app.name</span> <span tal:replace="product/version">1.0</span>)</em>
                     </p>
                     <dl class="portalMessage info"
+                        role="status"
                         tal:condition="not:product/uninstall_profile">
                       <dt i18n:translate="">Info</dt>
                       <dd i18n:translate="">This product cannot be uninstalled!</dd>

--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.pt
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.pt
@@ -30,7 +30,7 @@
    <div id="content-core">
       <span tal:replace="structure context/@@authenticator/authenticator"/>
       <div class="pat-resourceregistry" tal:attributes="data-pat-resourceregistry view/config">
-        <div class="portalMessage info">
+        <div class="portalMessage info" role="status">
           <strong i18n:translate="">Info</strong>
           <span i18n:translate="">If you see this, it is because there was an error rendering the resource registry
           configuration. It's possible you saved a bundle that gives a JavaScript error

--- a/Products/CMFPlone/controlpanel/browser/types.pt
+++ b/Products/CMFPlone/controlpanel/browser/types.pt
@@ -248,7 +248,7 @@
 
                 </tal:workflows>
 
-                <div tal:condition="view/have_new_workflow" class="portalMessage info">
+                <div tal:condition="view/have_new_workflow" class="portalMessage info" role="status">
                     <strong>Info</strong>
                     <span i18n:translate="types_controlpanel_warn_remap">
                         Changing the workflow of a type will take a while, and may slow down

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -52,7 +52,7 @@
           The symbol <img i18n:name="image_link_icon" tal:replace="structure context/site_icon.png" />
           indicates a role inherited from membership in a group.
         </p>
-        <p tal:condition="view/show_users_listing_warning" class="portalMessage warning">
+        <p tal:condition="view/show_users_listing_warning" class="portalMessage warning" role="status">
           <strong i18n:translate="">Note</strong>
           <span i18n:translate="description_pas_users_listing">Some or all of your PAS user source
           plugins do not allow listing of users, so you may not see

--- a/Products/CMFPlone/skins/plone_login/failsafe_login_form.cpt
+++ b/Products/CMFPlone/skins/plone_login/failsafe_login_form.cpt
@@ -43,7 +43,7 @@ If you do not have an account here, head over to the
 </p>
 
 
-<div class="portalMessage error pat-cookietrigger" style="display:none">
+<div class="portalMessage error pat-cookietrigger" style="display:none" role="alert">
     <strong i18n:translate="">
         Error
     </strong>

--- a/Products/CMFPlone/skins/plone_login/login_form.cpt
+++ b/Products/CMFPlone/skins/plone_login/login_form.cpt
@@ -49,7 +49,7 @@
                         target python:test(target in ('_parent', '_top', '_blank', '_self'), target, None);
                         ztu modules/ZTUtils;">
 
-            <div class="portalMessage error pat-cookietrigger" style="display:none">
+            <div class="portalMessage error pat-cookietrigger" style="display:none" role="alert">
                 <strong i18n:translate="">
                     Error
                 </strong>

--- a/Products/CMFPlone/skins/plone_prefs/prefs_error_log_showEntry.pt
+++ b/Products/CMFPlone/skins/plone_prefs/prefs_error_log_showEntry.pt
@@ -28,7 +28,8 @@
         <div tal:define="entry python:context.error_log.getLogEntryById(request.get('id'))">
 
             <div class="portalMessage error"
-                tal:condition="not:entry">
+                 role="alert"
+                 tal:condition="not:entry">
                 <strong i18n:translate="">
                     Error
                 </strong>

--- a/Products/CMFPlone/skins/plone_templates/test_rendering.pt
+++ b/Products/CMFPlone/skins/plone_templates/test_rendering.pt
@@ -40,7 +40,7 @@ Headlines
 
 <pre>Example document rendering</pre>
 
-<div class="portalMessage info">
+<div class="portalMessage info" role="status">
     <strong>
         Info
     </strong>
@@ -50,7 +50,7 @@ Headlines
     </span>
 </div>
 
-<dl class="portalMessage error">
+<dl class="portalMessage error" role="alert">
     <dt>
         Error
     </dt>
@@ -60,7 +60,7 @@ Headlines
     </dd>
 </dl>
 
-<dl class="portalMessage warning">
+<dl class="portalMessage warning" role="status">
     <dt>
         Warning
     </dt>
@@ -146,15 +146,15 @@ definition lists. We replace them in the following manners.
 
 <h4>in portal messages</h4>
 
-<div class="portalMessage info">
+<div class="portalMessage info" role="status">
   <strong>Not important</strong>
   This message is here to tell you something went just as you expected.
 </div>
-<div class="portalMessage warning">
+<div class="portalMessage warning" role="status">
   <strong>You might run into problems</strong>
   Please check your settings, be sure what you're doing is right.
 </div>
-<div class="portalMessage error">
+<div class="portalMessage error" role="alert">
   <strong>Something went wrong</strong>
   This is bad, you must notice this.
 </div>

--- a/news/2675.bugfix
+++ b/news/2675.bugfix
@@ -1,0 +1,1 @@
+a11y: Added role attribute for portalMessage [nzambello]


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.