### PR TITLE
Fix tests with Products.MailHost 4.10.

### DIFF
--- a/Products/CMFPlone/tests/emaillogin.rst
+++ b/Products/CMFPlone/tests/emaillogin.rst
@@ -224,7 +224,7 @@ in a list called ``messages``::
 Now that we have the message, we want to look at its contents, and
 then we extract the address that lets us reset our password::
 
-    >>> "To: email2@example.org" in msg
+    >>> b"To: email2@example.org" in msg
     True
 
 Now get the link::
@@ -265,7 +265,7 @@ The email is sent to the correct email address::
     >>> len(mailhost.messages)
     2
     >>> msg = mailhost.messages[-1]
-    >>> "To: username@example.org" in msg
+    >>> b"To: username@example.org" in msg
     True
 
 Now get the link::

--- a/Products/CMFPlone/tests/mails.txt
+++ b/Products/CMFPlone/tests/mails.txt
@@ -47,15 +47,15 @@ in a list called ``messages``:
 
 Now that we have the message, we want to look at its contents:
 
-  >>> 'To: mail@plone.test' in msg
+  >>> b'To: mail@plone.test' in msg
   True
 
-  >>> 'From: mail@plone.test' in msg
+  >>> b'From: mail@plone.test' in msg
   True
 
 We expect the headers to be properly header encoded (7-bit):
 
-  >>> 'Subject: =?utf-8?q?Some_t=C3=A4st_subject=2E?=' in msg
+  >>> b'Subject: =?utf-8?q?Some_t=C3=A4st_subject=2E?=' in msg
   True
 
 The output should be encoded in a reasonable manner (in this case
@@ -63,8 +63,8 @@ quoted-printable).  There may be some small differences in where
 exactly the lines are cut off, depending on whether you use five.pt
 (in Zope 2.13) or not, so we turn the message into one line first:
 
-  >>> msg.replace('=\n', '').replace('\n', ' ')
-  '...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...
+  >>> msg.replace(b'=\n', b'').replace(b'\n', b' ')
+  b'...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...
 
 We can also decode the string, though we should still be careful about
 lines ending in different spots:

--- a/Products/CMFPlone/tests/mails.txt
+++ b/Products/CMFPlone/tests/mails.txt
@@ -64,7 +64,7 @@ exactly the lines are cut off, depending on whether you use five.pt
 (in Zope 2.13) or not, so we turn the message into one line first:
 
   >>> msg.replace(b'=\n', b'').replace(b'\n', b' ')
-  b'...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...
+  b'...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...'
 
 We can also decode the string, though we should still be careful about
 lines ending in different spots:

--- a/Products/CMFPlone/tests/pwreset_browser.rst
+++ b/Products/CMFPlone/tests/pwreset_browser.rst
@@ -326,7 +326,7 @@ We should have received an e-mail at this point:
   >>> len(mailhost.messages)
   2
   >>> import quopri
-  >>> msg = quopri.decodestring(str(mailhost.messages[-1]))
+  >>> msg = quopri.decodestring(mailhost.messages[-1])
   >>> b"The site administrator asks you to reset your password for 'wsmith' userid" in msg
   True
   >>> please_visit_text = b"The following link will take you to a page where you can reset your password for Plone site site:"
@@ -400,7 +400,7 @@ We should have received an e-mail at this point:
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
   3
-  >>> msg = str(mailhost.messages[-1])
+  >>> msg = mailhost.messages[-1]
 
 Let's clear the events storage:
 
@@ -412,7 +412,7 @@ then we extract the address that lets us reset our password:
   >>> from email.parser import Parser
   >>> import re
   >>> parser = Parser()
-  >>> message = parser.parsestr(msg)
+  >>> message = parser.parsestr(msg.decode("utf-8"))
   >>> message["To"]
   'bsmith@example.com'
   >>> msgtext = quopri.decodestring(message.get_payload())
@@ -498,12 +498,12 @@ We should have received an e-mail at this point:
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
   4
-  >>> msg = str(mailhost.messages[-1])
+  >>> msg = mailhost.messages[-1]
 
 Now that we have the message, we want to look at its contents, and
 then we extract the address that lets us reset our password:
 
-  >>> message = parser.parsestr(msg)
+  >>> message = parser.parsestr(msg.decode("utf-8"))
   >>> message["To"]
   'wwwsmith@example.com'
   >>> msgtext = quopri.decodestring(message.get_payload())

--- a/Products/CMFPlone/tests/testRegistrationTool.py
+++ b/Products/CMFPlone/tests/testRegistrationTool.py
@@ -8,11 +8,17 @@ from Products.CMFPlone.interfaces.controlpanel import IMailSchema, ISiteSchema
 from Products.CMFPlone.tests import PloneTestCase
 from Products.CMFPlone.tests.utils import MockMailHost
 from Products.MailHost.interfaces import IMailHost
-from email import message_from_string
 from plone.registry.interfaces import IRegistry
 from zope.component import getSiteManager, getUtility
 
 member_id = 'new_member'
+
+try:
+    # Python 3
+    from email import message_from_bytes
+except ImportError:
+    # Python 2
+    from email import message_from_string as message_from_bytes
 
 
 class TestRegistrationTool(PloneTestCase.PloneTestCase):
@@ -150,7 +156,7 @@ class TestRegistrationTool(PloneTestCase.PloneTestCase):
         # Notify the registered user
         self.registration.registeredNotify(member_id)
         self.assertEqual(len(mails.messages), 1)
-        msg = message_from_string(mails.messages[0])
+        msg = message_from_bytes(mails.messages[0])
         # We get an encoded subject
         self.assertEqual(
             msg['Subject'],
@@ -182,7 +188,7 @@ class TestRegistrationTool(PloneTestCase.PloneTestCase):
         # Notify the registered user
         self.registration.registeredNotify(member_id)
         self.assertEqual(len(mails.messages), 1)
-        msg = message_from_string(mails.messages[0])
+        msg = message_from_bytes(mails.messages[0])
 
         # Ensure charset (and thus Content-Type) were set via template
         self.assertEqual(msg['Content-Type'], 'text/plain; charset="us-ascii"')
@@ -209,7 +215,7 @@ class TestRegistrationTool(PloneTestCase.PloneTestCase):
         from zope.publisher.browser import TestRequest
         self.registration.mailPassword(member_id, TestRequest())
         self.assertEqual(len(mails.messages), 1)
-        msg = message_from_string(mails.messages[0])
+        msg = message_from_bytes(mails.messages[0])
         # We get an encoded subject
         self.assertEqual(msg['Subject'],
                          '=?utf-8?q?Password_reset_request?=')
@@ -242,7 +248,7 @@ class TestRegistrationTool(PloneTestCase.PloneTestCase):
         from zope.publisher.browser import TestRequest
         self.registration.mailPassword(member_id, TestRequest())
         self.assertEqual(len(mails.messages), 1)
-        msg = message_from_string(mails.messages[0])
+        msg = message_from_bytes(mails.messages[0])
 
         # Ensure charset (and thus Content-Type) were set via template
         self.assertEqual(msg['Content-Type'], 'text/plain; charset="us-ascii"')

--- a/Products/CMFPlone/tests/test_login_help.py
+++ b/Products/CMFPlone/tests/test_login_help.py
@@ -70,8 +70,8 @@ class TestLoginHelp(unittest.TestCase):
         self.assertEqual(reset_password.status, '')
         self.assertEqual(len(self.portal.MailHost.messages), 1)
         message = self.portal.MailHost.messages[0]
-        self.assertIn('To: foo@plone.org', message)
-        self.assertIn('http://nohost/plone/passwordreset/', message)
+        self.assertIn(b'To: foo@plone.org', message)
+        self.assertIn(b'http://nohost/plone/passwordreset/', message)
 
 
 class TestLoginHelpFunctional(unittest.TestCase):
@@ -140,8 +140,8 @@ class TestLoginHelpFunctional(unittest.TestCase):
             'email has been sent with your username.', self.browser.contents)
         self.assertEqual(len(self.portal.MailHost.messages), 1)
         message = self.portal.MailHost.messages[0]
-        self.assertIn('To: foo@plone.org', message)
-        self.assertIn('Your username is: test_user_1_', message)
+        self.assertIn(b'To: foo@plone.org', message)
+        self.assertIn(b'Your username is: test_user_1_', message)
 
         self.browser.getControl(
             name='form.widgets.recover_username').value = 'noemail'

--- a/Products/CMFPlone/tests/utils.py
+++ b/Products/CMFPlone/tests/utils.py
@@ -48,13 +48,25 @@ class MockMailHost(MailBase):
         """ Send the message """
         self.messages.append(messageText)
 
-    def send(self, messageText, mto=None, mfrom=None, subject=None,
-             encode=None, immediate=False, charset=None, msg_type=None):
-        messageText, mto, mfrom = _mungeHeaders(messageText,
-                                                mto, mfrom, subject,
-                                                charset=charset,
-                                                msg_type=msg_type)
-        self.messages.append(messageText)
+    def send(self,
+             messageText,
+             mto=None,
+             mfrom=None,
+             subject=None,
+             encode=None,
+             immediate=False,
+             charset=None,
+             msg_type=None):
+        """send *messageText* modified by the other parameters.
+
+        *messageText* can either be an ``email.message.Message``
+        or a string.
+        Note that Products.MailHost 4.10 had changes here.
+        """
+        msg, mto, mfrom = _mungeHeaders(messageText, mto, mfrom,
+                                        subject, charset, msg_type,
+                                        encode)
+        self.messages.append(msg)
 
 
 # a function to test if a string is a valid CSS identifier

--- a/news/3178.bugfix
+++ b/news/3178.bugfix
@@ -1,0 +1,2 @@
+Fix tests with Products.MailHost 4.10.
+[maurits]


### PR DESCRIPTION
Also bring our MockMailHost.send method in line with Products.MailHost 4.10.
We were not passing the 'encode' argument.  (Code may now pass for example encode="8bit".)

Part of https://github.com/plone/Products.CMFPlone/issues/3178