### PR TITLE
Add test that there is no Uninstall button in a new site.

### DIFF
--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_installer.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_installer.py
@@ -71,6 +71,23 @@ class AddonsControlPanelFunctionalTest(unittest.TestCase):
             '%s/prefs_install_products_form' % self.portal_url)
         self.assertNotIn('Installed', self.browser.contents)
         self.assertNotIn('Uninstalled', self.browser.contents)
+
+        # In a fresh site there should be no uninstall buttons.
+        # If there is one, it is likely an upgrade profile that should be hidden.
+        # This could change: we might for example install a theme by default
+        # but make it uninstallable.  The logic in this test should be updated then.
+        try:
+            button = self.browser.getControl('Uninstall', index=0)
+        except LookupError:
+            # This is good.
+            pass
+        else:
+            # We cannot easily see what the Uninstall button is for.
+            # We have to get the form with a private attribute.
+            raise AssertionError(
+                f"Uninstall button found. Probably an upgrade profile needs to be hidden. {button._form.text}"
+            )
+
         # It is hard to determine which exact product will be installed
         # by clicking on a button, because they are all called 'Install'.
         # We install all available products.


### PR DESCRIPTION
I try to show for which package the Uninstall button is.
Currently you get this error because plone.app.contenttypes has an upgrade profile that is not hidden yet:

```
AssertionError: Uninstall button found. Probably an upgrade profile needs to be hidden. <form action="uninstall_products" class="float-end" method="post">
<input name="uninstall_product" type="hidden" value="plone.app.contenttypes"/>
<button class="btn btn-sm btn-danger" name="form.submitted" type="submit" value="Uninstall">Uninstall</button>
<input name="_authenticator" type="hidden" value="7783303fbea316a6b26de498519664ff59e3641e"/></form>
```

I fix that problem in https://github.com/plone/plone.app.contenttypes/pull/591
I will test the two PRs together for good measure.