### PR TITLE
Control panel configlets: first check visibility, then check condition.

### DIFF
--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -131,8 +131,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             for permission in a.permissions:
                 if _checkPermission(permission, portal):
                     verified = 1
-            if verified and a.category == group and a.testCondition(context) \
-                    and a.visible:
+            if verified and a.category == group and a.visible and a.testCondition(context):
                 res.append(a.getAction(context))
         # Translate the title for sorting
         if getattr(self, 'REQUEST', None) is not None:

--- a/news/3154.bugfix
+++ b/news/3154.bugfix
@@ -1,0 +1,4 @@
+Control panel configlets: first check visibility, then check condition.
+Visibility is cheaper to check.
+Also fixes `bug 3154 <https://github.com/plone/Products.CMFPlone/issues/3154>`_.
+[maurits]


### PR DESCRIPTION
Visibility is cheaper to check.
Also fixes https://github.com/plone/Products.CMFPlone/issues/3154.