### PR TITLE
Fix deprecation warning

### DIFF
--- a/Products/CMFPlone/earlypatches/security.py
+++ b/Products/CMFPlone/earlypatches/security.py
@@ -40,7 +40,7 @@ if bbb.HAS_ZSERVER:
     ObjectManager.manage_FTPlist = manage_FTPlist
 
 # 4. Make sure z3c.form widgets don't get declared as public
-from Products.Five.metaconfigure import ClassDirective
+from AccessControl.metaconfigure import ClassDirective
 old_require = ClassDirective.require
 
 


### PR DESCRIPTION
On Plone 5.2 this fixes the following warning:
```
/plone/test-patesting/src/Products.CMFPlone/Products/CMFPlone/earlypatches/security.py:43: DeprecationWarning: ClassDirective is deprecated. Please import from AccessControl.metaconfigure

```