### PR TITLE
Backport to Plone 5.1.x toolbar fixes from mockup master

### DIFF
--- a/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
+++ b/Products/CMFPlone/static/patterns/toolbar/src/css/toolbar.plone.less
@@ -7,7 +7,7 @@
   font-family: @plone-toolbar-font-primary;
   font-weight: 400;
   position: fixed;
-  z-index: 3;
+  z-index: 20;
   top: 0;
   left: 0;
   width: @plone-left-toolbar;
@@ -358,10 +358,16 @@
         }
 
         &.plonetoolbar-display-view.actionSeparator {
-            margin: 0;
+          margin: 0;
+          > :before {
+            content: '';
+          }
+          > span {
+            padding: 5px 15px;
+          }
         }
 
-        &:not(.plone-toolbar-submenu-header, .plonetoolbar-display-view.actionSeparator) {
+        &:not(.plone-toolbar-submenu-header) {
           > :before {
             position: absolute;
             left: 15px;
@@ -463,10 +469,10 @@
 }
 
 .plone-toolbar-left #edit-zone {
-  z-index: 5;
+  z-index: 20;
 
   nav > ul ul {
-    width: 0;
+    display: none;
     height: 100%;
   }
 
@@ -815,7 +821,7 @@
   }
 
   .plone-toolbar-left #edit-zone {
-    z-index: 5;
+    z-index: 20;
 
     nav {
       overflow-x: hidden;
@@ -898,7 +904,7 @@
     }
 
     nav {
-      overflow-y: scroll;
+      overflow-y: auto;
     }
   }
 

--- a/news/3159.bugfix
+++ b/news/3159.bugfix
@@ -1,0 +1,6 @@
+Backport toolbar fixes from mockup master (Plone 5.2):
+
+- Fix the scrollbar always present in the toolbar (fixes mockup#897) [ale-rt]
+- Move toolbar to be above structure pattern, by increasing its z-index from 3 to 20 (fixes Products.CMFPlone#2490) [fulv]
+- Set display none instead of width 0 to the plone-toolbar-left children ul for a correct keyboard tabbing (fixes mockup#950) [erral & ionlizarazu]
+- Fix toolbar menus missing checkmark on some browsers (fixes Products.CMFPlone#1972) [vincentfretin]


### PR DESCRIPTION
Backport toolbar fixes from mockup master (Plone 5.2):

- Fix the scrollbar always present in the toolbar (fixes mockup#897) [ale-rt]
- Move toolbar to be above structure pattern, by increasing its z-index from 3 to 20 (fixes Products.CMFPlone#2490) [fulv]
- Set display none instead of width 0 to the plone-toolbar-left children ul for a correct keyboard tabbing (fixes mockup#950)[erral & ionlizarazu]
- Fix toolbar menus missing checkmark on some browsers (fixes Products.CMFPlone#1972) [vincentfretin]