### PR TITLE
Return a Zope aware engine for page templates based on zope.pagetemplate

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -131,4 +131,9 @@
       provides="plone.scale.interfaces.IScaledImageQuality"
       />
 
+  <adapter
+      for="zope.pagetemplate.engine.ZopeBaseEngine"
+      factory=".traversal.get_zope_page_template_engine"
+      />
+
 </configure>

--- a/Products/CMFPlone/traversal.py
+++ b/Products/CMFPlone/traversal.py
@@ -5,7 +5,22 @@ from plone.resource.interfaces import IResourceDirectory
 from plone.resource.interfaces import IUniqueResourceRequest
 from Products.CMFPlone.interfaces.resources import (
     OVERRIDE_RESOURCE_DIRECTORY_NAME)
+from Products.PageTemplates.Expressions import getEngine
+from Products.PageTemplates.Expressions import getTrustedEngine
 from zope.globalrequest import getRequest
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.pagetemplate import engine as zpt_engine
+
+
+try:
+    # This was introduced in Zope 4.5.
+    # We try not to make this a hard dependency yet.
+    from Products.PageTemplates.interfaces import IZopeAwareEngine
+except ImportError:
+    # Zope 4.4-
+    class IZopeAwareEngine(Interface):
+        pass
 
 
 class PloneBundlesTraverser(ResourceTraverser):
@@ -38,3 +53,25 @@ class PloneBundlesTraverser(ResourceTraverser):
                 if resource_filepath in directory:
                     return directory
         return super(PloneBundlesTraverser, self).traverse(name, remaining)
+
+
+@implementer(IZopeAwareEngine)
+def get_zope_page_template_engine(engine):
+    """Get Zope-aware page template engine.
+
+    Hopefully a trusted one, but maybe an untrusted one,
+    with less possibilities and more security checks.
+    We fall back to nothing. This means the original engine will be used.
+
+    Needed since the page template refactoring/cleanup in Zope 4.4.
+    See https://github.com/plone/Products.CMFPlone/issues/3141
+
+    This is currently expected to only be called when a zope.pagetemplate
+    is being rendered, which can happen with z3c.form related code.
+    For Products.PageTemplates, this code should not be needed.
+    """
+    if isinstance(engine, zpt_engine.ZopeEngine):
+        # Get untrusted engine.
+        return getEngine()
+    if isinstance(engine, zpt_engine.TrustedZopeEngine):
+        return getTrustedEngine()

--- a/news/3141.bugfix
+++ b/news/3141.bugfix
@@ -1,0 +1,4 @@
+Return a Zope aware engine for page templates based on ``zope.pagetemplate`` instead of ``Products.PageTemplates``.
+Fixes possible problems with such templates, for example z3c.form ones, with Zope 4.4 and higher.
+See `issue 3141 <https://github.com/plone/Products.CMFPlone/issues/3141>`_.
+[maurits]


### PR DESCRIPTION
Fixes possible problems with such templates, for example z3c.form ones, with Zope 4.4 and higher.
Most templates are based on `Products.PageTemplates`, which is working fine.

See https://github.com/plone/Products.CMFPlone/issues/3141

cc @d-maurer.