### PR TITLE
Fix #1318: Always install default content types on Plone site creation

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -11,6 +11,7 @@ from zope.site.hooks import setSite
 
 _TOOL_ID = 'portal_setup'
 _DEFAULT_PROFILE = 'Products.CMFPlone:plone'
+_TYPES_PROFILE = 'plone.app.contenttypes:default'
 _CONTENT_PROFILE = 'plone.app.contenttypes:plone-content'
 
 # A little hint for PloneTestCase
@@ -152,9 +153,11 @@ def addPloneSite(context, site_id, title='Plone site', description='',
     reg['plone.default_language'] = default_language
     reg['plone.available_languages'] = [default_language]
 
-    if setup_content:
-        setup_tool.runAllImportStepsFromProfile(
-            'profile-%s' % content_profile_id)
+    # Install default content types profile if user do not select "example content"
+    # during site creation.
+    content_types_profile = content_profile_id if setup_content else _TYPES_PROFILE
+
+    setup_tool.runAllImportStepsFromProfile('profile-{0}'.format(content_types_profile))
 
     props = dict(
         title=title,

--- a/Products/CMFPlone/tests/test_factory.py
+++ b/Products/CMFPlone/tests/test_factory.py
@@ -1,9 +1,20 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.tests.PloneTestCase import PloneTestCase
+from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFPlone.factory import addPloneSite
+from Products.CMFPlone.utils import get_installer
+from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+from zope.component import queryUtility
+
+import unittest
 
 
-class TestFactoryPloneSite(PloneTestCase):
+class TestFactoryPloneSite(unittest.TestCase):
+
+    layer = PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.request = self.layer['request']
 
     def testPlonesiteWithUnicodeTitle(self):
         TITLE = 'Ploné'
@@ -28,3 +39,18 @@ class TestFactoryPloneSite(PloneTestCase):
         ploneSiteTitle = ploneSite.Title()
         self.assertTrue(isinstance(ploneSiteTitle, str))
         self.assertEqual(ploneSiteTitle, TITLE)
+
+    def test_site_creation_without_content_but_with_dexterity(self):
+        """Test site creation without example content have dexterity installed."""
+        ploneSite = addPloneSite(
+            self.app, 'ploneFoo', title='Foo', setup_content=False)
+        qi = get_installer(ploneSite, self.request)
+        self.assertTrue(qi.is_product_installed('plone.app.dexterity'))
+
+    def test_site_creation_without_content_but_with_content_types(self):
+        """Test site creation without example content have content types."""
+        ploneSite = addPloneSite(
+            self.app, 'ploneFoo', title='Foo', setup_content=False)
+        # Folder
+        fti = queryUtility(IDexterityFTI, name='Folder')
+        self.assertIsNotNone(fti)

--- a/news/1318.bugfix
+++ b/news/1318.bugfix
@@ -1,0 +1,2 @@
+fix creation of Plone site not adding default Dexterity content types if example content not explicitily selected by user.
+[ericof]


### PR DESCRIPTION
* Fix #1318: Always install default content types on Plone site creation

* Update changelog entry