### PR TITLE
Fix some more unstable robot tests by adding waits

### DIFF
--- a/Products/CMFPlone/tests/robot/test_actionmenu.robot
+++ b/Products/CMFPlone/tests/robot/test_actionmenu.robot
@@ -94,7 +94,7 @@ Scenario:
 an actionsmenu page
     Create content  type=Document  title=${TITLE}
     Go to  ${PLONE_URL}/${PAGE_ID}
-
+    Wait until page contains  An actionsmenu page
 
 # --- WHEN -------------------------------------------------------------------
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -111,6 +111,7 @@ anonymous users can see the new action title
 anonymous users can see the actions new ordering
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Accessibility
   Page Should Contain Element   xpath=//div[@id='portal-footer']//ul/li[1]/a/span[contains(text(), 'Accessibility')]
   Page Should Contain Element   xpath=//div[@id='portal-footer']//ul/li[3]/a/span[contains(text(), 'Site Map')]
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -63,6 +63,7 @@ a logged-in administrator
 
 the actions control panel
   Go to  ${PLONE_URL}/@@actions-controlpanel
+  Wait until page contains  Portal actions
 
 # --- WHEN -------------------------------------------------------------------
 
@@ -106,6 +107,7 @@ I unhide the action
 anonymous users can see the new action title
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Accessibility
   Page Should Contain  A new site map
 
 anonymous users can see the actions new ordering
@@ -119,14 +121,17 @@ logged-in users can see the new action
   Disable autologin
   Enable autologin as   Contributor
   Go to  ${PLONE_URL}
+  Wait until page contains  Accessibility
   Page Should Contain  My favorites
 
 anonymous users cannot see the action anymore
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Accessibility
   Page Should Not Contain  Site Map
 
 anonymous users can see the action again
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Accessibility
   Page Should Contain  Site Map

--- a/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
@@ -53,7 +53,7 @@ a document '${title}'
 
 the editing control panel
   Go to  ${PLONE_URL}/@@editing-controlpanel
-
+  Wait until page contains  Editing Settings
 
 # --- WHEN -------------------------------------------------------------------
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -64,6 +64,7 @@ a logged-in site administrator
 
 the filter control panel
   Go to  ${PLONE_URL}/@@filter-controlpanel
+  Wait until page contains  HTML Filtering Settings
 
 Input RichText
   [Arguments]  ${input}

--- a/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
@@ -29,6 +29,7 @@ a logged-in site administrator
 
 the language control panel
   Go to  ${PLONE_URL}/@@language-controlpanel
+  Wait until page contains  Language Settings
 
 
 # --- WHEN -------------------------------------------------------------------
@@ -45,4 +46,5 @@ I set the site language to German
 
 the Plone user interface is in German
   Go to  ${PLONE_URL}
+  Wait until page contains  Sie sind hier
   Page should contain  Sie sind hier

--- a/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -40,6 +40,7 @@ a document '${title}'
 
 the markup control panel
   Go to  ${PLONE_URL}/@@markup-controlpanel
+  Wait until page contains  Markup Settings
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
@@ -53,6 +53,7 @@ Scenario: Filter Navigation By Displayed Types in the Navigation Control Panel
 
 the navigation control panel
   Go to  ${PLONE_URL}/@@navigation-controlpanel
+  Wait until page contains  Navigation Settings
 
 a published document '${title}'
   ${uid}=  a document '${title}'

--- a/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
@@ -41,6 +41,7 @@ a document '${title}'
 
 the search control panel
   Go to  ${PLONE_URL}/@@search-controlpanel
+  Wait until page contains  Search Settings
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/Products/CMFPlone/tests/robot/test_controlpanel_security.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_security.robot
@@ -61,9 +61,11 @@ a logged-in site administrator
 
 the security control panel
   Go to  ${PLONE_URL}/@@security-controlpanel
+  Wait until page contains  Security Settings
 
 a published test folder
   Go to  ${PLONE_URL}/test-folder
+  Wait until element is visible  css=#plone-contentmenu-workflow
   Click link  xpath=//li[@id='plone-contentmenu-workflow']/a
   Wait until element is visible  id=workflow-transition-publish
   Click link  id=workflow-transition-publish
@@ -114,16 +116,19 @@ I enable UUID to be used as a user id
 Anonymous users can register to the site
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Plone site
   Element Should Be Visible  xpath=//a[@id='personaltools-join']
 
 Users can select their own passwords when registering
   Disable autologin
   Go to  ${PLONE_URL}/@@register
+  Wait until page contains  Registration form
   Element Should Be Visible  xpath=//input[@id='form-widgets-password']
 
 Users can use email as their login name
   Disable autologin
   Go to  ${PLONE_URL}/@@register
+  Wait until page contains  Registration form
   Element Should Be Visible  xpath=//input[@id='form-widgets-email']
   Element Should Not Be Visible  xpath=//input[@id='form-widgets-username']
 
@@ -133,6 +138,7 @@ A user folder should be created when a user registers and logs in to the site
 
   # I register to the site
   Go to  ${PLONE_URL}/@@register
+  Wait until page contains  Registration form
   Input Text for sure  form.widgets.username  joe
   Input Text for sure  form.widgets.email  joe@test.com
   Input Text for sure  form.widgets.password  supersecret
@@ -141,6 +147,7 @@ A user folder should be created when a user registers and logs in to the site
 
   # I login to the site
   Go to  ${PLONE_URL}/login
+  Wait until page contains  Login Name
   Input text for sure  __ac_name  joe
   Input text for sure  __ac_password  supersecret
   Click Button  Log in
@@ -148,12 +155,14 @@ A user folder should be created when a user registers and logs in to the site
 
   # The user folder should be created
   Go to  ${PLONE_URL}/Members/joe
+  Wait until page contains  joe
   Element Should Contain  css=h1.documentFirstHeading  joe
   Page should Not contain  This page does not seem to exist
 
 Anonymous users can view 'about' information
   Disable autologin
   Go to  ${PLONE_URL}/@@search?SearchableText=test
+  Wait until page contains  Search results
   Element Should Be Visible  xpath=//span[contains(@class, 'documentAuthor')]
 
 UUID should be used for the user id
@@ -162,6 +171,7 @@ UUID should be used for the user id
 
   # I register to the site
   Go to  ${PLONE_URL}/@@register
+  Wait until page contains  Registration form
   Input Text for sure  form.widgets.username  joe
   Input Text for sure  form.widgets.email  joe@test.com
   Input Text for sure  form.widgets.password  supersecret
@@ -170,6 +180,7 @@ UUID should be used for the user id
 
   # I login to the site
   Go to  ${PLONE_URL}/login
+  Wait until page contains  Login Name
   Input text for sure  __ac_name  joe
   Input text for sure  __ac_password  supersecret
   Click Button  Log in

--- a/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
@@ -100,6 +100,7 @@ the site title should be set to '${expected_site_title}'
 
 the site logo should be set to the custom logo
   Go To  ${PLONE_URL}
+  Wait Until Element Is Visible  css=#portal-logo
   Page should contain element  //*[@id="portal-logo"]/img[contains(@src,'@@site-logo/pixel.png')]
 
 then I can see a sitemap

--- a/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
@@ -36,6 +36,7 @@ a logged-in site administrator
 
 the social control panel
   Go to  ${PLONE_URL}/@@social-controlpanel
+  Wait until page contains  Social Media Settings
 
 
 # --- WHEN -------------------------------------------------------------------
@@ -59,17 +60,20 @@ I provide social settings
 
 social tags should exist for anonymous
   Go to  ${PLONE_URL}
+  Wait until page contains  Plone site
   Page should not contain element  css=meta[name="twitter:site"]
   Page should not contain element  css=meta[property="og:article:publisher"]
   Page should not contain element  css=meta[property="fb:app_id"]
   Disable autologin
   Go to  ${PLONE_URL}
+  Wait until page contains  Plone site
   Page should contain element  css=meta[name="twitter:site"]
   Page should contain element  css=meta[property="og:article:publisher"]
   Page should contain element  css=meta[property="fb:app_id"]
 
 social tags should not exist
   Go to  ${PLONE_URL}
+  Wait until page contains  Plone site
   Page should not contain element  css=meta[name="twitter:site"]
   Page should not contain element  css=meta[property="og:article:publisher"]
   Page should not contain element  css=meta[property="fb:app_id"]

--- a/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
@@ -41,9 +41,11 @@ a logged-in manager
 
 the types control panel
   Go to  ${PLONE_URL}/@@content-controlpanel
+  Wait until page contains  Content Settings
 
 Globaly enabled comments
   Go to  ${PLONE_URL}/@@discussion-settings
+  Wait until page contains  Discussion settings
   Select checkbox  name=form.widgets.globally_enabled:list
   Click button  Save
 
@@ -65,6 +67,7 @@ I select '${workflow}' workflow
 
 I add new Link '${id}'
   Go to  ${PLONE_URL}
+  Wait until page contains  Plone site
   Create content  type=Link  id=${id}  title=${id}  remoteUrl=http://www.starzel.de
 
 
@@ -72,9 +75,11 @@ I add new Link '${id}'
 
 Link '${id}' should have comments enabled
   Go to  ${PLONE_URL}/${id}
+  Wait until page contains  ${id}
   Page should contain element  xpath=//div[@id="commenting"]
 
 Link '${id}' should have Single State Workflow enabled
   Go to  ${PLONE_URL}/${id}
+  Wait until page contains  ${id}
   # We check that single state worklow is used, publish button is not present
   Page should not contain element  xpath=//a[@id="workflow-transition-publish"]

--- a/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
@@ -61,18 +61,22 @@ a logged-in site administrator
 
 the usergroups control panel
   Go to  ${PLONE_URL}/@@usergroup-userprefs
+  Wait until page contains  Users and Groups
 
 
 # --- WHEN -------------------------------------------------------------------
 
 I click show all users
   Click button  Show all
+  Wait until page contains  User Search
 
 I go to Groups control panel
   Click link  Groups
+  Wait until page contains  Group Search
 
 I click show all groups
   Click button  Show all
+  Wait until page contains  Group Search
 
 I create new group
   Click button  Add New Group
@@ -89,11 +93,13 @@ I create new group
 
 I go to Settings control panel
   Click link  Settings
+  Wait until page contains  User and groups settings
 
 enable many groups and many users settings
   Select Checkbox  name=form.widgets.many_groups:list
   Select Checkbox  name=form.widgets.many_users:list
   Click button  Save
+  Wait until page contains  Data successfully updated.
 
 # --- THEN -------------------------------------------------------------------
 
@@ -109,10 +115,12 @@ all groups should be shown
 
 showing all users is disabled
   Click link  Users
+  Wait until page contains  User Search
   Page should not contain  Show all
 
 showing all groups is disabled
   Click link  Groups
+  Wait until page contains  Group Search
   Page should not contain  Show all
 
 new group should show under all groups

--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -73,6 +73,7 @@ Scenario: Form dropdowns follows DateTime widget values
 an edited page
     Create content  type=Document  title=${TITLE}
     Go to  ${PLONE_URL}/${PAGE_ID}/edit
+    Wait until page contains  Edit Page
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
+++ b/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
@@ -80,6 +80,7 @@ a logged-in manager
 
 site registration enabled
   Go To  ${PLONE_URL}/@@security-controlpanel
+  Wait until page contains  Security Settings
   Wait until page contains element  form.widgets.enable_self_reg:list
   Select Checkbox  form.widgets.enable_self_reg:list
   Click Button  Save

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -91,6 +91,7 @@ a link in rich text
 
 should show warning when deleting page
   Go To  ${PLONE_URL}/foo
+  Wait until element is visible  css=#plone-contentmenu-actions a
   Click Link  css=#plone-contentmenu-actions a
   Wait until element is visible  css=#plone-contentmenu-actions-delete
   Click Link  css=#plone-contentmenu-actions-delete
@@ -126,6 +127,7 @@ should not show warning when deleting page from folder_contents
 
 should not show warning when deleting page
   Go To  ${PLONE_URL}/foo
+  Wait until element is visible  css=#plone-contentmenu-actions a
   Click Link  css=#plone-contentmenu-actions a
   Wait until element is visible  css=#plone-contentmenu-actions-delete
   Click Link  css=#plone-contentmenu-actions-delete
@@ -134,6 +136,7 @@ should not show warning when deleting page
 
 remove link to page
   Go To  ${PLONE_URL}/bar
+  Wait until element is visible  css=#contentview-edit a
   Click Link  css=#contentview-edit a
   Wait until element is visible  css=.mce-edit-area iframe
   Select Frame  css=.mce-edit-area iframe

--- a/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -218,12 +218,15 @@ a logged-in site administrator
 
 the users and groups configlet
     Go to  ${PLONE_URL}/@@usergroup-userprefs
+    Wait until page contains  User Search
 
 I click the '${link_name}' link
+    Wait until page contains  ${link_name}
     Element should be visible  xpath=//a[descendant-or-self::*[contains(text(), '${link_name}')]]
     Click Link  xpath=//a[descendant-or-self::*[contains(text(), '${link_name}')]]
 
 the '${link_name}' overlay
+    Wait until page contains  ${link_name}
     Click Link  xpath=//a[descendant-or-self::*[contains(text(), '${link_name}')]]
     Wait until keyword succeeds  30  1  Page should contain element  css=div.plone-modal-dialog
 

--- a/Products/CMFPlone/tests/robot/test_portlets.robot
+++ b/Products/CMFPlone/tests/robot/test_portlets.robot
@@ -24,6 +24,7 @@ Scenario: Add Login Portlet
 
 a manage portlets view
     Go to   ${PLONE_URL}/@@manage-portlets
+    Wait until page contains  Manage portlets
 
 I add a '${portletname}' portlet to the left column
     Select from list  xpath=//div[@id="portletmanager-plone-leftcolumn"]//select  ${portletname}

--- a/Products/CMFPlone/tests/robot/test_thememapper.robot
+++ b/Products/CMFPlone/tests/robot/test_thememapper.robot
@@ -50,6 +50,7 @@ Scenario: Thememapper LESS builder
 
 a new theme to edit
     Go to  ${PLONE_URL}/theming-controlpanel
+    Wait until page contains  Theme settings
     Click Element   jquery=a[href="#modal-copy-barceloneta"]
     Wait Until Element Is Visible   jquery=.plone-modal-body input[type="text"]
     Input Text  jquery=.plone-modal-body input[type="text"]   Test

--- a/Products/CMFPlone/tests/robot/test_tinymce.robot
+++ b/Products/CMFPlone/tests/robot/test_tinymce.robot
@@ -43,6 +43,7 @@ Scenario: A page is opened to edit in TinyMCE
 an edited page
     Create content  type=Document  title=${TITLE}
     Go to  ${PLONE_URL}/${PAGE_ID}/edit
+    Wait until page contains  Edit Page
 
 an uploaded image
     Create content  type=Image  title=an-image

--- a/news/2809.bugfix
+++ b/news/2809.bugfix
@@ -1,1 +1,1 @@
-Fixed unstable Markup Control Panel robot test.  [maurits]
+Fixed unstable Markup Control Panel and other robot tests.   [maurits]


### PR DESCRIPTION
A few of these have actually failed at some point in Jenkins, others probably not. But it seems that if you go to a url or click somewhere, that it is best to first wait on something before you do a test assertion: the browser may need a few (micro) seconds to get to the point where the assertion will pass.  So I added some waits.