### PR TITLE
Fix py38 time.clock removal

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -45,6 +45,12 @@ import re
 import six
 import time
 
+try:
+    from time import clock as process_time
+except ImportError:
+    from time import process_time
+
+
 logger = logging.getLogger('Plone')
 
 _marker = object()
@@ -514,12 +520,12 @@ class CatalogTool(PloneBaseTool, BaseTool):
         method. This may take a long time.
         """
         elapse = time.time()
-        c_elapse = time.clock()
+        c_elapse = process_time()
 
         self.clearFindAndRebuild()
 
         elapse = time.time() - elapse
-        c_elapse = time.clock() - c_elapse
+        c_elapse = process_time() - c_elapse
 
         msg = ('Catalog Rebuilt\n'
                'Total time: %s\n'

--- a/news/3082.bugfix
+++ b/news/3082.bugfix
@@ -1,0 +1,1 @@
+Fix Python 3.8 ``time.clock`` removal in CatalogTool [jensens]


### PR DESCRIPTION
the module uses ``time.clock()`` 
https://github.com/zopefoundation/Products.ZCatalog/blob/adc99ac6c3db510b8b275c73573811ac45d9e1b4/src/Products/ZCatalog/ZCatalog.py#L240

Which was removed from Python 3.8
https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals

> The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in bpo-36895.)
