### PR TITLE
enable custom format string i18n/l10n

### DIFF
--- a/Products/CMFPlone/i18nl10n.py
+++ b/Products/CMFPlone/i18nl10n.py
@@ -30,8 +30,8 @@ _dt_format_string_regexp = re.compile(r'\%([{0}])'.format(_all_regexp_set))
 # structures, so here a copy:
 ENGLISH_NAMES = {
     '_days': (
-        '', 'January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December'
+        'Sunday', 'Monday', 'Tuesday', 'Wednesday',  'Thursday', 'Friday',
+        'Saturday',
     ),
     '_days_a': ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'),
     '_days_p': ('Sun.', 'Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.'),
@@ -202,13 +202,13 @@ def ulocalized_time(time, long_format=None, time_only=False, context=None,
 
     # add weekday name, abbr. weekday name, month name, abbr month name
     name_elements = formatelements & name_formatvariables
-    if bool({'a', 'A'} & name_elements):
+    if {'a', 'A'} & name_elements:
         weekday = int(time.strftime('%w'))  # weekday, sunday = 0
         if 'a' in name_elements:
             mapping['a'] = weekdayname_msgid_abbr(weekday)
         if 'A' in name_elements:
             mapping['A'] = weekdayname_msgid(weekday)
-    if bool({'b', 'B'} & name_elements):
+    if {'b', 'B'} & name_elements:
         monthday = int(time.strftime('%m'))  # month, january = 1
         if 'b' in name_elements:
             mapping['b'] = monthname_msgid_abbr(monthday)

--- a/Products/CMFPlone/tests/test_doctests.py
+++ b/Products/CMFPlone/tests/test_doctests.py
@@ -21,7 +21,6 @@ def test_suite():
             package='Products.CMFPlone.tests',
             checker=Py23DocChecker(),
             ),
-        doctest.DocTestSuite('Products.CMFPlone.i18nl10n'),
         doctest.DocTestSuite('Products.CMFPlone.TranslationServiceTool'),
         doctest.DocTestSuite('Products.CMFPlone.utils'),
         doctest.DocTestSuite('Products.CMFPlone.workflow'),

--- a/Products/CMFPlone/tests/test_l18nl10n.py
+++ b/Products/CMFPlone/tests/test_l18nl10n.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+""" Unit tests for Products.CMFPlone.i18nl10n module. """
+
+import unittest
+
+class BasicI18nl10nTests(unittest.TestCase):
+
+    def test_regexp_dt_format_string_regexp(self):
+        from Products.CMFPlone.i18nl10n import _dt_format_string_regexp
+        dt_string = "%Y-%m-%d %H:%M"
+        locales_string = "${H}:${M}"
+
+        # test for strftime format string
+        self.assertTrue(bool(_dt_format_string_regexp.findall(dt_string)))
+        self.assertFalse(bool(_dt_format_string_regexp.findall(locales_string)))
+
+    def test_regexp_interp_regex(self):
+        from Products.CMFPlone.i18nl10n import _interp_regex
+        locales_string = "${H}:${M}"
+
+        # test for locale string elements:
+        self.assertEquals(
+            _interp_regex.findall(locales_string),
+            ["${H}", "${M}"],
+        )

--- a/news/3084.feature
+++ b/news/3084.feature
@@ -1,0 +1,4 @@
+Custom date format strings from registry can be in the ``${}`` format as in the locales files. 
+If theres a day or month name used, this will be translated. 
+For bbb the classic strftime ``%`` strings are still behaving like before.
+[jensens]


### PR DESCRIPTION
Now custom date format strings from registry can be in the `${}` format as in the locales files. if theres a day or month name used, this will be translated. for bbb the classic strftime % strings are still behaving like before. I also did some cleanup and use sets and intersections for some operations.