### PR TITLE
Removed broken X-XSS-Protection header.

### DIFF
--- a/Products/CMFPlone/skins/plone_templates/main_template.pt
+++ b/Products/CMFPlone/skins/plone_templates/main_template.pt
@@ -21,8 +21,7 @@
                   ajax_load request/ajax_load | nothing;
                   ajax_include_head request/ajax_include_head | nothing;
                   dummy python:request.RESPONSE.setHeader('X-UA-Compatible', 'IE=edge');
-                  dummy python:request.RESPONSE.setHeader('X-Content-Type-Options', 'nosniff');
-                  dummy python:request.RESPONSE.setHeader('X-XSS-Protection', '1; mode=block');"
+                  dummy python:request.RESPONSE.setHeader('X-Content-Type-Options', 'nosniff');"
       tal:attributes="lang lang;
                       xml:lang lang">
 

--- a/Products/CMFPlone/testing.py
+++ b/Products/CMFPlone/testing.py
@@ -50,7 +50,33 @@ class ProductsCMFPloneLayer(PloneSandboxLayer):
         portal.manage_delObjects(['test-folder'])
 
 
+class UnstyledThemeLayer(ProductsCMFPloneLayer):
+
+    def setUpPloneSite(self, portal):
+        super(UnstyledThemeLayer, self).setUpPloneSite(portal)
+        portal.portal_skins.default_skin = 'Plone Default'
+
+
+class ClassicThemeLayer(ProductsCMFPloneLayer):
+
+    def setUpZope(self, app, configurationContext):
+        super(ClassicThemeLayer, self).setUpZope(app, configurationContext)
+        import plonetheme.classic
+        xmlconfig.file(
+            'configure.zcml',
+            plonetheme.classic,
+            context=configurationContext
+        )
+
+    def setUpPloneSite(self, portal):
+        super(ClassicThemeLayer, self).setUpPloneSite(portal)
+        portal.portal_quickinstaller.installProducts(['plonetheme.classic'])
+        portal.portal_skins.default_skin = 'Plone Classic Theme'
+
+
 PRODUCTS_CMFPLONE_FIXTURE = ProductsCMFPloneLayer()
+UNSTYLED_THEME_FIXTURE = UnstyledThemeLayer()
+CLASSIC_THEME_FIXTURE = ClassicThemeLayer()
 
 PRODUCTS_CMFPLONE_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PRODUCTS_CMFPLONE_FIXTURE,),
@@ -72,6 +98,20 @@ PRODUCTS_CMFPLONE_ROBOT_TESTING = FunctionalTesting(
            PRODUCTS_CMFPLONE_ROBOT_REMOTE_LIBRARY_FIXTURE,
            z2.ZSERVER_FIXTURE),
     name="CMFPloneLayer:Acceptance"
+)
+
+UNSTYLED_THEME_ROBOT_TESTING = FunctionalTesting(
+    bases=(UNSTYLED_THEME_FIXTURE,
+           PRODUCTS_CMFPLONE_ROBOT_REMOTE_LIBRARY_FIXTURE,
+           z2.ZSERVER_FIXTURE),
+    name="UnstyledThemingLayer:Acceptance"
+)
+
+CLASSIC_THEME_ROBOT_TESTING = FunctionalTesting(
+    bases=(CLASSIC_THEME_FIXTURE,
+           PRODUCTS_CMFPLONE_ROBOT_REMOTE_LIBRARY_FIXTURE,
+           z2.ZSERVER_FIXTURE),
+    name="ClassicThemingLayer:Acceptance"
 )
 
 optionflags = (doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)

--- a/Products/CMFPlone/tests/robot/test_classic.robot
+++ b/Products/CMFPlone/tests/robot/test_classic.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+
+Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Resource  common.robot
+
+Test Setup  Run keywords  Open SauceLabs test browser
+Test Teardown  Run keywords  Report test status  Close all browsers
+
+*** Test cases ***
+
+Scenario: View homepage
+    [Documentation]  We simply view the home page to see if it renders without error.
+    Given the site root
+    Then Page should contain  Plone

--- a/Products/CMFPlone/tests/robot/test_unstyled.robot
+++ b/Products/CMFPlone/tests/robot/test_unstyled.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+
+Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Resource  common.robot
+
+Test Setup  Run keywords  Open SauceLabs test browser
+Test Teardown  Run keywords  Report test status  Close all browsers
+
+*** Test cases ***
+
+Scenario: View homepage
+    [Documentation]  We simply view the home page to see if it renders without error.
+    Given the site root
+    Then Page should contain  Plone

--- a/Products/CMFPlone/tests/test_robot.py
+++ b/Products/CMFPlone/tests/test_robot.py
@@ -3,7 +3,9 @@ import unittest
 import robotsuite
 from plone.testing import layered
 
+from Products.CMFPlone.testing import CLASSIC_THEME_ROBOT_TESTING
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_ROBOT_TESTING
+from Products.CMFPlone.testing import UNSTYLED_THEME_ROBOT_TESTING
 
 
 def test_suite():
@@ -15,10 +17,16 @@ def test_suite():
         if doc.endswith('.robot') and doc.startswith('test_')
     ]
     for test in robot_tests:
+        if 'unstyled' in test:
+            layer = UNSTYLED_THEME_ROBOT_TESTING
+        elif 'classic' in test:
+            layer = CLASSIC_THEME_ROBOT_TESTING
+        else:
+            layer = PRODUCTS_CMFPLONE_ROBOT_TESTING
         suite.addTests([
             layered(
                 robotsuite.RobotTestSuite(test),
-                layer=PRODUCTS_CMFPLONE_ROBOT_TESTING
+                layer=layer
             ),
         ])
     return suite

--- a/news/2964.bugfix
+++ b/news/2964.bugfix
@@ -1,0 +1,2 @@
+Removed broken ``X-XSS-Protection`` header.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2964 for the unstyled theme (Plone Default).

Added robot test to check that the homepage renderers without error in Plone Default style
Added robot test to check that the homepage renderers without error in Plone Classic Theme style.
(Note: I could not trigger an error in other, simpler tests.)

Test and merge this in combination with https://github.com/plone/plonetheme.classic/pull/8
Merge that one first.