### PR TITLE
add plone.resource as a dependency before plone.app.discussion

### DIFF
--- a/Products/CMFPlone/profiles/dependencies/metadata.xml
+++ b/Products/CMFPlone/profiles/dependencies/metadata.xml
@@ -7,6 +7,7 @@
     <dependency>profile-Products.PortalTransforms:PortalTransforms</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>
     <dependency>profile-Products.PlonePAS:PlonePAS</dependency>
+    <dependency>profile-plone.resource:default</dependency>
     <dependency>profile-plone.app.discussion:default</dependency>
     <dependency>profile-plone.app.linkintegrity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/news/2899.bugfix
+++ b/news/2899.bugfix
@@ -1,0 +1,2 @@
+Fix site-creation with static resources in the legacy-bundle by moving plone.resource up.
+[pbauer]


### PR DESCRIPTION
This fixes `combine_bundles` with static resources in the legacy-bundle during site-creation
With https://github.com/plone/plone.app.discussion/pull/158 p.a.discussion gains a resource in the legacy-bundle thus triggering the combination of bundles. But at this state the tool `portal_resource` and the utility `IResourceDirectory` are not yet initialized. 

See https://github.com/plone/plone.app.discussion/issues/157