### PR TITLE
No longer doubly undo Content-Type change when combining bundles

### DIFF
--- a/news/1924.bugfix
+++ b/news/1924.bugfix
@@ -1,0 +1,2 @@
+No longer doubly undo a response Content-Type change when combining bundles.
+[maurits]


### PR DESCRIPTION
See my confusion in an [easyform PR](https://github.com/collective/collective.easyform/pull/248#issuecomment-689365240).