### PR TITLE
Fixed deprecation warning for wrap_form from plone.app.z3cform. [5.1]

### DIFF
--- a/Products/CMFPlone/browser/syndication/views.py
+++ b/Products/CMFPlone/browser/syndication/views.py
@@ -14,7 +14,7 @@ from Products.CMFPlone.interfaces.syndication import IFeedSettings
 from Products.CMFPlone import PloneMessageFactory as _
 
 from z3c.form import form, button, field
-from plone.app.z3cform.layout import wrap_form
+from plone.z3cform.layout import wrap_form
 
 
 class FeedView(BrowserView):

--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for wrap_form from plone.app.z3cform.
+[maurits]


### PR DESCRIPTION
```
Products/CMFPlone/browser/syndication/views.py:17:
  DeprecationWarning: wrap_form is deprecated. Import from plone.z3cform.layout instead.
  from plone.app.z3cform.layout import wrap_form
```