### PR TITLE
Redirection view: factor our navigation root editing to a method. [5.2]

### DIFF
--- a/news/3153.bugfix
+++ b/news/3153.bugfix
@@ -1,0 +1,3 @@
+Redirection view: factor our navigation root editing to a method `edit_for_navigation_root`.
+This makes it possible to override this method to simply return the redirection unchanged, if you want to support redirects in the site root.
+[maurits]


### PR DESCRIPTION
This makes it possible to override this method to not do anything.

With the original Products.RedirectionTool in Plone 4.3, nothing was done with the navigation root.
So when you are in `/nav-root/page` and add an alternative url `/fnord`, it was stored as `/fnord`.
In current Plone 5.2, it is stored as `/nav-root/fnord`.
Makes sense to me, but some want the old behavior back.
Now they can, by overriding the new `edit_for_navigation_root` method to simply return the redirection unchanged.