### PR TITLE
Only check once if ATCT is available

### DIFF
--- a/Products/CMFPlone/PloneBaseTool.py
+++ b/Products/CMFPlone/PloneBaseTool.py
@@ -29,7 +29,7 @@ def initializeTFC():
         try:
             pkg_resources.get_distribution('Products.ATContentTypes')
         except pkg_resources.DistributionNotFound:
-            pass
+            TempFolderClass = False
         else:
             from Products.ATContentTypes.tool.factory import TempFolder
             TempFolderClass = TempFolder

--- a/news/2765.bugfix
+++ b/news/2765.bugfix
@@ -1,0 +1,2 @@
+Check only once if Products.ATContentTypes is available.
+[gforcada]


### PR DESCRIPTION
Otherwise the call to check if the distribution is available is done on every single call to ``getOAI``, which can be potentially hundreds of times per request. 

Fixes https://github.com/plone/Products.CMFPlone/issues/2765