### PR TITLE
Plone 6: Removed dependency on Products.Sessions.

### DIFF
--- a/news/2957.bugfix
+++ b/news/2957.bugfix
@@ -1,0 +1,4 @@
+Removed dependency on Products.Sessions.
+It is still pulled in by Products.PluggableAuthService though.
+See also `CMFPlacefulWorkflow issue 35 <https://github.com/plone/Products.CMFPlacefulWorkflow/issues/35>`_.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setup(
         'Products.PluggableAuthService',
         'Products.PluginRegistry',
         'Products.PortalTransforms',
-        'Products.Sessions',
         'Products.SiteErrorLog',
         'Products.statusmessages',
         'pyScss',


### PR DESCRIPTION
It is still pulled in by `Products.PluggableAuthService` though.
See also https://github.com/plone/Products.CMFPlacefulWorkflow/issues/35

Since it is still pulled in, this change should not matter. I will only run one Jenkins job, just for good measure.