### PR TITLE
gracefully handle tracebacks when installing addons during site creation

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.Portal import PloneSite
 from Products.CMFPlone.events import SiteManagerCreatedEvent
 from Products.CMFPlone.interfaces import INonInstallable
@@ -168,11 +169,15 @@ def addPloneSite(context, site_id, title='Plone site', description='',
             setup_tool.runAllImportStepsFromProfile(
                 'profile-%s' % extension_id)
         except Exception as msg:
-            IStatusMessage(request).add(
-                'Could not install {}: {}\n'
+            IStatusMessage(request).add(_(
+                'Could not install ${profile_id}: ${error_msg}! '
                 'Please try to install it manually using the "Addons" '
                 'controlpanel and report any issues to the '
-                'addon maintainers'.format(extension_id, msg.args),
+                'addon maintainers.',
+                mapping={
+                    'profile_id': extension_id,
+                    'error_msg': msg.args,
+                }),
                 type='warning')
 
     if snapshot is True:

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -3,6 +3,7 @@ from Products.CMFPlone.Portal import PloneSite
 from Products.CMFPlone.events import SiteManagerCreatedEvent
 from Products.CMFPlone.interfaces import INonInstallable
 from Products.GenericSetup.tool import SetupTool
+from Products.statusmessages.interfaces import IStatusMessage
 from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
 from zope.event import notify
@@ -163,8 +164,16 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     site.manage_changeProperties(**props)
 
     for extension_id in extension_ids:
-        setup_tool.runAllImportStepsFromProfile(
-            'profile-%s' % extension_id)
+        try:
+            setup_tool.runAllImportStepsFromProfile(
+                'profile-%s' % extension_id)
+        except Exception as msg:
+            IStatusMessage(request).add(
+                'Could not install {}: {}\n'
+                'Please try to install it manually using the "Addons" '
+                'controlpanel and report any issues to the '
+                'addon maintainers'.format(extension_id, msg.args),
+                type='warning')
 
     if snapshot is True:
         setup_tool.createSnapshot('initial_configuration')

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -5,6 +5,7 @@ from Products.CMFPlone.events import SiteManagerCreatedEvent
 from Products.CMFPlone.interfaces import INonInstallable
 from Products.GenericSetup.tool import SetupTool
 from Products.statusmessages.interfaces import IStatusMessage
+from logging import getLogger
 from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
 from zope.event import notify
@@ -17,6 +18,8 @@ _CONTENT_PROFILE = 'plone.app.contenttypes:plone-content'
 
 # A little hint for PloneTestCase
 _IMREALLYPLONE5 = True
+
+logger = getLogger('Plone')
 
 
 @implementer(INonInstallable)
@@ -178,7 +181,10 @@ def addPloneSite(context, site_id, title='Plone site', description='',
                     'profile_id': extension_id,
                     'error_msg': msg.args,
                 }),
-                type='warning')
+                type='error')
+            logger.exception(
+                'Error while installing addon {}. '
+                'See traceback below for details.'.format(extension_id))
 
     if snapshot is True:
         setup_tool.createSnapshot('initial_configuration')

--- a/news/2228.bugfix
+++ b/news/2228.bugfix
@@ -1,0 +1,2 @@
+gracefully handle tracebacks during addon installation
+[petschki]


### PR DESCRIPTION
fixes #2228

This shows a warning instead of the mentioned traceback (https://github.com/plone/Products.CMFPlone/issues/2228#issuecomment-483191236) after creating the site ... 

<img width="1095" alt="Bildschirmfoto 2019-04-15 um 12 24 47" src="https://user-images.githubusercontent.com/511761/56125795-07061a00-5f7a-11e9-9542-fdf70c1c3360.png">
