### PR TITLE
remove six - we are Python 3 only

### DIFF
--- a/Products/CMFPlone/ActionsTool.py
+++ b/Products/CMFPlone/ActionsTool.py
@@ -7,8 +7,6 @@ from Products.CMFCore.interfaces import IActionProvider
 from Products.CMFPlone.PloneBaseTool import PloneBaseTool
 from Products.CMFCore.interfaces import IActionCategory
 
-import six
-
 
 class ActionsTool(PloneBaseTool, BaseTool):
 
@@ -62,7 +60,7 @@ class ActionsTool(PloneBaseTool, BaseTool):
 
         if action_chain:
             filtered_actions = []
-            if isinstance(action_chain, six.string_types):
+            if isinstance(action_chain, str):
                 action_chain = (action_chain, )
             for action_ident in action_chain:
                 sep = action_ident.rfind('/')

--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -30,7 +30,6 @@ from Products.CMFPlone.utils import human_readable_size
 from Products.CMFPlone.utils import safe_callable
 from Products.CMFPlone.utils import safe_unicode
 from Products.ZCatalog.ZCatalog import ZCatalog
-from six.moves import urllib
 from time import process_time
 from zExceptions import Unauthorized
 from zope.annotation.interfaces import IAnnotations
@@ -43,8 +42,8 @@ from zope.interface import providedBy
 
 import logging
 import re
-import six
 import time
+import urllib
 
 
 
@@ -192,7 +191,7 @@ def sortable_title(obj):
         if safe_callable(title):
             title = title()
 
-        if isinstance(title, six.string_types):
+        if isinstance(title, str):
             # Ignore case, normalize accents, strip spaces
             sortabletitle = mapUnicode(safe_unicode(title)).lower().strip()
             # Replace numbers with zero filled numbers
@@ -202,8 +201,6 @@ def sortable_title(obj):
                 start = sortabletitle[:(MAX_SORTABLE_TITLE - 13)]
                 end = sortabletitle[-10:]
                 sortabletitle = start + '...' + end
-            if six.PY2:
-                return sortabletitle.encode('utf-8')
             return sortabletitle
     return ''
 
@@ -390,14 +387,12 @@ class CatalogTool(PloneBaseTool, BaseTool):
             # Or: {'path': {'depth': 0, 'query': '/Plone/events/'}}
             paths = paths.get('query', [])
 
-        if isinstance(paths, six.string_types):
+        if isinstance(paths, str):
             paths = [paths]
 
         objs = []
         site = getSite()
         for path in list(paths):
-            if six.PY2:
-                path = path.encode('utf-8')  # paths must not be unicode
             try:
                 site_path = '/'.join(site.getPhysicalPath())
                 parts = path[len(site_path) + 1:].split('/')
@@ -444,7 +439,7 @@ class CatalogTool(PloneBaseTool, BaseTool):
 
         # filter out invalid sort_on indexes
         sort_on = kw.get('sort_on') or []
-        if isinstance(sort_on, six.string_types):
+        if isinstance(sort_on, str):
             sort_on = [sort_on]
         valid_indexes = self.indexes()
         try:

--- a/Products/CMFPlone/DublinCore.py
+++ b/Products/CMFPlone/DublinCore.py
@@ -30,7 +30,6 @@ from Products.CMFPlone.permissions import ModifyPortalContent
 from Products.CMFPlone.permissions import View
 from Products.CMFPlone.utils import WWW_DIR
 
-import six
 
 _marker = []
 
@@ -59,7 +58,7 @@ def tuplize(valueName, value, splitter=lambda x: x.split()):
     if isinstance(value, list):
         return seq_strip(tuple(value))
 
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         return seq_strip(tuple(splitter(value)))
 
     raise ValueError("%s of unsupported type" % valueName)

--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -11,7 +11,7 @@ from Products.CMFCore.utils import UniqueObject
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 from Products.CMFPlone.interfaces import IMigrationTool
 from Products.CMFPlone.PloneBaseTool import PloneBaseTool
-from six import StringIO
+from io import StringIO
 from ZODB.POSException import ConflictError
 from zope.interface import implementer
 

--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -20,8 +20,6 @@ from zope.i18n import translate
 from zope.i18nmessageid import Message
 from zope.interface import implementer
 
-import six
-
 
 class PloneConfiglet(ActionInformation):
 
@@ -197,7 +195,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
             except ValueError:
                 visible = 0
 
-        if isinstance(permissions, six.string_types):
+        if isinstance(permissions, str):
             permissions = (permissions, )
 
         return PloneConfiglet(id=id,

--- a/Products/CMFPlone/PloneFolder.py
+++ b/Products/CMFPlone/PloneFolder.py
@@ -26,7 +26,6 @@ from Products.CMFPlone.DublinCore import DefaultDublinCoreImpl
 from zExceptions import NotFound
 from zope.interface import implementer
 
-import six
 import warnings
 
 
@@ -196,7 +195,7 @@ class BasePloneFolder(CatalogAware, WorkflowAware, OpaqueItemManager,
         if ids is None:
             ids = []
         mt = getToolByName(self, 'portal_membership')
-        if isinstance(ids, six.string_types):
+        if isinstance(ids, str):
             ids = [ids]
         for id in ids:
             item = self._getOb(id)

--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -116,16 +116,6 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
         """ Get the the site encoding, which is utf-8."""
         return 'utf-8'
 
-    @security.public
-    def portal_utf8(self, str, errors='strict'):
-        """Transforms an string in portal encoding to utf8."""
-        return utils.portal_utf8(self, str, errors)
-
-    @security.public
-    def utf8_portal(self, str, errors='strict'):
-        """Transforms an utf8 string to portal encoding."""
-        return utils.utf8_portal(self, str, errors)
-
     @security.private
     def getMailHost(self):
         """Gets the MailHost."""

--- a/Products/CMFPlone/PloneTool.py
+++ b/Products/CMFPlone/PloneTool.py
@@ -43,7 +43,7 @@ from Products.CMFPlone.utils import safe_hasattr
 from Products.CMFPlone.utils import safe_unicode
 from Products.CMFPlone.utils import transaction_note
 from Products.statusmessages.interfaces import IStatusMessage
-from six.moves.urllib import parse
+from urllib import parse
 from ZODB.POSException import ConflictError
 from zope.component import getUtility
 from zope.component import queryAdapter
@@ -54,7 +54,6 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 import re
 import sys
-import six
 import transaction
 
 
@@ -136,7 +135,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
     def validateSingleNormalizedEmailAddress(self, address):
         # Lower-level function to validate a single normalized email address,
         # see validateEmailAddress.
-        if not isinstance(address, six.string_types):
+        if not isinstance(address, str):
             return False
 
         sub = EMAIL_CUTOFF_RE.match(address)
@@ -153,7 +152,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
     @security.public
     def validateSingleEmailAddress(self, address):
         # Validate a single email address, see also validateEmailAddresses.
-        if not isinstance(address, six.string_types):
+        if not isinstance(address, str):
             return False
 
         sub = EMAIL_CUTOFF_RE.match(address)
@@ -176,7 +175,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
     def validateEmailAddresses(self, addresses):
         # Validate a list of possibly several email addresses, see also
         # validateSingleEmailAddress.
-        if not isinstance(addresses, six.string_types):
+        if not isinstance(addresses, str):
             return False
 
         sub = EMAIL_CUTOFF_RE.match(addresses)
@@ -429,7 +428,7 @@ class PloneTool(PloneBaseTool, UniqueObject, SimpleItem):
         s = sys.exc_info()[:2]
         if s[0] == None:
             return None
-        if isinstance(s[0], six.string_types):
+        if isinstance(s[0], str):
             return s[0]
         return str(s[1])
 

--- a/Products/CMFPlone/Portal.py
+++ b/Products/CMFPlone/Portal.py
@@ -28,7 +28,6 @@ from Products.CMFPlone.permissions import View
 from plone.i18n.locales.interfaces import IMetadataLanguageAvailability
 from zope.component import queryUtility
 from zope.interface import implementer
-import six
 
 if bbb.HAS_ZSERVER:
     from webdav.NullResource import NullResource
@@ -121,7 +120,7 @@ class PloneSite(PortalObjectBase, DefaultDublinCoreImpl, OrderedContainer,
         """We need to enforce security."""
         if ids is None:
             ids = []
-        if isinstance(ids, six.string_types):
+        if isinstance(ids, str):
             ids = [ids]
         for id in ids:
             item = self._getOb(id)

--- a/Products/CMFPlone/RegistrationTool.py
+++ b/Products/CMFPlone/RegistrationTool.py
@@ -32,7 +32,6 @@ from zope.schema import ValidationError
 
 import random
 import re
-import six
 
 
 # - remove '1', 'l', and 'I' to avoid confusion
@@ -114,7 +113,7 @@ class RegistrationTool(PloneBaseTool, BaseTool):
     def _md5base(self):
         if self._v_md5base is None:
             key = self.md5key
-            if not isinstance(key, six.binary_type):
+            if not isinstance(key, bytes):
                 key = key.encode()
             self._v_md5base = md5(key)
         return self._v_md5base
@@ -149,7 +148,7 @@ class RegistrationTool(PloneBaseTool, BaseTool):
                 password += password_chars[random.randint(0, nchars - 1)]
             return password
         else:
-            if not isinstance(s, six.binary_type):
+            if not isinstance(s, bytes):
                 s = s.encode()
             m = self._md5base().copy()
             m.update(s)
@@ -157,11 +156,8 @@ class RegistrationTool(PloneBaseTool, BaseTool):
             assert(len(d) >= length)
             password = ''
             nchars = len(password_chars)
-            for i in range(0, length):
-                if six.PY2:
-                    password += password_chars[ord(d[i]) % nchars]
-                else:
-                    password += password_chars[d[i] % nchars]
+            for idx in range(0, length):
+                password += password_chars[d[idx] % nchars]
             return password
 
     security.declarePublic('isValidEmail')
@@ -389,8 +385,6 @@ class RegistrationTool(PloneBaseTool, BaseTool):
             password=member.getPassword(), charset=encoding)
         # The mail headers are not properly encoded we need to extract
         # them and let MailHost manage the encoding.
-        if six.PY2 and isinstance(mail_text, six.text_type):
-            mail_text = mail_text.encode(encoding)
         message_obj = message_from_string(mail_text.strip())
         subject = message_obj['Subject']
         m_to = message_obj['To']
@@ -444,8 +438,6 @@ class RegistrationTool(PloneBaseTool, BaseTool):
 
         # The mail headers are not properly encoded we need to extract
         # them and let MailHost manage the encoding.
-        if six.PY2 and isinstance(mail_text, six.text_type):
-            mail_text = mail_text.encode(encoding)
         message_obj = message_from_string(mail_text.strip())
         subject = message_obj['Subject']
         m_to = message_obj['To']

--- a/Products/CMFPlone/TranslationServiceTool.py
+++ b/Products/CMFPlone/TranslationServiceTool.py
@@ -24,8 +24,6 @@ from zope.i18n import translate
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 
-import six
-
 
 @implementer(ITranslationServiceTool)
 class TranslationServiceTool(PloneBaseTool, UniqueObject, SimpleItem):
@@ -62,10 +60,10 @@ class TranslationServiceTool(PloneBaseTool, UniqueObject, SimpleItem):
         # output_encoding
 
         # check if input is not type unicode
-        if not isinstance(m, six.text_type):
+        if not isinstance(m, str):
             if input_encoding is None:
                 input_encoding = 'utf-8'
-            m = six.text_type(str(m), input_encoding, errors)
+            m = str(str(m), input_encoding, errors)
 
         if output_encoding is None:
             output_encoding = 'utf-8'
@@ -78,14 +76,14 @@ class TranslationServiceTool(PloneBaseTool, UniqueObject, SimpleItem):
     def asunicodetype(self, m, input_encoding=None, errors='strict'):
         # create type unicode from type string
 
-        if isinstance(m, six.text_type):
+        if isinstance(m, str):
             return m
 
         if input_encoding is None:
             input_encoding = 'utf-8'
 
         # return as type unicode
-        return six.text_type(str(m), input_encoding, errors)
+        return str(str(m), input_encoding, errors)
 
     security.declarePublic('ulocalized_time')
 

--- a/Products/CMFPlone/TypesTool.py
+++ b/Products/CMFPlone/TypesTool.py
@@ -8,8 +8,6 @@ from Products.CMFCore.TypesTool import TypesTool as BaseTool
 
 from Products.CMFPlone.PloneBaseTool import PloneBaseTool
 
-import six
-
 
 class TypesTool(PloneBaseTool, BaseTool):
 
@@ -69,7 +67,7 @@ class TypesTool(PloneBaseTool, BaseTool):
 
         if action_chain:
             filtered_actions = []
-            if isinstance(action_chain, six.string_types):
+            if isinstance(action_chain, str):
                 action_chain = (action_chain, )
             for action_ident in action_chain:
                 sep = action_ident.rfind('/')

--- a/Products/CMFPlone/UnicodeSplitter/config.py
+++ b/Products/CMFPlone/UnicodeSplitter/config.py
@@ -5,7 +5,7 @@ config.py
 Created by Manabu Terada, CMScom on 2009-08-08.
 """
 import re
-import six
+
 
 STOP_WORD = []
 
@@ -47,13 +47,9 @@ rx_all = re.compile(r"[%s]" % allp, re.UNICODE)
 rx_U = re.compile(r"\w+", re.UNICODE)
 rxGlob_U = re.compile(r"\w+[\w*?]*", re.UNICODE)
 
-if six.PY2:
-    rx_L = re.compile(r"\w+", re.LOCALE)
-    rxGlob_L = re.compile(r"\w+[\w*?]*", re.LOCALE)
-else:
-    # FIXME: since py3.6 re.LOCALE can be only used with bytes
-    rx_L = re.compile(r"\w+")
-    rxGlob_L = re.compile(r"\w+[\w*?]*")
+# FIXME: since py3.6 re.LOCALE can be only used with bytes
+rx_L = re.compile(r"\w+")
+rxGlob_L = re.compile(r"\w+[\w*?]*")
 
 # pattern = re.compile(u"[a-zA-Z0-9_]+|[\uac00-\ud7af]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff]+", re.UNICODE)
 # pattern_g = re.compile(u"[a-zA-Z0-9_]+[*?]*|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]+[*?]*", re.UNICODE)

--- a/Products/CMFPlone/UnicodeSplitter/splitter.py
+++ b/Products/CMFPlone/UnicodeSplitter/splitter.py
@@ -15,10 +15,8 @@ from Products.CMFPlone.UnicodeSplitter.config import rxGlob_L
 from Products.CMFPlone.UnicodeSplitter.config import rxGlob_U
 from Products.ZCTextIndex.interfaces import ISplitter
 from Products.ZCTextIndex.PipelineFactory import element_factory
-from six.moves import range
 from zope.interface import implementer
 
-import six
 import unicodedata
 
 
@@ -37,11 +35,11 @@ def bigram(u, limit=1):
 
 def process_str_post(s, enc='utf-8'):
     """Receive str, remove ? and *, then return str.
-    If decode gets successful, process str as six.text_type.
+    If decode gets successful, process str as str.
     If decode gets failed, process str as ASCII.
     """
     try:
-        if not isinstance(s, six.text_type):
+        if not isinstance(s, str):
             uni = s.decode(enc, "strict")
         else:
             uni = s
@@ -56,12 +54,12 @@ def process_str_post(s, enc='utf-8'):
 def process_str(s, enc='utf-8'):
     """Receive str and encoding, then return the list
     of str as bi-grammed result.
-    Decode str into six.text_type and pass it to process_unicode.
+    Decode str into str and pass it to process_unicode.
     When decode failed, return the result splitted per word.
     Splitting depends on locale specified by rx_L.
     """
     try:
-        if not isinstance(s, six.text_type):
+        if not isinstance(s, str):
             uni = s.decode(enc, "strict")
         else:
             uni = s
@@ -74,12 +72,12 @@ def process_str(s, enc='utf-8'):
 def process_str_glob(s, enc='utf-8'):
     """Receive str and encoding, then return the list
     of str considering glob processing.
-    Decode str into six.text_type and pass it to process_unicode_glob.
+    Decode str into str and pass it to process_unicode_glob.
     When decode failed, return the result splitted per word.
     Splitting depends on locale specified by rxGlob_L.
     """
     try:
-        if not isinstance(s, six.text_type):
+        if not isinstance(s, str):
             uni = s.decode(enc, "strict")
         else:
             uni = s
@@ -173,7 +171,7 @@ class CaseNormalizer(object):
             # This is a hack to get the normalizer working with
             # non-unicode text.
             try:
-                if not isinstance(s, six.text_type):
+                if not isinstance(s, str):
                     s = s.decode(enc)
             except (UnicodeDecodeError, TypeError):
                 result.append(s.lower())
@@ -201,7 +199,7 @@ class I18NNormalizer(object):
         result = []
         for s in lst:
             try:
-                if not isinstance(s, six.text_type):
+                if not isinstance(s, str):
                     s = s.decode(enc)
             except (UnicodeDecodeError, TypeError):
                 pass

--- a/Products/CMFPlone/__init__.py
+++ b/Products/CMFPlone/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from App.ImageFile import ImageFile
 import os
-import six
 import sys
 import pkg_resources
 
@@ -70,9 +69,6 @@ def initialize(context):
     this_module.Batch = Batch
 
     ModuleSecurityInfo('StringIO').declarePublic('StringIO')
-    if six.PY2:
-        from six import StringIO
-        allow_class(StringIO)
 
     # Make Unauthorized importable TTW
     ModuleSecurityInfo('AccessControl').declarePublic('Unauthorized')

--- a/Products/CMFPlone/_compat.py
+++ b/Products/CMFPlone/_compat.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 from json import dumps
-from six import text_type
 
 
 def dump_json_to_text(obj):
     ''' Encode an obj into a text
     '''
     text = dumps(obj, indent=4)
-    if not isinstance(text, text_type):
+    if not isinstance(text, str):
         text = text.decode('utf8')
     return text

--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -18,7 +18,7 @@ from plone.i18n.locales.interfaces import IContentLanguageAvailability
 from plone.keyring.interfaces import IKeyManager
 from plone.protect.authenticator import check as checkCSRF
 from plone.protect.interfaces import IDisableCSRFProtection
-from six.moves.urllib import parse
+from urllib import parse
 from zope.component import adapts
 from zope.component import getAllUtilitiesRegisteredFor
 from zope.component import getUtility

--- a/Products/CMFPlone/browser/atd.py
+++ b/Products/CMFPlone/browser/atd.py
@@ -2,7 +2,7 @@
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry
-from six.moves import http_client
+from http import client as http_client
 from Products.CMFPlone.interfaces import ITinyMCESchema
 from Products.CMFPlone.interfaces.atd import IATDProxyView
 from zope.interface import implementer

--- a/Products/CMFPlone/browser/author.py
+++ b/Products/CMFPlone/browser/author.py
@@ -16,7 +16,7 @@ from ZODB.POSException import ConflictError
 from .interfaces import IAuthorFeedbackForm
 
 from plone.registry.interfaces import IRegistry
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 
 from z3c.form import button
 from z3c.form import field

--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -12,7 +12,7 @@ from Products.CMFPlone.interfaces import IRedirectAfterLogin
 from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
-from six.moves.urllib import parse
+from urllib import parse
 from z3c.form import button
 from z3c.form import field
 from z3c.form import form

--- a/Products/CMFPlone/browser/login/login_help.py
+++ b/Products/CMFPlone/browser/login/login_help.py
@@ -22,7 +22,6 @@ from zope.i18n import translate
 from zope.interface import implementer
 
 import logging
-import six
 
 
 SEND_USERNAME_TEMPLATE = _(u"mailtemplate_username_info", default=u"""From: {encoded_mail_sender}
@@ -154,10 +153,6 @@ class RequestUsername(form.Form):
             email_from_name=registry['plone.email_from_name'],
             encoded_mail_sender=self.encoded_mail_sender(),
         )
-        # The mail headers are not properly encoded we need to extract
-        # them and let MailHost manage the encoding.
-        if six.PY2 and isinstance(mail_text, six.text_type):
-            mail_text = mail_text.encode(encoding)
         message_obj = message_from_string(mail_text.strip())
         subject = message_obj['Subject']
         m_to = message_obj['To']

--- a/Products/CMFPlone/browser/ploneview.py
+++ b/Products/CMFPlone/browser/ploneview.py
@@ -10,8 +10,6 @@ from zope.i18n import translate
 from zope.interface import implementer
 from zope.size import byteDisplay
 
-import six
-
 _marker = []
 
 
@@ -113,7 +111,7 @@ class Plone(BrowserView):
         if not length:
             return text
         converted = False
-        if not isinstance(text, six.text_type):
+        if not isinstance(text, str):
             text = utils.safe_unicode(text)
             converted = True
         if len(text) > length:

--- a/Products/CMFPlone/browser/search.py
+++ b/Products/CMFPlone/browser/search.py
@@ -17,15 +17,12 @@ from ZPublisher.HTTPRequest import record
 from ZTUtils import make_query
 
 import json
-import six
 
 _ = MessageFactory('plone')
 
 # We should accept both a simple space, unicode u'\u0020 but also a
 # multi-space, so called 'waji-kankaku', unicode u'\u3000'
 MULTISPACE = u'\u3000'
-if six.PY2:
-    MULTISPACE = u'\u3000'.encode('utf-8')
 BAD_CHARS = ('?', '-', '+', '*', MULTISPACE)
 EVER = DateTime('1970-01-03')
 

--- a/Products/CMFPlone/browser/syndication/adapters.py
+++ b/Products/CMFPlone/browser/syndication/adapters.py
@@ -29,8 +29,6 @@ from plone.namedfile.interfaces import INamedField
 
 from plone.app.contenttypes.behaviors.leadimage import ILeadImage
 
-import six
-
 try:
     from Products.ATContentTypes.interfaces.file import IFileContent
 except ImportError:
@@ -233,7 +231,7 @@ class BaseItem(BaseFeedData):
             value = self.context.text
         else:
             value = self.description
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             if hasattr(value, 'output'):
                 # could be RichTextValue object, needs transform
                 value = value.output

--- a/Products/CMFPlone/controlpanel/bbb/site.py
+++ b/Products/CMFPlone/controlpanel/bbb/site.py
@@ -7,8 +7,6 @@ from zope.component import adapts
 from zope.component import getUtility
 from zope.interface import implementer
 
-import six
-
 
 @implementer(ISiteSchema)
 class SiteControlPanelAdapter(object):
@@ -23,16 +21,12 @@ class SiteControlPanelAdapter(object):
         return self.settings.site_title
 
     def set_site_title(self, value):
-        if six.PY2 and isinstance(value, six.binary_type):
-            value = value.decode('utf-8')
         self.settings.site_title = value
 
     def get_webstats_js(self):
         return self.settings.webstats_js
 
     def set_webstats_js(self, value):
-        if six.PY2 and isinstance(value, six.binary_type):
-            value = value.decode('utf-8')
         self.settings.webstats_js = value
 
     site_title = property(get_site_title, set_site_title)

--- a/Products/CMFPlone/controlpanel/browser/mail.py
+++ b/Products/CMFPlone/controlpanel/browser/mail.py
@@ -10,7 +10,6 @@ from plone.registry.interfaces import IRegistry
 from z3c.form import button
 from zope.component import getUtility
 
-import six
 import smtplib
 import socket
 import sys
@@ -88,7 +87,7 @@ class MailControlPanelForm(controlpanel.RegistryEditForm):
                 log.exception('Unable to send test e-mail.')
                 value = sys.exc_info()[1]
                 msg = _(u'Unable to send test e-mail ${error}.',
-                        mapping={'error': six.text_type(value)})
+                        mapping={'error': str(value)})
                 IStatusMessage(self.request).addStatusMessage(
                     msg, type='error')
             else:

--- a/Products/CMFPlone/controlpanel/browser/redirects.py
+++ b/Products/CMFPlone/controlpanel/browser/redirects.py
@@ -10,8 +10,8 @@ from Products.CMFPlone.PloneBatch import Batch
 from Products.CMFPlone.utils import safe_text
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
-from six import StringIO
-from six.moves.urllib.parse import urlparse
+from io import StringIO
+from urllib.parse import urlparse
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import getSite

--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -13,14 +13,13 @@ from Products.CMFPlone.resources import RESOURCE_DEVELOPMENT_MODE
 from Products.CMFPlone.resources.browser.configjs import RequireJsView
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.statusmessages.interfaces import IStatusMessage
-from six.moves.urllib import parse
+from urllib import parse
 from zExceptions import NotFound
 from zope.component import getUtility
 
 import json
 import posixpath
 import re
-import six
 
 
 CSS_URL_REGEX = re.compile(r'url\(([^)]+)\)')
@@ -49,13 +48,9 @@ def updateRecordFromDict(record, data):
         if name in data:
             # almost all string data needs to be str, not unicode
             val = data[name]
-            if six.PY2 and isinstance(val, six.text_type):
-                val = val.encode('utf-8')
             if isinstance(val, list):
                 newval = []
                 for item in val:
-                    if six.PY2 and isinstance(item, six.text_type):
-                        item = item.encode('utf-8')
                     newval.append(item)
                 val = newval
 
@@ -344,7 +339,7 @@ class ResourceRegistryControlPanelView(RequireJsView):
         for key, value in req.form.items():
             if not key.startswith('data-'):
                 continue
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 value = [value]
             data += '\n'.join(value) + '\n'
         overrides.save_file(filepath, data)
@@ -360,9 +355,6 @@ class ResourceRegistryControlPanelView(RequireJsView):
     def save_less_variables(self):
         data = {}
         for key, val in json.loads(self.request.form.get('data')).items():
-            if six.PY2 and isinstance(key, six.text_type):
-                # need to convert to str: unicode
-                key = key.encode('utf8')
             data[key] = val
         self.registry['plone.lessvariables'] = data
         return json.dumps({
@@ -372,9 +364,6 @@ class ResourceRegistryControlPanelView(RequireJsView):
     def save_pattern_options(self):
         data = {}
         for key, val in json.loads(self.request.form.get('data')).items():
-            if six.PY2 and isinstance(key, six.text_type):
-                # need to convert to str: unicode
-                key = key.encode('utf8')
             data[key] = val
         self.registry['plone.patternoptions'] = data
         return json.dumps({

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.py
@@ -16,7 +16,6 @@ from Products.CMFPlone.controlpanel.browser.usergroups import \
     UsersGroupsControlPanelView
 
 import logging
-import six
 
 logger = logging.getLogger('Products.CMFPlone')
 
@@ -212,7 +211,7 @@ class UsersOverviewControlPanel(UsersGroupsControlPanelView):
 
         # Delete members in acl_users.
         acl_users = context.acl_users
-        if isinstance(member_ids, six.string_types):
+        if isinstance(member_ids, str):
             member_ids = (member_ids,)
         member_ids = list(member_ids)
         for member_id in member_ids[:]:

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_site.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_site.py
@@ -4,7 +4,7 @@ from plone.registry.interfaces import IRegistry
 from plone.testing.zope import Browser
 from Products.CMFPlone.interfaces import ISiteSchema
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
-from six import BytesIO
+from io import BytesIO
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
@@ -8,11 +8,10 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.zope import Browser
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
-from six import StringIO
-from six.moves.urllib.parse import urlencode
+from io import StringIO
+from urllib.parse import urlencode
 
 import re
-import six
 import transaction
 import unittest
 import zExceptions

--- a/Products/CMFPlone/controlpanel/tests/test_doctests.py
+++ b/Products/CMFPlone/controlpanel/tests/test_doctests.py
@@ -4,33 +4,32 @@ from plone.testing import layered
 
 import doctest
 import re
-import six
 import unittest
+
+
+tests = ('../README.rst',)
 
 
 class Py23DocChecker(doctest.OutputChecker):
 
     def check_output(self, want, got, optionflags):
-        if not six.PY2:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
-            want = re.sub('u"(.*?)"', '"\\1"', want)
+        # TODO: Fix tests to use Python 3 syntax
+        want = re.sub("u'(.*?)'", "'\\1'", want)
+        want = re.sub('u"(.*?)"', '"\\1"', want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-
-tests = ('../README.rst',)
-
 
 def test_suite():
     return unittest.TestSuite(
         [
             layered(
                 doctest.DocFileSuite(
-                    f,
+                    ft,
                     optionflags=doctest.ELLIPSIS,
                     checker=Py23DocChecker(),
                 ),
-                layer=PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
+                layer=PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING,
+
             )
-            for f in tests
+            for ft in tests
         ]
     )

--- a/Products/CMFPlone/defaultpage.py
+++ b/Products/CMFPlone/defaultpage.py
@@ -13,8 +13,6 @@ from zope.component import queryAdapter
 from zope.component import queryUtility
 from zope.component import queryMultiAdapter
 
-import six
-
 
 def get_default_page(context):
     """Given a folderish item, find out if it has a default-page using
@@ -74,7 +72,7 @@ def get_default_page(context):
 
     # 3.1 Test for default_page attribute in folder, no acquisition
     pages = getattr(aq_base(context), 'default_page', [])
-    if isinstance(pages, six.string_types):
+    if isinstance(pages, str):
         pages = [pages]
     for page in pages:
         if page and page in ids:

--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -15,7 +15,6 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 import json
-import six
 
 
 deprecated(
@@ -67,7 +66,7 @@ def validate_json(value):
         class JSONError(schema.ValidationError):
             __doc__ = _(u"Must be empty or a valid JSON-formatted "
                         u"configuration – ${message}.", mapping={
-                            'message': six.text_type(exc)})
+                            'message': str(exc)})
 
         raise JSONError(value)
 

--- a/Products/CMFPlone/patches/unicodehacks.py
+++ b/Products/CMFPlone/patches/unicodehacks.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
-import six
-
 
 def _unicode_replace(structure):
-    if isinstance(structure, six.binary_type):
-        text = structure.decode('utf-8', 'replace')
-    else:
-        text = six.text_type(structure)
-    return text
+    if isinstance(structure, bytes):
+        return structure.decode('utf-8', 'replace')
+    return str(structure)
 
 
 def _nulljoin(valuelist):

--- a/Products/CMFPlone/patches/z3c_form.py
+++ b/Products/CMFPlone/patches/z3c_form.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This is from Products.PloneHotfix20160830.
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from z3c.form import widget
 
 

--- a/Products/CMFPlone/resources/browser/combine.py
+++ b/Products/CMFPlone/resources/browser/combine.py
@@ -13,7 +13,6 @@ from zope.component import queryUtility
 
 import logging
 import re
-import six
 
 
 PRODUCTION_RESOURCE_DIRECTORY = 'production'
@@ -32,7 +31,7 @@ def get_production_resource_directory():
     if 'timestamp.txt' not in production_folder:
         return '%s/++unique++1' % PRODUCTION_RESOURCE_DIRECTORY
     timestamp = production_folder.readFile('timestamp.txt')
-    if not six.PY2 and isinstance(timestamp, six.binary_type):
+    if isinstance(timestamp, bytes):
         timestamp = timestamp.decode()
     return '%s/++unique++%s' % (
         PRODUCTION_RESOURCE_DIRECTORY, timestamp)
@@ -114,7 +113,7 @@ def write_js(context, folder, meta_bundle):
 
     fi = BytesIO()
     for script in resources:
-        if not isinstance(script, six.binary_type):
+        if not isinstance(script, bytes):
             script = script.encode()
         fi.write((script + b'\n'))
     folder.writeFile(meta_bundle + '.js', fi)
@@ -139,7 +138,7 @@ def write_css(context, folder, meta_bundle):
             # Process relative urls:
             # we prefix with current resource path any url not starting with
             # '/' or http: or data:
-            if not isinstance(path, six.binary_type):
+            if not isinstance(path, bytes):
                 path = path.encode()
             css = re.sub(
                 br"""(url\(['"]?(?!['"]?([a-z]+:|\/)))""",
@@ -149,7 +148,7 @@ def write_css(context, folder, meta_bundle):
 
     fi = BytesIO()
     for script in resources:
-        if not isinstance(script, six.binary_type):
+        if not isinstance(script, bytes):
             script = script.encode()
         fi.write((script + b'\n'))
     folder.writeFile(meta_bundle + '.css', fi)

--- a/Products/CMFPlone/resources/browser/cook.py
+++ b/Products/CMFPlone/resources/browser/cook.py
@@ -19,7 +19,6 @@ from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 
 import logging
-import six
 
 
 logger = logging.getLogger('Products.CMFPlone')
@@ -97,7 +96,7 @@ def cookWhenChangingSettings(context, bundle=None):
                     css = response.getBody()
                     if css_resource[-8:] != '.min.css':
                         css = css_compiler.compile_string(css)
-                    if not isinstance(css, six.text_type):
+                    if not isinstance(css, str):
                         css = css.decode('utf8')
                     cooked_css += '\n/* Resource: {0} */\n{1}\n'.format(
                         css_resource,
@@ -116,7 +115,7 @@ def cookWhenChangingSettings(context, bundle=None):
         if response.status == 200:
             logger.info('Cooking js %s', resource.js)
             js = response.getBody()
-            if not isinstance(js, six.text_type):
+            if not isinstance(js, str):
                 js = js.decode('utf8')
             try:
                 cooked_js += '\n/* resource: {0} */\n{1}'.format(
@@ -156,7 +155,7 @@ def cookWhenChangingSettings(context, bundle=None):
             resource_filepath = resource_path
         if resource_name not in container:
             container.makeDirectory(resource_name)
-        if not isinstance(cooked_string, six.binary_type):  # handle Error of OFS.Image  # noqa: E501
+        if not isinstance(cooked_string, bytes):  # handle Error of OFS.Image  # noqa: E501
             cooked_string = cooked_string.encode('ascii', errors='ignore')
         try:
             folder = container[resource_name]

--- a/Products/CMFPlone/resources/browser/mixins.py
+++ b/Products/CMFPlone/resources/browser/mixins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from AccessControl.safe_formatter import SafeFormatter
 from plone.registry.interfaces import IRegistry
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from Products.CMFPlone.interfaces import IResourceRegistry
 from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter

--- a/Products/CMFPlone/resources/browser/scripts.py
+++ b/Products/CMFPlone/resources/browser/scripts.py
@@ -2,7 +2,7 @@
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceView
 from Products.CMFPlone.utils import get_top_request
-from six.moves.urllib import parse
+from urllib import parse
 from zope.component import getMultiAdapter
 
 

--- a/Products/CMFPlone/resources/browser/styles.py
+++ b/Products/CMFPlone/resources/browser/styles.py
@@ -5,7 +5,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 from Products.CMFPlone.resources.browser.resource import ResourceBase
 from Products.CMFPlone.utils import get_top_request
-from six.moves.urllib import parse
+from urllib import parse
 from zope.component import getUtility
 
 

--- a/Products/CMFPlone/setuphandlers.py
+++ b/Products/CMFPlone/setuphandlers.py
@@ -16,8 +16,6 @@ from zope.component.hooks import getSite
 from zope.i18n.locales import LoadLocaleError
 from zope.i18n.locales import locales
 
-import six
-
 
 def addCacheHandlers(portal):
     """ Add RAM and AcceleratedHTTP cache handlers """
@@ -150,31 +148,12 @@ def importFinalSteps(context):
     first_weekday_setup(context)
     timezone_setup(context)
 
-    external_editor_permissions(site)
     set_zsqlmethods_permissions(site)
 
     # setup resource overrides plone.resource
     persistentDirectory = getUtility(IResourceDirectory, name="persistent")
     if OVERRIDE_RESOURCE_DIRECTORY_NAME not in persistentDirectory:
         persistentDirectory.makeDirectory(OVERRIDE_RESOURCE_DIRECTORY_NAME)
-
-
-def external_editor_permissions(site):
-    """The permission to use Products.ExternalEditor only makes sense when
-    ExternalEditor is installed. In py3 it will not exists because it depends
-    on webdav.
-    The following xml was taken from rolemap.xml:
-    <permission name="Use external editor" acquire="False">
-      <role name="Authenticated"/>
-      <role name="Manager"/>
-      <role name="Site Administrator"/>
-    </permission>
-    """
-    if six.PY2:
-        site.manage_permission(
-            'Use external editor',
-            ['Authenticated', 'Manager', 'Site Administrator'],
-            False)
 
 
 def set_zsqlmethods_permissions(site):

--- a/Products/CMFPlone/skins/plone_scripts/queryCatalog.py
+++ b/Products/CMFPlone/skins/plone_scripts/queryCatalog.py
@@ -22,16 +22,7 @@ second_pass = {}
 if REQUEST is None:
     REQUEST = context.REQUEST
 
-# We should accept both a simple space, unicode u'\u0020 but also a
-# multi-space, so called 'waji-kankaku', unicode u'\u3000'
-# Stupid hack to find py-version since importing six or sys is forbidden.
-try:
-    # PY2
-    u'foo'.decode('utf8')
-    multispace = u'\u3000'.encode('utf-8')
-except AttributeError:
-    # PY3
-    multispace = u'\u3000'
+multispace = u'\u3000'
 
 def quotestring(s):
     return '"%s"' % s

--- a/Products/CMFPlone/tests/dummy.py
+++ b/Products/CMFPlone/tests/dummy.py
@@ -7,8 +7,8 @@ from OFS.Folder import Folder as SimpleFolder
 from OFS.SimpleItem import SimpleItem
 from Products.CMFPlone.interfaces import INonStructuralFolder
 from Products.CMFPlone.interfaces import IWorkflowChain
-from six import StringIO
-from six import BytesIO
+from io import StringIO
+from io import BytesIO
 from zope.interface import implementer
 from zope.interface import Interface
 from ZPublisher.HTTPRequest import FileUpload

--- a/Products/CMFPlone/tests/messages.txt
+++ b/Products/CMFPlone/tests/messages.txt
@@ -122,7 +122,7 @@ to get the parsed and interpreted text.
 
   >>> from zope.tal.htmltalparser import HTMLTALParser
   >>> from zope.tal.talinterpreter import TALInterpreter
-  >>> from six import StringIO
+  >>> from io import StringIO
 
   >>> def compile(source):
   ...     parser = HTMLTALParser()

--- a/Products/CMFPlone/tests/testCSRFProtection.py
+++ b/Products/CMFPlone/tests/testCSRFProtection.py
@@ -5,7 +5,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing.bbb import PloneTestCase
 from plone.keyring.interfaces import IKeyManager
 from plone.protect.authenticator import AuthenticatorView
-from six import BytesIO
+from io import BytesIO
 from zope.component import queryUtility
 
 

--- a/Products/CMFPlone/tests/testContentTypeScripts.py
+++ b/Products/CMFPlone/tests/testContentTypeScripts.py
@@ -6,8 +6,6 @@ from plone.namedfile.file import NamedImage
 from Products.CMFPlone.tests import PloneTestCase
 from Products.CMFPlone.tests import dummy
 
-import six
-
 AddPortalTopics = 'Add portal topics'
 
 
@@ -121,10 +119,7 @@ class TestImageProps(PloneTestCase.PloneTestCase):
 
     def testImageComputedProps(self):
         from OFS.Image import Image
-        if six.PY2:
-            tag = Image.tag.im_func
-        else:
-            tag = Image.tag
+        tag = Image.tag
         kw = {'_title': 'some title',
               '_alt': 'alt tag',
               'height': 100,

--- a/Products/CMFPlone/tests/testCutPasteSecurity.py
+++ b/Products/CMFPlone/tests/testCutPasteSecurity.py
@@ -6,10 +6,11 @@ from Products.CMFPlone.tests.PloneTestCase import PloneTestCase
 from Products.CMFCore.interfaces import IContentish
 from zope.component import provideHandler, getGlobalSiteManager
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
+from urllib.error import HTTPError
+
 import transaction
 
 
-from six.moves.urllib.error import HTTPError
 
 
 class TestCutPasteSecurity(PloneTestCase):

--- a/Products/CMFPlone/tests/testNavTree.py
+++ b/Products/CMFPlone/tests/testNavTree.py
@@ -12,13 +12,12 @@ from plone.app.layout.navigation.root import getNavigationRoot
 from zope.interface import directlyProvides
 from zope.interface import implementer
 
-default_user = PloneTestCase.default_user
 
 from Products.CMFPlone.PloneFolder import PloneFolder
 from Products.CMFPlone.interfaces import INonStructuralFolder
 
+default_user = PloneTestCase.default_user
 
-import six
 
 
 @implementer(INonStructuralFolder)
@@ -558,7 +557,7 @@ class TestNavigationRoot(PloneTestCase.PloneTestCase):
         folderPath = '/'.join(self.folder.getPhysicalPath())
         portalPath = '/'.join(self.portal.getPhysicalPath())
         relativePath = folderPath[len(portalPath):]
-        self.portal.portal_registry['plone.root'] = six.text_type(relativePath)
+        self.portal.portal_registry['plone.root'] = str(relativePath)
         root = getNavigationRoot(self.portal)
         self.assertEqual(root, folderPath)
 

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -6,7 +6,6 @@ from plone.app.testing import SITE_OWNER_PASSWORD
 from zExceptions import Unauthorized
 
 import re
-import six
 import unittest
 
 
@@ -147,7 +146,7 @@ class TestAttackVectorsFunctional(PloneTestCase):
         self.setRoles(['Manager', 'Owner'])
         self.portal.REQUEST.PARENTS = [self.app]
         res = self.portal.news.manage_FTPlist(self.portal.REQUEST)
-        self.assertTrue(isinstance(res, six.string_types))
+        self.assertTrue(isinstance(res, str))
         self.portal.portal_workflow.doActionFor(self.portal.news, 'hide')
         self.setRoles(['Member'])
         from zExceptions import Unauthorized

--- a/Products/CMFPlone/tests/testWebDAV.py
+++ b/Products/CMFPlone/tests/testWebDAV.py
@@ -8,7 +8,7 @@ from Products.CMFPlone import bbb
 from Products.CMFPlone.tests import dummy
 from Products.CMFPlone.tests import PloneTestCase
 
-import six
+import io
 
 
 html = """\
@@ -45,7 +45,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/new_html',
                                 env={'CONTENT_TYPE': 'text/html'},
                                 request_method='PUT',
-                                stdin=six.StringIO(html),
+                                stdin=io.StringIO(html),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -59,7 +59,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.rst',
                                 env={'CONTENT_LENGTH': '0'},
                                 request_method='PUT',
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -73,7 +73,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.txt',
                                 env={'CONTENT_LENGTH': '0'},
                                 request_method='PUT',
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -87,7 +87,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.ini',
                                 env={'CONTENT_LENGTH': '0'},
                                 request_method='PUT',
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -100,7 +100,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/index_html',
                                 env={'CONTENT_TYPE': 'text/html'},
                                 request_method='PUT',
-                                stdin=six.StringIO(html),
+                                stdin=io.StringIO(html),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -114,7 +114,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/new_image',
                                 env={'CONTENT_TYPE': 'image/gif'},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -131,7 +131,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.gif',
                                 env={'CONTENT_LENGTH': len(dummy.GIF)},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -149,7 +149,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.jpg',
                                 env={'CONTENT_LENGTH': len(dummy.GIF)},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -167,7 +167,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.png',
                                 env={'CONTENT_LENGTH': len(dummy.GIF)},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -185,7 +185,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.tiff',
                                 env={'CONTENT_LENGTH': len(dummy.GIF)},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -203,7 +203,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/test.ico',
                                 env={'CONTENT_LENGTH': len(dummy.GIF)},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -221,7 +221,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.folder_path + '/index_html',
                                 env={'CONTENT_TYPE': 'image/gif'},
                                 request_method='PUT',
-                                stdin=six.StringIO(dummy.GIF),
+                                stdin=io.StringIO(dummy.GIF),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -237,7 +237,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.portal_path + '/new_html',
                                 env={'CONTENT_TYPE': 'text/html'},
                                 request_method='PUT',
-                                stdin=six.StringIO(html),
+                                stdin=io.StringIO(html),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -252,7 +252,7 @@ class TestPUTObjects(PloneTestCase.PloneTestCase):
         response = self.publish(self.portal_path + '/index_html',
                                 env={'CONTENT_TYPE': 'text/html'},
                                 request_method='PUT',
-                                stdin=six.StringIO(html),
+                                stdin=io.StringIO(html),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 201)
@@ -293,7 +293,7 @@ class TestPUTIndexHtml(PloneTestCase.PloneTestCase):
             self.folder_path + '/index_html',
             basic=self.basic_auth,
             env={'Content-Length': self.length},
-            stdin=six.StringIO(self.body),
+            stdin=io.StringIO(self.body),
             request_method='PUT',
             handle_errors=False)
 
@@ -312,7 +312,7 @@ class TestPUTIndexHtml(PloneTestCase.PloneTestCase):
             self.portal_path + '/index_html',
             basic=self.basic_auth,
             env={'Content-Length': self.length},
-            stdin=six.StringIO(self.body),
+            stdin=io.StringIO(self.body),
             request_method='PUT',
             handle_errors=False)
 
@@ -339,7 +339,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path + '/sub/index_html',
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())
@@ -353,7 +353,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path + '/sub/index_html',
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 404, response.getBody())
@@ -368,7 +368,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.portal_path + '/index_html',
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())
@@ -384,7 +384,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.portal_path + '/index_html',
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 404, response.getBody())
@@ -399,7 +399,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.portal_path,
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())
@@ -414,7 +414,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.portal_path,
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())
@@ -429,7 +429,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path,
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())
@@ -444,7 +444,7 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path,
                                 request_method='PROPFIND',
                                 env={'HTTP_DEPTH': '0'},
-                                stdin=six.StringIO(),
+                                stdin=io.StringIO(),
                                 basic=self.basic_auth)
 
         self.assertEqual(response.getStatus(), 207, response.getBody())

--- a/Products/CMFPlone/tests/testWorkflowTool.py
+++ b/Products/CMFPlone/tests/testWorkflowTool.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from zope.interface import directlyProvides, Interface
 from zope.component import provideAdapter, getGlobalSiteManager
-
 from Products.CMFPlone.tests import PloneTestCase
 from Products.CMFPlone.tests.dummy import Dummy, DummyWorkflowChainAdapter
 from Products.CMFCore.interfaces import IWorkflowTool
-
-import six
 
 default_user = PloneTestCase.default_user
 

--- a/Products/CMFPlone/tests/test_PloneTool.py
+++ b/Products/CMFPlone/tests/test_PloneTool.py
@@ -26,24 +26,6 @@ class TestPloneTool(unittest.TestCase):
             'utf-8'
         )
 
-    def test_portal_utf8(self):
-        text = u'Eksempel \xe6\xf8\xe5'
-        site_text = text.encode('utf-8')
-
-        self.assertEqual(
-            self.tool.portal_utf8(site_text),
-            text.encode('utf-8')
-        )
-
-    def test_utf8_portal(self):
-        text = u'Eksempel \xe6\xf8\xe5'
-        utf8text = text.encode('utf-8')
-
-        self.assertEqual(
-            self.tool.utf8_portal(utf8text),
-            text.encode('utf-8')
-        )
-
     def test_getMailHost(self):
         self.assertTrue(
             IMailHost.providedBy(self.tool.getMailHost())

--- a/Products/CMFPlone/tests/test_doctests.py
+++ b/Products/CMFPlone/tests/test_doctests.py
@@ -3,14 +3,13 @@ from unittest import TestSuite
 
 import doctest
 import re
-import six
 
 
 class Py23DocChecker(doctest.OutputChecker):
 
     def check_output(self, want, got, optionflags):
-        if not six.PY2:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
+        # TODO: Fix tests to check Python 3 style
+        want = re.sub("u'(.*?)'", "'\\1'", want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/Products/CMFPlone/tests/test_functional.py
+++ b/Products/CMFPlone/tests/test_functional.py
@@ -7,7 +7,6 @@ import doctest
 import glob
 import os
 import re
-import six
 import unittest
 
 
@@ -26,19 +25,15 @@ OPTIONFLAGS = (doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
 class Py23DocChecker(doctest.OutputChecker):
 
     def check_output(self, want, got, optionflags):
-        if six.PY2:
-            want = re.sub('zExceptions.Forbidden', 'Forbidden', want)
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        else:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
-            # translate doctest exceptions
-            for dotted in ('urllib.error.HTTPError', ):
-                if dotted in got:
-                    got = re.sub(
-                        dotted,
-                        dotted.rpartition('.')[-1],
-                        got,
-                    )
+        # translate doctest exceptions
+        # TODO: fix tests to check for full path
+        for dotted in ('urllib.error.HTTPError', ):
+            if dotted in got:
+                got = re.sub(
+                    dotted,
+                    dotted.rpartition('.')[-1],
+                    got,
+                )
 
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 

--- a/Products/CMFPlone/tests/test_mails.py
+++ b/Products/CMFPlone/tests/test_mails.py
@@ -10,7 +10,6 @@ from zope.component import getUtility
 
 import doctest
 import re
-import six
 import unittest
 
 
@@ -41,10 +40,7 @@ MOCK_MAILHOST_FUNCTIONAL_TESTING = FunctionalTesting(
 
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
-        if six.PY2:
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        else:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
+        want = re.sub("u'(.*?)'", "'\\1'", want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/Products/CMFPlone/tests/test_okay.py
+++ b/Products/CMFPlone/tests/test_okay.py
@@ -2,7 +2,6 @@
 from plone.testing.zope import Browser
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
 
-import six
 import unittest
 
 
@@ -29,10 +28,7 @@ class OkayTest(unittest.TestCase):
         for url in urls:
             browser.open(url)
             self.assertEqual(browser.contents, u'OK')
-            if six.PY2:
-                get_header = browser.headers.getheader
-            else:
-                get_header = browser.headers.get
+            get_header = browser.headers.get
             self.assertEqual(
                 get_header('Expires'), 'Sat, 1 Jan 2000 00:00:00 GMT')
             self.assertEqual(

--- a/Products/CMFPlone/tests/test_passwordreset.py
+++ b/Products/CMFPlone/tests/test_passwordreset.py
@@ -7,7 +7,6 @@ from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
 
 import doctest
 import re
-import six
 import unittest
 
 
@@ -19,10 +18,7 @@ OPTIONFLAGS = (
 
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
-        if six.PY2:
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        else:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
+        want = re.sub("u'(.*?)'", "'\\1'", want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/Products/CMFPlone/tests/test_patternsettings.py
+++ b/Products/CMFPlone/tests/test_patternsettings.py
@@ -9,7 +9,6 @@ from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
 from zope.component import getUtility
 
 import json
-import six
 import unittest
 
 
@@ -62,8 +61,8 @@ class TestPatternSettingsView(unittest.TestCase):
         result = settings()
         self.assertEqual(type(result), dict)
         for key, value in result.items():
-            self.assertTrue(isinstance(key, six.string_types))
-            self.assertTrue(isinstance(value, six.string_types))
+            self.assertTrue(isinstance(key, str))
+            self.assertTrue(isinstance(value, str))
 
     def testFolderUrls(self):
         settings = PatternsSettingsView(self.folder, self.layer['request'])

--- a/Products/CMFPlone/tests/test_safe_formatter.py
+++ b/Products/CMFPlone/tests/test_safe_formatter.py
@@ -7,8 +7,6 @@ from plone.app.testing import TEST_USER_NAME
 from Products.CMFPlone.tests.PloneTestCase import PloneTestCase
 from zExceptions import Unauthorized
 
-import six
-
 
 BAD_ATTR_STR = """
 <p tal:content="python:'class of {0} is {0.__class__}'.format(context)" />
@@ -107,7 +105,7 @@ class TestSafeFormatter(PloneTestCase):
 
     def test_cook_zope2_page_templates_good_unicode(self):
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
-        pt = ZopePageTemplate('mytemplate', six.text_type(GOOD_UNICODE))
+        pt = ZopePageTemplate('mytemplate', str(GOOD_UNICODE))
         hack_pt(pt)
         self.assertEqual(pt.pt_render().strip(), '<p>none</p>')
         hack_pt(pt, self.portal)
@@ -209,11 +207,7 @@ class TestSafeFormatter(PloneTestCase):
             "'access {0.foobar.Title}'.format(context)")
         hack_pt(pt, context=self.portal)
         login(self.portal, TEST_USER_NAME)
-        # We replace ATDocument with Document to make the tests pass
-        # with ATContentTypes and plone.app.contenttypes.
         method_name = 'DexterityContent.Title'
-        if six.PY2:
-            method_name = 'Document.Title'
         self.assertEqual(
             pt.pt_render(),
             u'<p>access <bound method %s of '
@@ -306,7 +300,7 @@ class TestFunctionalSafeFormatter(PloneTestCase):
         string_rule = ca[str]['format']
         self.assertTrue(isinstance(string_rule, types.FunctionType))
         # Take less steps for unicode.
-        unicode_rule = ca[six.text_type]['format']
+        unicode_rule = ca[str]['format']
         self.assertTrue(isinstance(unicode_rule, types.FunctionType))
         self.assertEqual(string_rule, unicode_rule)
 

--- a/Products/CMFPlone/tests/test_utils.py
+++ b/Products/CMFPlone/tests/test_utils.py
@@ -79,7 +79,7 @@ class DefaultUtilsTests(unittest.TestCase):
         PloneSite and SubSite implement ISite
         """
         from plone.app.content.browser.contents import get_top_site_from_url
-        from six.moves.urllib.parse import urlparse
+        from urllib.parse import urlparse
         from zope.component.interfaces import ISite
 
         class MockContext(object):

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -221,18 +221,6 @@ deprecated('getSiteEncoding',
             'currently. This method always returns "utf-8"'))
 
 
-# XXX portal_utf8 and utf8_portal probably can go away
-def portal_utf8(context, str_, errors='strict'):
-    # Test
-    warnings.warn("portal_utf8/utf8_portal are deprecated.")
-    str(str_, 'utf-8', errors)
-    return str
-
-
-# XXX this is the same method as above
-utf8_portal = portal_utf8
-
-
 def getEmptyTitle(context, translated=True):
     """Returns string to be used for objects with no title or id"""
     # The default is an extra fancy unicode elipsis

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -31,7 +31,7 @@ from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.CMFPlone.log import log
 from Products.CMFPlone.log import log_deprecated
 from Products.CMFPlone.log import log_exc
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from ZODB.POSException import ConflictError
 from zope import schema
 from zope.component import getMultiAdapter
@@ -50,7 +50,6 @@ import json
 import OFS
 import pkg_resources
 import re
-import six
 import sys
 import transaction
 import warnings
@@ -182,7 +181,7 @@ def isExpired(content):
         expiry = expiry()
 
     # Convert to DateTime if necessary, ExpirationDate may return 'None'
-    if expiry and expiry != 'None' and isinstance(expiry, six.string_types):
+    if expiry and expiry != 'None' and isinstance(expiry, str):
         expiry = DateTime(expiry)
 
     if isinstance(expiry, DateTime) and expiry.isPast():
@@ -223,26 +222,21 @@ deprecated('getSiteEncoding',
 
 
 # XXX portal_utf8 and utf8_portal probably can go away
-def portal_utf8(context, str, errors='strict'):
+def portal_utf8(context, str_, errors='strict'):
     # Test
-    six.text_type(str, 'utf-8', errors)
+    warnings.warn("portal_utf8/utf8_portal are deprecated.")
+    str(str_, 'utf-8', errors)
     return str
 
 
 # XXX this is the same method as above
-def utf8_portal(context, str, errors='strict'):
-    # Test
-    six.text_type(str, 'utf-8', errors)
-    return str
+utf8_portal = portal_utf8
 
 
 def getEmptyTitle(context, translated=True):
     """Returns string to be used for objects with no title or id"""
     # The default is an extra fancy unicode elipsis
-    if six.PY2:
-        empty = unicode('\x5b\xc2\xb7\xc2\xb7\xc2\xb7\x5d', 'utf-8')
-    else:
-        empty = b'\x5b\xc2\xb7\xc2\xb7\xc2\xb7\x5d'.decode('utf8')
+    empty = b'\x5b\xc2\xb7\xc2\xb7\xc2\xb7\x5d'.decode('utf8')
     if translated:
         if context is not None:
             if not IBrowserRequest.providedBy(context):
@@ -488,16 +482,6 @@ def safe_text(value, encoding='utf-8'):
         >>> print(safe_unicode(None))
         None
     """
-    if six.PY2:
-        if isinstance(value, unicode):
-            return value
-        elif isinstance(value, basestring):
-            try:
-                value = unicode(value, encoding)
-            except (UnicodeDecodeError):
-                value = value.decode('utf-8', 'replace')
-        return value
-
     if isinstance(value, str):
         return value
     elif isinstance(value, bytes):
@@ -514,7 +498,7 @@ safe_unicode = safe_text
 def safe_bytes(value, encoding='utf-8'):
     """Convert text to bytes of the specified encoding.
     """
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         value = value.encode(encoding)
     return value
 
@@ -525,9 +509,7 @@ safe_encode = safe_bytes
 def safe_nativestring(value, encoding='utf-8'):
     """Convert a value to str in py2 and to text in py3
     """
-    if six.PY2 and isinstance(value, six.text_type):
-        value = safe_bytes(value, encoding)
-    if not six.PY2 and isinstance(value, six.binary_type):
+    if isinstance(value, bytes):
         value = safe_text(value, encoding)
     return value
 
@@ -700,7 +682,7 @@ def validate_json(value):
         class JSONError(schema.ValidationError):
             __doc__ = _(u"Must be empty or a valid JSON-formatted "
                         u"configuration – ${message}.", mapping={
-                            'message': six.text_type(exc)})
+                            'message': str(exc)})
 
         raise JSONError(value)
 
@@ -821,11 +803,7 @@ def get_top_site_from_url(context, request):
         url_path = urlparse(context.absolute_url()).path.split('/')
         for idx in range(len(url_path)):
             _path = '/'.join(url_path[:idx + 1]) or '/'
-            site_path = request.physicalPathFromURL(_path)
-            if six.PY2:
-                site_path = safe_encode('/'.join(site_path)) or '/'
-            else:
-                site_path = '/'.join(site_path) or '/'
+            site_path = '/'.join(request.physicalPathFromURL(_path)) or '/'
             _site = context.restrictedTraverse(site_path)
             if ISite.providedBy(_site):
                 break
@@ -866,7 +844,7 @@ def human_readable_size(size):
     if not size:
         return '0 %s' % smaller
 
-    if isinstance(size, six.integer_types):
+    if isinstance(size, int):
         if size < SIZE_CONST[smaller]:
             return '1 %s' % smaller
         for c in SIZE_ORDER:

--- a/Products/CMFPlone/workflow.py
+++ b/Products/CMFPlone/workflow.py
@@ -5,8 +5,6 @@ from Acquisition import aq_base
 from Products.CMFCore.interfaces import IWorkflowTool
 from Products.CMFPlone.interfaces import IWorkflowChain
 
-import six
-
 
 @adapter(Interface, IWorkflowTool)
 @implementer(IWorkflowChain)
@@ -42,7 +40,7 @@ def ToolWorkflowChain(context, workflow_tool):
       ()
 
     """
-    if isinstance(context, six.string_types):
+    if isinstance(context, str):
         pt = context
     elif hasattr(aq_base(context), 'getPortalTypeName'):
         pt = context.getPortalTypeName()

--- a/news/3183.misc
+++ b/news/3183.misc
@@ -1,0 +1,2 @@
+Remove six at all places where used. [jensens]
+

--- a/news/3183.removal
+++ b/news/3183.removal
@@ -1,0 +1,3 @@
+
+Remove ``portal_utf8`` and it twin ``utf8_portal`` from ``utils`` and ``PloneTool`` since its never used nowhere. [jensens]
+

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ setup(
         'Products.TemporaryFolder',
         'pyScss',
         'setuptools>=36.2',
-        'six',
         'transaction',
         'z3c.autoinclude',
         'ZODB3',


### PR DESCRIPTION
No more six needed. 

Remove `portal_utf8` and its twin `utf8_portal`. Both are not used anywhere in whole `plone` and at 1 place by accident in `collective`.