### PR TITLE
Add custom.css resource after diazo bundle [5.2]

### DIFF
--- a/Products/CMFPlone/resources/browser/styles.py
+++ b/Products/CMFPlone/resources/browser/styles.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from plone.app.layout.viewlets.common import ViewletBase
+from plone.app.theming.interfaces import IThemeSettings
+from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceBase
 from Products.CMFPlone.utils import get_top_request
 from six.moves.urllib import parse
+from zope.component import getUtility
 
 
 class StylesBase(ResourceBase):
@@ -81,6 +84,12 @@ class StylesBase(ResourceBase):
                     'src': css_location
                 })
 
+    @property
+    def custom_css_timestamp(self):
+        registry = getUtility(IRegistry)
+        theme_settings = registry.forInterface(IThemeSettings, False)
+        return theme_settings.custom_css_timestamp
+
     def styles(self):
         """
         Get all the styles
@@ -143,6 +152,18 @@ class StylesBase(ResourceBase):
                     'bundle': 'diazo'}
 
             result.append(data)
+
+        # custom.css
+        custom_css = {
+            'rel': 'stylesheet',
+            'conditionalcomment': '',
+            'src': "{0}/custom.css?timestamp={1}".format(
+                self.site_url,
+                self.custom_css_timestamp,
+            ),
+            'bundle': 'custom-css'
+        }
+        result.append(custom_css)
         return result
 
 

--- a/news/3086.feature
+++ b/news/3086.feature
@@ -1,0 +1,2 @@
+Insert virtual custom.css bundle into the header after diazo bundle.
+[MrTango]


### PR DESCRIPTION
Backport of PR #3089 from 6.0/master into 5.2, as [approved by the Framework Team](https://github.com/plone/Products.CMFPlone/pull/3089#issuecomment-634032215).