### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/Products/CMFPlone/tests/robot/test_actionmenu.robot
+++ b/Products/CMFPlone/tests/robot/test_actionmenu.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -8,8 +8,8 @@ Library  Remote  ${PLONE_URL}/RobotRemote
 
 Resource  keywords.robot
 
-Test Setup  Run keywords  Open SauceLabs test browser
-Test Teardown  Run keywords  Plone Test Teardown
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test Cases ***************************************************************

--- a/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -12,6 +12,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  Collections

--- a/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -6,6 +6,7 @@ Documentation
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_redirection.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_redirection.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
@@ -6,6 +6,7 @@ Documentation
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 Variables  Products/CMFPlone/tests/robot/variables.py
 
 Library  Remote  ${PLONE_URL}/RobotRemote

--- a/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
@@ -12,6 +12,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
+++ b/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
@@ -12,6 +12,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_folder_contents.robot
+++ b/Products/CMFPlone/tests/robot/test_folder_contents.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -12,12 +12,12 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
 Resource  keywords.robot
 
-# Suite setup  Set Selenium speed  0.5s
 Test Setup  Run keywords  Plone Test Setup
 Test Teardown  Run keywords  Plone Test Teardown
 

--- a/Products/CMFPlone/tests/robot/test_livesearch.robot
+++ b/Products/CMFPlone/tests/robot/test_livesearch.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -8,13 +8,14 @@ Documentation  These tests are just testing the overlay behavior not the
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
 Resource  common.robot
 
-Test Setup  Run keywords  Plone Test Setup  Background
-Test Teardown  Run keywords  Plone Test Teardown
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test cases ***

--- a/Products/CMFPlone/tests/robot/test_portlets.robot
+++ b/Products/CMFPlone/tests/robot/test_portlets.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_thememapper.robot
+++ b/Products/CMFPlone/tests/robot/test_thememapper.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/Products/CMFPlone/tests/robot/test_tinymce.robot
+++ b/Products/CMFPlone/tests/robot/test_tinymce.robot
@@ -2,6 +2,7 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/news/2864.bugfix
+++ b/news/2864.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

Also re-enabled two previously disabled Robot tests.

In tandem with plone/plone.app.robotframework#110
Closes https://github.com/plone/Products.CMFPlone/issues/2864