### PR TITLE
Fix TTW Bundle compilation broken.

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -409,14 +409,8 @@ class ResourceRegistryControlPanelView(RequireJsView):
         base_url = self.context.absolute_url()
         resources = self.get_resources()
 
-        try:
-            less_url = self.registry['plone.resources.lessc']
-        except KeyError:
-            less_url = '++plone++static/components/less/dist/less-1.7.4.min.js'
-        try:
-            rjs_url = resources['rjs'].js
-        except KeyError:
-            rjs_url = '++plone++static/components/r.js/dist/r.js'
+        less_url = self.registry['plone.resources.lessc']
+        rjs_url = self.registry['plone.resources.rjs']
 
         data = {
             'development': self.registry['plone.resources.development'],

--- a/news/2969.bugfix
+++ b/news/2969.bugfix
@@ -1,0 +1,2 @@
+Fix TTW Bundle compilation broken.
+[thet]


### PR DESCRIPTION
Fixes #2969
Fixes https://github.com/plone/plone.staticresources/issues/58


The PR https://github.com/plone/Products.CMFPlone/pull/2970 got merged for master, which became Plone 6.0 during the Ploneconf sprints IIRC.