### PR TITLE
Pythonify templates

### DIFF
--- a/Products/CMFPlone/browser/login/templates/forced_password_change.pt
+++ b/Products/CMFPlone/browser/login/templates/forced_password_change.pt
@@ -3,7 +3,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="plone"
-      metal:use-macro="context/main_template/macros/master">
+      metal:use-macro="context/@@main_template/macros/master">
 
   <metal:title fill-slot="content-title">
     <h1 class="documentFirstHeading"

--- a/Products/CMFPlone/browser/login/templates/initial_login_password_change.pt
+++ b/Products/CMFPlone/browser/login/templates/initial_login_password_change.pt
@@ -3,7 +3,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="plone"
-      metal:use-macro="context/main_template/macros/master">
+      metal:use-macro="context/@@main_template/macros/master">
 
   <metal:title fill-slot="content-title">
     <h1 class="documentFirstHeading"

--- a/Products/CMFPlone/browser/login/templates/insufficient_privileges.pt
+++ b/Products/CMFPlone/browser/login/templates/insufficient_privileges.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/browser/login/templates/logged_out.pt
+++ b/Products/CMFPlone/browser/login/templates/logged_out.pt
@@ -2,7 +2,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/browser/login/templates/mail_password_form.pt
+++ b/Products/CMFPlone/browser/login/templates/mail_password_form.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/login/templates/mail_password_response.pt
+++ b/Products/CMFPlone/browser/login/templates/mail_password_response.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/login/templates/pwreset_expired.pt
+++ b/Products/CMFPlone/browser/login/templates/pwreset_expired.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/login/templates/pwreset_finish.pt
+++ b/Products/CMFPlone/browser/login/templates/pwreset_finish.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/login/templates/pwreset_form.pt
+++ b/Products/CMFPlone/browser/login/templates/pwreset_form.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/login/templates/pwreset_invalid.pt
+++ b/Products/CMFPlone/browser/login/templates/pwreset_invalid.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 <body>
 

--- a/Products/CMFPlone/browser/templates/accessibility-info.pt
+++ b/Products/CMFPlone/browser/templates/accessibility-info.pt
@@ -3,7 +3,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <body>

--- a/Products/CMFPlone/browser/templates/author.pt
+++ b/Products/CMFPlone/browser/templates/author.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/browser/templates/contact-info.pt
+++ b/Products/CMFPlone/browser/templates/contact-info.pt
@@ -2,7 +2,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/browser/templates/error_message.pt
+++ b/Products/CMFPlone/browser/templates/error_message.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <body>

--- a/Products/CMFPlone/browser/templates/five_template.pt
+++ b/Products/CMFPlone/browser/templates/five_template.pt
@@ -1,5 +1,5 @@
 <metal:macro metal:define-macro="page"
-><html metal:use-macro="context/main_template/macros/master">
+><html metal:use-macro="context/@@main_template/macros/master">
 <head>
 <metal:slot metal:fill-slot="style_slot"
 ><metal:slot metal:define-slot="style_slot" /></metal:slot>

--- a/Products/CMFPlone/browser/templates/main_template.pt
+++ b/Products/CMFPlone/browser/templates/main_template.pt
@@ -5,17 +5,17 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      tal:define="portal_state context/@@plone_portal_state;
-          context_state context/@@plone_context_state;
-          plone_view context/@@plone;
-          plone_layout context/@@plone_layout;
-          lang portal_state/language;
+      tal:define="portal_state python:context.restrictedTraverse('@@plone_portal_state');
+          context_state python:context.restrictedTraverse('@@plone_context_state');
+          plone_view python:context.restrictedTraverse('@@plone');
+          plone_layout python:context.restrictedTraverse('@@plone_layout');
+          lang python:portal_state.language();
           view nocall:view | nocall: plone_view;
           dummy python: plone_layout.mark_view(view);
-          portal_url portal_state/portal_url;
-          checkPermission nocall: context/portal_membership/checkPermission;
-          site_properties context/portal_properties/site_properties;
-          ajax_include_head request/ajax_include_head | nothing;
+          portal_url python:portal_state.portal_url();
+          checkPermission python:context.restrictedTraverse('portal_membership').checkPermission;
+          site_properties python:context.restrictedTraverse('portal_properties').site_properties;
+          ajax_include_head python:request.get('ajax_include_head', False);
           ajax_load python:False;"
       i18n:domain="plone"
       tal:attributes="lang lang;">

--- a/Products/CMFPlone/browser/templates/search.pt
+++ b/Products/CMFPlone/browser/templates/search.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/browser/templates/send_feedback_confirm.pt
+++ b/Products/CMFPlone/browser/templates/send_feedback_confirm.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>
@@ -19,7 +19,7 @@
         i18n:translate="heading_send_feedback_confirm">
         Site Administrator has been contacted.
     </h1>
-	
+
     <div class="documentDescription" i18n:translate="message_send_feedback_confirm">
         A mail has now been sent to the site administrator regarding your
         questions and/or comments.

--- a/Products/CMFPlone/browser/templates/sitemap.pt
+++ b/Products/CMFPlone/browser/templates/sitemap.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <head>

--- a/Products/CMFPlone/skins/plone_prefs/prefs_main_template.pt
+++ b/Products/CMFPlone/skins/plone_prefs/prefs_main_template.pt
@@ -1,5 +1,5 @@
 <metal:page define-macro="master">
-  <tal:block metal:use-macro="context/main_template/macros/master">
+  <tal:block metal:use-macro="context/@@main_template/macros/master">
 
     <metal:block fill-slot="top_slot">
         <metal:override define-slot="top_slot">
@@ -21,7 +21,7 @@
         <metal:slot define-slot="prefs_configlet_wrapper">
           <metal:slot define-slot="prefs_configlet_content">
 
-            <metal:block metal:use-macro="context/main_template/macros/content">
+            <metal:block metal:use-macro="context/@@main_template/macros/content">
               <metal:override metal:fill-slot="main">
                 <metal:slot metal:define-slot="prefs_configlet_main" tal:content="nothing">
                   Page body text

--- a/Products/CMFPlone/skins/plone_templates/index_html.pt
+++ b/Products/CMFPlone/skins/plone_templates/index_html.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <body>

--- a/Products/CMFPlone/skins/plone_templates/recently_modified.pt
+++ b/Products/CMFPlone/skins/plone_templates/recently_modified.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <metal:block fill-slot="top_slot"

--- a/Products/CMFPlone/skins/plone_templates/recently_published.pt
+++ b/Products/CMFPlone/skins/plone_templates/recently_published.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <metal:block fill-slot="top_slot"

--- a/Products/CMFPlone/skins/plone_templates/test_rendering.pt
+++ b/Products/CMFPlone/skins/plone_templates/test_rendering.pt
@@ -5,7 +5,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       i18n:domain="plone">
 
 <body>


### PR DESCRIPTION
Using `@@` should speed up acquiring the template since it bypasses attributes, properties and skin-templates.

I'd prefer using `python:context.restrictedTraverse('@@main_template').macros['master']` but that is  not possible because ttw-customized templates (using `portal_view_customization`) do not allow to call the property `macros`. I don't know why...