### PR TITLE
Removed dependency on ``Products.TemporaryFolder``.

### DIFF
--- a/news/2957.breaking
+++ b/news/2957.breaking
@@ -1,0 +1,5 @@
+Removed dependency on ``Products.TemporaryFolder``.
+Note: in your ``plone.recipe.zope2instance`` buildout part, you must set ``zodb-temporary-storage = off``,
+otherwise you get errors when starting Plone.
+See `issue 2957 <https://github.com/plone/Products.CMFPlone/issues/2957>`_.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ setup(
         'Products.Sessions',
         'Products.SiteErrorLog',
         'Products.statusmessages',
-        'Products.TemporaryFolder',
         'pyScss',
         'setuptools>=36.2',
         'transaction',


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/2957.

Note: in your `plone.recipe.zope2instance` buildout part, you must set `zodb-temporary-storage = off`,
otherwise you get errors when starting Plone.
We could make this the default in the recipe, but that can only be done in a branch for Plone 6.
It feels too early to make such a branch, as much can still be improved to the recipe on Plone 5.2, leading to double efforts.

Tested in https://github.com/plone/buildout.coredev/pull/697