### PR TITLE
Fix tests in combination with Products.PluggableAuthService 2.6.0. [5.2]

### DIFF
--- a/Products/CMFPlone/tests/testCookieAuth.py
+++ b/Products/CMFPlone/tests/testCookieAuth.py
@@ -32,7 +32,7 @@ class TestCookieAuth(unittest.TestCase):
         self.assertIn('200', self.browser.headers['status'])
         self.assertEqual(
             self.browser.url,
-            'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'  # noqa: E501
+            'http://nohost/plone/login?came_from=/plone/test-folder'  # noqa: E501
         )
 
     def testInsufficientPrivileges(self):
@@ -43,7 +43,7 @@ class TestCookieAuth(unittest.TestCase):
         self.assertIn('200', self.browser.headers['status'])
         self.assertEqual(
             self.browser.url,
-            'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'  # noqa: E501
+            'http://nohost/plone/login?came_from=/plone/test-folder'  # noqa: E501
         )
 
     def testSetSessionCookie(self):

--- a/news/3251.bugfix
+++ b/news/3251.bugfix
@@ -1,0 +1,2 @@
+Fixed tests in combination with Products.PluggableAuthService 2.6.0.
+[maurits]


### PR DESCRIPTION
Jenkins fails:

```
'http://nohost/plone/login?came_from=/plone/test-folder' != 'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'

  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Products.CMFPlone/Products/CMFPlone/tests/testCookieAuth.py", line 35, in testAutoLoginPage
    'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'  # noqa: E501
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
```

and

```
'http://nohost/plone/login?came_from=/plone/test-folder' != 'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'

  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Products.CMFPlone/Products/CMFPlone/tests/testCookieAuth.py", line 46, in testInsufficientPrivileges
    'http://nohost/plone/login?came_from=http%3A//nohost/plone/test-folder'  # noqa: E501
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
```
