### PR TITLE
plone.app.discussion extends the review workflow (Plone 5.1)

### DIFF
--- a/Products/CMFPlone/tests/testWorkflowTool.py
+++ b/Products/CMFPlone/tests/testWorkflowTool.py
@@ -112,7 +112,7 @@ class TestWorkflowTool(PloneTestCase.PloneTestCase):
 
     def testListWFStatesByTitle(self):
         states = self.workflow.listWFStatesByTitle()
-        self.assertEqual(len(states), len(all_states))
+        self.assertGreaterEqual(len(states), len(all_states))
         pub_states = [s for s in states if s[1] == 'published']
         priv_states = [s for s in states if s[1] == 'private']
         pend_states = [s for s in states if s[1] == 'pending']
@@ -122,9 +122,9 @@ class TestWorkflowTool(PloneTestCase.PloneTestCase):
         internal_pub_states = [s for s in states
                                if s[1] == 'internally_published']
 
-        self.assertEqual(len(pub_states), all_states.count('published'))
+        self.assertGreaterEqual(len(pub_states), all_states.count('published'))
         self.assertEqual(len(priv_states), all_states.count('private'))
-        self.assertEqual(len(pend_states), all_states.count('pending'))
+        self.assertGreaterEqual(len(pend_states), all_states.count('pending'))
         self.assertEqual(len(vis_states), all_states.count('visible'))
         self.assertEqual(len(external_states), all_states.count('external'))
         self.assertEqual(len(internal_states), all_states.count('internal'))

--- a/news/2957.bugfix
+++ b/news/2957.bugfix
@@ -1,0 +1,2 @@
+plone.app.discussion extends the review workflow for moderation of comments. This change takes the additional workflow states into account.
+[ksuess]


### PR DESCRIPTION
plone.app.discussion extends the review workflow for moderation of comments. This change takes the additional workflow states into account.
see plone/plone.app.discussion#166