### PR TITLE
Fixed unstable Markup Control Panel robot test again.

### DIFF
--- a/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -46,12 +46,11 @@ the markup control panel
 # --- WHEN -------------------------------------------------------------------
 
 I set allowed types to "${type}"
-  [Documentation]  'Wait until page contains  Changes saved' is nicer, but is unstable. See https://github.com/plone/Products.CMFPlone/issues/2809
+  with the label  ${type}   Select Checkbox
   with the label  text/html  UnSelect Checkbox
   with the label  text/x-web-textile  UnSelect Checkbox
-  with the label  ${type}   Select Checkbox
   Click Button  Save
-  Go to  ${PLONE_URL}/@@markup-controlpanel
+  Wait until page contains  Changes saved
   Checkbox Should Be Selected  ${type}
   Checkbox Should Not Be Selected  text/html
   Checkbox Should Not Be Selected  text/x-web-textile

--- a/news/2809.bugfix
+++ b/news/2809.bugfix
@@ -1,0 +1,1 @@
+Fixed unstable Markup Control Panel robot test again.  [maurits]


### PR DESCRIPTION
The test is unstable again on Jenkins.  [Plone 5.2 Python 3.7](https://jenkins.plone.org/job/plone-5.2-python-3.7-robot-chrome/15/robot/report/robot_log.html#s1-s12-t1) this time, but on-and-off there may be other jobs.  See the [trend on 3.7](https://jenkins.plone.org/job/plone-5.2-python-3.7-robot-chrome/15/robot/Robot/Test%20Controlpanel%20Markup/Scenario%3A%20Change%20Default%20Markup%20Types%20in%20the%20Markup%20Control%20Panel/).

The trick seems to be to first check the allowed type that we want to add, and then uncheck the other ones, instead of the other way around. Otherwise you get a slightly belated validation error before pressing Save, and the Save has no effect.  From a local screen shot before pressing Save:

![robot_test_controlpanel_markup_Scenario_Change_Default_Markup_Types_in_the_Markup_Control_Panel_selenium-screenshot-1](https://user-images.githubusercontent.com/210587/55800013-fd406a80-5ad2-11e9-84e7-4c47e234319d.png)


This partially undoes my own fixes from PR #2810.
(If this does not help, we really have to add a 'Sleep  1' before pressing Save.)