### PR TITLE
Fixed unstable robot test Scenario: A page is opened to edit in TinyMCE.

### DIFF
--- a/Products/CMFPlone/tests/robot/test_tinymce.robot
+++ b/Products/CMFPlone/tests/robot/test_tinymce.robot
@@ -59,6 +59,7 @@ insert link
     Click Button  css=div[aria-label="Insert/edit link"] button
     Click Button  css=.pattern-relateditems-container button.favorites
     Click Link  css=.pattern-relateditems-container .favorites a.fav[href='/']
+    Wait Until Element Is Visible  css=.pattern-relateditems-result-select.selectable
     Click Link  css=.pattern-relateditems-result-select.selectable
     Input Text  css=.plone-modal-body [name="title"]  SomeTitle
     Click Button  css=.plone-modal-footer .plone-btn-primary
@@ -71,6 +72,7 @@ insert image
     Click Button  css=div[aria-label="Insert/edit image"] button
     Click Button  css=.pattern-relateditems-container button.favorites
     Click Link  css=.pattern-relateditems-container .favorites a.fav[href='/']
+    Wait Until Element Is Visible  css=.pattern-relateditems-result-select.selectable
     Click Link  css=.pattern-relateditems-result-select.selectable
     Input Text  css=.plone-modal-body [name="title"]  SomeTitle
     Input Text  css=.plone-modal-body [name="alt"]  SomeAlt

--- a/news/2707.bugfix
+++ b/news/2707.bugfix
@@ -1,0 +1,2 @@
+Fixed unstable robot test Scenario: A page is opened to edit in TinyMCE.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2707.

Related note: I also see a few lines in this file that are meant to keep the tests working on an old Firefox 34. I tried cleaning those up, but that didn't work reliably with Firefox locally. So never mind that for now.