### PR TITLE
Fix #2914: Fix the TinyMCE pattern loading HTML as CSS...

### DIFF
--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -48,7 +48,7 @@ class TinyMCESettingsGenerator(object):
                 files.append('/'.join([self.nav_root_url, url.strip()]))
         theme = self.get_theme()
         tinymce_content_css = getattr(theme, 'tinymce_content_css', None)
-        if tinymce_content_css is not None:
+        if tinymce_content_css:
             for path in theme.tinymce_content_css.split(','):
                 if path.startswith('http://') or path.startswith('https://'):
                     files.append(path)

--- a/news/2914.bugfix
+++ b/news/2914.bugfix
@@ -1,0 +1,2 @@
+Fix the TinyMCE pattern loading HTML as CSS.
+[rpatterson]


### PR DESCRIPTION
For some reason, plone.app.theming===2.0.5 [replaces empty resource lists with
empty
strings](https://github.com/plone/plone.app.theming/blob/2.0.x/src/plone/app/theming/utils.py#L318).
While this seems less than ideal to me, that using None/null is more explicit,
it still seems like a bug that in the pattern here the empty string ends up
adding the nav root URL to the list of CSS files to load.  This results in a
warning in the browser console and greatly slows down loading the edit form.