### PR TITLE
Unordered folders make next/prev navigation at plone.restapi don't work

### DIFF
--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -270,7 +270,6 @@ class TestPortalCreation(PloneTestCase.PloneTestCase):
         self.assertTrue('news' in self.portal.objectIds())
         folder = getattr(self.portal, 'news')
         self.assertEqual(folder.portal_type, 'Folder')
-        self.assertEqual(folder._ordering, 'unordered')
         self.assertEqual(folder.getDefaultPage(), 'aggregator')
         self.assertEqual(folder.immediately_addable_types, ['News Item'])
 
@@ -278,7 +277,6 @@ class TestPortalCreation(PloneTestCase.PloneTestCase):
         self.assertTrue('events' in self.portal.objectIds())
         folder = getattr(self.portal, 'events')
         self.assertEqual(folder.portal_type, 'Folder')
-        self.assertEqual(folder._ordering, 'unordered')
         self.assertEqual(folder.getDefaultPage(), 'aggregator')
         self.assertEqual(folder.immediately_addable_types, ['Event'])
 


### PR DESCRIPTION
related to: https://github.com/plone/plone.app.contenttypes/pull/553