### PR TITLE
Fix several unstable robot tests

### DIFF
--- a/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -45,11 +45,15 @@ the markup control panel
 # --- WHEN -------------------------------------------------------------------
 
 I set allowed types to "${type}"
+  [Documentation]  'Wait until page contains  Changes saved' is nicer, but is unstable. See https://github.com/plone/Products.CMFPlone/issues/2809
   with the label  text/html  UnSelect Checkbox
   with the label  text/x-web-textile  UnSelect Checkbox
   with the label  ${type}   Select Checkbox
   Click Button  Save
-  Wait until page contains  Changes saved
+  Go to  ${PLONE_URL}/@@markup-controlpanel
+  Checkbox Should Be Selected  ${type}
+  Checkbox Should Not Be Selected  text/html
+  Checkbox Should Not Be Selected  text/x-web-textile
 
 I set the default type to "${type}"
   Select from list by label  name=form.widgets.default_type:list  ${type}

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -332,6 +332,7 @@ we expect ${NUM} hits
     mark results
 
 we do not expect any hits
+    Wait Until Element Is Visible  css=div#search-results
     Wait Until Element Contains  css=div#search-results  No results were found.
 
 a logged-in manager

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -70,6 +70,7 @@ Scenario: Searchable text query
     and the querystring pattern
     When I open the criteria Searchable text
     and I search for a
+    and Wait Until Element Is Visible  css=div.querystring-preview
     and Click Element  css=div.querystring-preview
     Then we expect 2 hits
     When I open the criteria Searchable text

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -70,6 +70,7 @@ Scenario: Searchable text query
     and the querystring pattern
     When I open the criteria Searchable text
     and I search for a
+    and Sleep  0.2
     and Wait Until Element Is Visible  css=div.querystring-preview
     and Click Element  css=div.querystring-preview
     Then we expect 2 hits
@@ -332,6 +333,8 @@ we expect ${NUM} hits
     mark results
 
 we do not expect any hits
+    [Documentation]  The search results may be the previous results that are still visible for a short time, so sleep a bit.  Alternatively look at http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html
+    Sleep  0.2
     Wait Until Element Is Visible  css=div#search-results
     Wait Until Element Contains  css=div#search-results  No results were found.
 

--- a/news/2808.bugfix
+++ b/news/2808.bugfix
@@ -1,0 +1,1 @@
+Fixed unstable SearchableText querystring robot test.  [maurits]

--- a/news/2808.bugfix
+++ b/news/2808.bugfix
@@ -1,1 +1,1 @@
-Fixed unstable SearchableText querystring robot test.  [maurits]
+Fixed unstable SearchableText and Scenario Type querystring robot tests.  [maurits]

--- a/news/2809.bugfix
+++ b/news/2809.bugfix
@@ -1,0 +1,1 @@
+Fixed unstable Markup Control Panel robot test.  [maurits]


### PR DESCRIPTION
Fixes #2808 and #2809, plus [Scenario Type Query](https://jenkins.plone.org/job/plone-5.2-python-2.7-robot-chrome/1117/robot/Robot/Test%20Querystring/Scenario%20Type%20query/).
Well, I *hope* it fixes the stability. Locally the tests always passed anyway.