### PR TITLE
Fix errors that abort the verification when debugging a DB

### DIFF
--- a/Products/CMFPlone/_scripts/verifydb.py
+++ b/Products/CMFPlone/_scripts/verifydb.py
@@ -82,7 +82,9 @@ def verify_record(oid, data, debug=False):
             try:
                 pickletools.dis(pickle[pos:])
             except Exception:
-                logger.info(traceback.format_exc())
+                # ignore exceptions while disassembling the pickle since the
+                # real issue is that it references a unavailable module
+                pass
             finally:
                 pdb.set_trace()
         elif debug and pos is None:

--- a/Products/CMFPlone/_scripts/verifydb.py
+++ b/Products/CMFPlone/_scripts/verifydb.py
@@ -64,6 +64,7 @@ def verify_record(oid, data, debug=False):
     input_file = io.BytesIO(data)
     unpickler = PersistentUnpickler(None, persistent_load, input_file)
     class_info = 'unknown'
+    pos = None
     try:
         class_info = unpickler.load()
         pos = input_file.tell()
@@ -77,11 +78,15 @@ def verify_record(oid, data, debug=False):
         ))
         logger.info(repr(pickle))
         logger.info(traceback.format_exc())
-        if debug:
+        if debug and pos is not None:
             try:
                 pickletools.dis(pickle[pos:])
+            except Exception:
+                logger.info(traceback.format_exc())
             finally:
                 pdb.set_trace()
+        elif debug and pos is None:
+            pdb.set_trace()
         return False
     return True
 

--- a/news/2792.bugfix
+++ b/news/2792.bugfix
@@ -1,0 +1,2 @@
+Fix errors that abort the verification when debugging a DB with ./bin/instance verifydb -D.
+[pbauer]


### PR DESCRIPTION
 with `./bin/instance verifydb -D`
Fixes #2792