### PR TITLE
Fixed saving ignored exception types in Python 3.

### DIFF
--- a/Products/CMFPlone/skins/plone_prefs/prefs_error_log_setProperties.py
+++ b/Products/CMFPlone/skins/plone_prefs/prefs_error_log_setProperties.py
@@ -8,9 +8,11 @@
 ##title=
 
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import safe_nativestring
 
 request = context.REQUEST
 
+ignored_exceptions = map(safe_nativestring, ignored_exceptions)
 context.error_log.setProperties(keep_entries, copy_to_zlog, ignored_exceptions)
 context.plone_utils.addPortalMessage(_(u'Changes made.'))
 

--- a/news/3115.bugfix
+++ b/news/3115.bugfix
@@ -1,0 +1,1 @@
+Fixed saving ignored exception types in Python 3.  [maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/3115

Tested on 5.2 Python 2 and 3.