### PR TITLE
Prevent loading of css at nav_root_url

### DIFF
--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -49,7 +49,7 @@ class TinyMCESettingsGenerator(object):
                 files.append('/'.join([self.nav_root_url, url.strip()]))
         theme = self.get_theme()
         tinymce_content_css = getattr(theme, 'tinymce_content_css', None)
-        if tinymce_content_css is not None:
+        if tinymce_content_css is not None and tinymce_content_css != '':
             for path in theme.tinymce_content_css.split(','):
                 if path.startswith('http://') or path.startswith('https://'):
                     files.append(path)

--- a/news/2861.bugfix
+++ b/news/2861.bugfix
@@ -1,0 +1,1 @@
+ If 'tinymce-content-css' option is missing in themes manifest.cfg prevent unnecessary loading of a css at nav_root_url while editing a page.  [krissik]


### PR DESCRIPTION
If 'tinymce-content-css' option is missing in themes manifest.cfg its default value is `''` (see https://github.com/plone/plone.app.theming/blob/98e8285f9c22700414671a1cdb191e4f903ef3f5/src/plone/app/theming/utils.py#L328). If we check only for `None` here an unnecessary request to nav root is triggered.

I found that while improving performance. It looked like that:
![unnecessary_css](https://user-images.githubusercontent.com/5301889/57620704-db328000-7589-11e9-9d5d-e7ce333eed17.jpg)
