### PR TITLE
4.3.x Hotfix20200121 isURLInPortal

### DIFF
--- a/Products/CMFPlone/URLTool.py
+++ b/Products/CMFPlone/URLTool.py
@@ -8,6 +8,8 @@ from Products.CMFPlone.PloneBaseTool import PloneBaseTool
 from posixpath import normpath
 from urlparse import urlparse, urljoin
 import re
+import string
+import unicodedata
 
 
 hp = HTMLParser()
@@ -28,6 +30,62 @@ BAD_URL_PARTS = [
     'javascript%3a',
 ]
 
+# Determine allowed ascii characters.
+# We want to allow most printable characters,
+# but no whitespace, and no punctuation, except for a few exceptions.
+# This boils down to ascii letters plus digits plus exceptions.
+# Exceptions:
+# - dot and slash for relative or absolute paths.
+# - @ because we have views starting with @@
+# - + because we have ++resource++ urls
+allowed_ascii = string.ascii_letters + string.digits + "./@+"
+
+def safe_url_first_char(url):
+    # For character code points higher than 127, the bytes representation of a character
+    # is longer than the unicode representation, so url[0] may give different results
+    # for bytes and unicode.  On Python 2:
+    # >>> unichr(128)
+    # u'\x80'
+    # >>> len(unichr(128))
+    # 1
+    # >>> unichr(128).encode("latin-1")
+    # '\x80'
+    # >>> len(unichr(128).encode("latin-1"))
+    # 1
+    # >>> unichr(128).encode("utf-8")
+    # '\xc2\x80'
+    # >>> len(unichr(128).encode("utf-8"))
+    # 2
+    # >>> unichr(128).encode("utf-8")[0]
+    # '\xc2'
+    # So make sure we have unicode here for comparing the first character.
+    if isinstance(url, bytes):
+        # Remember, on Python 2, bytes == str.
+        try:
+            first = url.decode("utf-8")[0]
+        except UnicodeDecodeError:
+            # We don't trust this
+            return False
+    else:
+        first = url[0]
+    if ord(first) < 128:
+        if first not in allowed_ascii:
+            # The first character of the url is ascii but not in the allowed range.
+            return False
+    else:
+        # This is non-ascii, which has lots of control characters, which may be dangerous.
+        # Check taken from django.utils.http._is_safe_url.  See
+        # https://github.com/django/django/blob/2.1.5/django/utils/http.py#L356-L382
+        # Forbid URLs that start with control characters. Some browsers (like
+        # Chrome) ignore quite a few control characters at the start of a
+        # URL and might consider the URL as scheme relative.
+        # For categories, see 5.7.1 General Category Values here:
+        # http://www.unicode.org/reports/tr44/tr44-6.html#Property_Values
+        # We look for Control categories here.
+        if unicodedata.category(first)[0] == "C":
+            return False
+    return True
+
 
 class URLTool(PloneBaseTool, BaseTool):
 
@@ -47,6 +105,9 @@ class URLTool(PloneBaseTool, BaseTool):
         # External sites listed in 'allow_external_login_sites' of
         # site_properties are also considered within the portal to allow for
         # single sign on.
+
+        if url and not safe_url_first_char(url):
+            return False
 
         # sanitize url
         url = re.sub('^[\x00-\x20]+', '', url).strip()

--- a/Products/CMFPlone/tests/testURLTool.py
+++ b/Products/CMFPlone/tests/testURLTool.py
@@ -56,6 +56,7 @@ class TestURLTool(unittest.TestCase):
         self.assertTrue(iURLiP('https://www.foobar.com/bar/foo/folder'))
         self.assertFalse(iURLiP('http://www.foobar.com:8080/bar/foo/folder'))
         self.assertFalse(iURLiP('http://www.foobar.com/bar'))
+        self.assertTrue(iURLiP('//www.foobar.com/bar/foo'))
         self.assertFalse(iURLiP('/images'))
         self.assertTrue(iURLiP('/bar/foo/foo'))
 
@@ -124,6 +125,15 @@ class TestURLTool(unittest.TestCase):
         url_tool = self._makeOne()
         iURLiP = url_tool.isURLInPortal
         self.assertFalse(iURLiP('\\\\www.example.com'))
+
+    def test_escape(self):
+        url_tool = self._makeOne()
+        iURLiP = url_tool.isURLInPortal
+        self.assertFalse(iURLiP('\/\/www.example.com'))
+        self.assertFalse(iURLiP('\%2F\%2Fwww.example.com'))
+        self.assertFalse(iURLiP('\%2f\%2fwww.example.com'))
+        self.assertFalse(iURLiP('%2F%2Fwww.example.com'))
+        self.assertFalse(iURLiP('%2f%2fwww.example.com'))
 
     def test_regression_absolute_url_in_portal(self):
         url_tool = self._makeOne()

--- a/news/3021.bugfix.2
+++ b/news/3021.bugfix.2
@@ -1,0 +1,1 @@
+Merge Hotfix20200121: isURLInPortal could be tricked into accepting malicious links.


### PR DESCRIPTION
The isURLInPortal check that is done to avoid linking to an external
site could be tricked into accepting malicious links.

See #3021