### PR TITLE
PloneBatch: define __bool__ as copy of __nonzero__.

### DIFF
--- a/Products/CMFPlone/PloneBatch.py
+++ b/Products/CMFPlone/PloneBatch.py
@@ -27,10 +27,13 @@ class Batch(QuantumBatch):
                           'Use the `sequence_length` attribute for the size of the '
                           'entire sequence. '))
 
-    def __nonzero__(self):
-        # Without __nonzero__ a bool(self) would call len(self), which
+    def __bool__(self):
+        # Without __bool__ a bool(self) would call len(self), which
         # gives a deprecation warning.
         return bool(self.length)
+
+    # For Python 2 compatibility:
+    __nonzero__ = __bool__
 
     def initialize(self, start, end, size):
         super(Batch, self).initialize(start, end, size)

--- a/news/3175.bugfix
+++ b/news/3175.bugfix
@@ -1,0 +1,3 @@
+PloneBatch: define ``__bool__`` as copy of ``__nonzero__``.
+Python 3 calls ``__bool__`` when doing ``bool(batch)``.
+[maurits]


### PR DESCRIPTION
Python 2 calls `__nonzero__`, Python 3 calls `__bool__`.
Since `__bool__` was not defined, Python 3 called `len(batch)` instead, leading to these warnings when a template has code like `tal:condition="batch"`:

```
Products/PageTemplates/Expressions.py:253: DeprecationWarning: Using len() is deprecated.
Use the `length` attribute for the size of the current page, which is what we return now.
Use the `sequence_length` attribute for the size of the entire sequence. 
  return bool(value)
```

(I now think we should undo this deprecation, but that is something for a different issue.)