### PR TITLE
Don't use // as bundle comment separators Closes #2820

### DIFF
--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -124,9 +124,9 @@ class MetaBundleWriter(object):
         fi = StringIO()
         for bname, script in resources.items():
             fi.write('''
-// Start Bundle: {0}
+/* Start Bundle: {0} */
 {1}
-// End Bundle: {2}
+/* End Bundle: {2} */
 '''.format(bname, script, bname))
         self.folder.writeFile(self.name + postfix, fi)
         resources.clear()

--- a/news/2820.bugfix
+++ b/news/2820.bugfix
@@ -1,0 +1,1 @@
+Don't use // as bundle separators in the resource registry's meta bundle generator. It comments the first css construct in every bundle that follows. [fredvd]


### PR DESCRIPTION
Don't use // as bundle separators in the resource registry's meta bundle generator. It comments the first css construct in every bundle that follows. 

Doesn't need a fix for 5.2/master as the bundle generation was completely rewritten for python3/unicode support.
