### PR TITLE
Sort control panel items by title

### DIFF
--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -143,9 +143,10 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
                 a['title'] = translate(title,
                                        context=self.REQUEST)
 
-        def _id(v):
-            return v['id']
-        res.sort(key=_id)
+        def _title(v):
+            return v['title']
+
+        res.sort(key=_title)
         return res
 
     security.declareProtected(ManagePortal, 'unregisterConfiglet')

--- a/news/721.bugfix
+++ b/news/721.bugfix
@@ -1,0 +1,2 @@
+Change control panel item sorting and sort them by title
+[erral]


### PR DESCRIPTION
Revert [previous commit](https://github.com/plone/Products.CMFPlone/commit/f831db3102f349ccd4347ca29e9048c56d6ce27d) and get control panels sorted by its title.

Fixes #721