### PR TITLE
Add markdown extension settings to markup control panel.

### DIFF
--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_markup.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_markup.py
@@ -72,3 +72,32 @@ class MarkupControlPanelFunctionalTest(unittest.TestCase):
         settings = registry.forInterface(IMarkupSchema, prefix='plone')
         self.assertEqual(settings.allowed_types,
                          ('text/html', 'text/x-web-textile'))
+
+    def test_markdown_extensions(self):
+        self.browser.open(
+            "%s/@@markup-controlpanel" % self.portal_url)
+        self.assertEqual(
+            self.browser.getControl(
+                name='form.widgets.markdown_extensions'
+            ).value,
+            'markdown.extensions.fenced_code\nmarkdown.extensions.nl2br')
+
+        self.browser.getControl(
+            name='form.widgets.markdown_extensions'
+        ).value = '\n'.join([
+            'markdown.extensions.fenced_code',
+            'markdown.extensions.nl2br',
+            'markdown.extensions.extra',
+        ])
+        self.browser.getControl('Save').click()
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IMarkupSchema, prefix='plone')
+        self.assertEqual(
+            settings.markdown_extensions,
+            [
+                'markdown.extensions.fenced_code',
+                'markdown.extensions.nl2br',
+                'markdown.extensions.extra',
+            ]
+        )

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_markup.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_markup.py
@@ -37,3 +37,6 @@ class MarkupRegistryIntegrationTest(unittest.TestCase):
 
     def test_allowed_types_exists(self):
         self.assertTrue(hasattr(self.settings, 'allowed_types'))
+
+    def test_markdown_extensions_exists(self):
+        self.assertTrue(hasattr(self.settings, 'markdown_extensions'))

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -1381,6 +1381,21 @@ class IMarkupSchema(Interface):
         )
     )
 
+    markdown_extensions = schema.List(
+        default=[
+            'markdown.extensions.fenced_code',
+            'markdown.extensions.nl2br',
+        ],
+        description=_(
+            u'Look for available extensions at '
+            u'https://python-markdown.github.io/extensions/ or write your own.'
+        ),
+        missing_value=(),
+        required=False,
+        title=_(u'Enabled markdown extensions'),
+        value_type=schema.TextLine()
+    )
+
 
 class IUserGroupsSettingsSchema(Interface):
 

--- a/news/3076.feature
+++ b/news/3076.feature
@@ -1,0 +1,2 @@
+Add markdown extension settings to markup control panel.
+[thomasmassmann]


### PR DESCRIPTION
Adds enabled markdown extensions for markup portal transform module to markup controlpanel.

The required changes in Products.PortalTransforms will be applied in https://github.com/plone/Products.PortalTransforms/pull/30.

Needs PR:
https://github.com/plone/plone.app.upgrade/pull/229
https://github.com/plone/Products.PortalTransforms/pull/30