### PR TITLE
Robot tests: Do not use jQuery.size() but use ``.length`` instead.

### DIFF
--- a/Products/CMFPlone/tests/robot/common.robot
+++ b/Products/CMFPlone/tests/robot/common.robot
@@ -61,7 +61,7 @@ there should be '${count}' livesearch results
     Wait until keyword succeeds  5s  1s  Xpath Should Match X Times  //div[@id = 'LSResult']/descendant::li  ${count}
 
 patterns are loaded
-    Wait For Condition  return window.jQuery('body.patterns-loaded').size() > 0
+    Wait For Condition  return !!document.querySelector('body.patterns-loaded')
 
 Refresh JS/CSS resources
     # Not needed anymore, and it is breaking the Plone Zope 4 tests.

--- a/Products/CMFPlone/tests/robot/keywords.robot
+++ b/Products/CMFPlone/tests/robot/keywords.robot
@@ -28,7 +28,7 @@ a folder '${title}'
   Create content  type=Folder  title=${title}
 
 patterns are loaded
-  Wait For Condition  return window.jQuery('body.patterns-loaded').size() > 0
+  Wait For Condition  return !!document.querySelector('body.patterns-loaded')
 
 a folder with a document '${title}'
   ${folder_uid}=  Create content  type=Folder  title=folder

--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -83,7 +83,7 @@ I have the title input field
     Element Should Be Visible  xpath=//fieldset[@id='fieldset-default']
 
 I can only see the default tab
-    Wait For Condition  return window.jQuery('.autotoc-nav .active:visible').size() > 0
+    Wait For Condition  return window.jQuery('.autotoc-nav .active:visible').length > 0
     Element Should Not Be Visible  xpath=//fieldset[@id='fieldset-settings']
     Element Should Not Be Visible  xpath=//fieldset[@id='fieldset-dates']
     Element Should Not Be Visible  xpath=//fieldset[@id='fieldset-categorization']

--- a/Products/CMFPlone/tests/robot/test_folder_contents.robot
+++ b/Products/CMFPlone/tests/robot/test_folder_contents.robot
@@ -129,4 +129,4 @@ Should be above
     Should be true  ${locator1-position} < ${locator2-position}
 
 folder contents pattern loaded
-    Wait For Condition  return window.jQuery('.pat-structure div.navbar').size() > 0
+    Wait For Condition  return !!document.querySelector('.pat-structure div.navbar')

--- a/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -283,7 +283,7 @@ I trigger the add a new user action
 
 a document '${title}' in the test folder
     Go to  ${PLONE_URL}/${TEST_FOLDER}/++add++Document
-    Wait For Condition  return window.jQuery('.autotoc-nav .active:visible').size() > 0
+    Wait For Condition  return window.jQuery('.autotoc-nav .active:visible').length > 0
     Execute Javascript  $('#form-widgets-IDublinCore-title').val('${title}'); return 0;
     Click Button  Save
 

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -231,7 +231,7 @@ the querystring pattern
     Execute Javascript  $(window).unbind('beforeunload')
 
 querystring pattern loaded
-    Wait For Condition  return window.jQuery('.querystring-criteria-remove').size() > 0
+    Wait For Condition  return !!document.querySelector('.querystring-criteria-remove')
 
 a bunch of folders
     #We create enough items to give meaningful test results

--- a/news/3195.bugfix
+++ b/news/3195.bugfix
@@ -1,0 +1,3 @@
+Robot tests: Do not use jQuery.size() but use ``.length`` instead.
+``.size()`` is deprecated since 1.8.
+[thet]


### PR DESCRIPTION
``.size()`` is deprecated since 1.8.


This PR targets the ``5.2.x`` branch.
The one for the ``master`` branch is at: https://github.com/plone/Products.CMFPlone/pull/3196