### PR TITLE
Fix scripts.pt Parsing Errors & Self-Closing Tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ Bug fixes:
 - Fix DeprecationWarning in syndication-view. [jensens] (#2831)
 - Fix malformed url when redirecting to external login. [ericof] (#2842)
 - Make navigation (CatalogNavigationTabs) subclassing easier. [iham] (#2849)
-- Fix script resource parsing error because of self closing tags. [netroxen] (#2870)
+
 
 5.2rc2 (2019-03-21)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ Bug fixes:
 - Fix DeprecationWarning in syndication-view. [jensens] (#2831)
 - Fix malformed url when redirecting to external login. [ericof] (#2842)
 - Make navigation (CatalogNavigationTabs) subclassing easier. [iham] (#2849)
-
+- Fix script resource parsing error because of self closing tags. [netroxen] (#2870)
 
 5.2rc2 (2019-03-21)
 -------------------

--- a/Products/CMFPlone/resources/browser/scripts.pt
+++ b/Products/CMFPlone/resources/browser/scripts.pt
@@ -1,26 +1,38 @@
 <script tal:content="string:PORTAL_URL = '${view/site_url}';"></script>
-<tal:scripts repeat="script view/scripts"><tal:block define="condcomment script/conditionalcomment; resetrjs script/resetrjs|nothing"><tal:if condition="resetrjs">
-  <tal:openreset content='structure string:&lt;script&gt;'/>
-      /* reset requirejs definitions so that people who put requirejs in legacy compilation do not get errors */
+
+<tal:scripts repeat="script view/scripts">
+  <tal:block define="condcomment script/conditionalcomment; resetrjs script/resetrjs|nothing">
+
+    <tal:if condition="resetrjs">
+      <tal:openreset content='structure string:&lt;script&gt;'></tal:openreset>
+
+      <tal:comment tal:replace="nothing">
+        Reset RequireJS definitions so that people who put RequireJS in a legacy compilation do not get errors
+      </tal:comment>
+
       var _old_define = define;
       var _old_require = require;
       define = undefined;
       require = undefined;
-  <tal:endreset content='structure string:&lt;/script&gt;'/>
-</tal:if><tal:if condition="condcomment">
-    <tal:opencc tal:replace="structure string:&lt;!--[if ${condcomment}]&gt;" />
-</tal:if>
-  <script type="text/javascript"
-      tal:attributes="
-        src script/src;
-        data-bundle script/bundle;
-        async script/async|nothing;
-        defer script/defer|nothing"/>
-<tal:if condition="condcomment">
-  <tal:closecc tal:condition="condcomment" tal:replace="structure string:&lt;![endif]--&gt;" />
-</tal:if><tal:if condition="resetrjs">
-  <tal:openredefine content='structure string:&lt;script&gt;'/>
+      <tal:endreset content='structure string:&lt;/script&gt;'></tal:endreset>
+    </tal:if>
+
+    <tal:if condition="condcomment">
+      <tal:opencc tal:replace="structure string:&lt;!--[if ${condcomment}]&gt;"></tal:opencc>
+    </tal:if>
+
+    <script type="text/javascript" tal:attributes="src script/src; data-bundle script/bundle; async script/async|nothing; defer script/defer|nothing"></script>
+
+    <tal:if condition="condcomment">
+      <tal:closecc tal:condition="condcomment" tal:replace="structure string:&lt;![endif]--&gt;"></tal:closecc>
+    </tal:if>
+
+    <tal:if condition="resetrjs">
+      <tal:openredefine content='structure string:&lt;script&gt;'></tal:openredefine>
       define = _old_define;
       require = _old_require;
-  <tal:endredefine content='structure string:&lt;/script&gt;'/>
-</tal:if></tal:block></tal:scripts>
+      <tal:endredefine content='structure string:&lt;/script&gt;'></tal:endredefine>
+    </tal:if>
+
+  </tal:block>
+</tal:scripts>

--- a/news/2870.bugfix
+++ b/news/2870.bugfix
@@ -1,0 +1,2 @@
+Fix script resource parsing error because of self closing tags.
+[Netroxen]


### PR DESCRIPTION
This resolves the issue found in: https://github.com/plone/Products.CMFPlone/issues/2870

### Note

Normally self closing tags are fine to use, but for whatever reason, the template is parsed incorrectly when NOT using Diazo. To fix this I have reverted the template to using full tags.