### PR TITLE
Test fix: wait until the folder contents items are loaded.

### DIFF
--- a/Products/CMFPlone/tests/robot/test_folder_contents.robot
+++ b/Products/CMFPlone/tests/robot/test_folder_contents.robot
@@ -59,7 +59,8 @@ I click the '${link_name}' link
     Click Link  ${link_name}
 
 I select all the elements
-    Element should be visible  css=.pat-structure .select-all
+    Wait until page contains element  css=.pat-structure .select-all
+    Wait until page contains element  css=.itemRow
     Click Element  css=.pat-structure .select-all
 
 the four elements got selected

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -101,6 +101,8 @@ should show warning when deleting page
 should show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
   Wait until keyword succeeds  30  1  Page should contain element  css=tr[data-id="foo"] input
+  # Might still take a bit before it is clickable.
+  Sleep  1
   Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled
@@ -114,6 +116,8 @@ should show warning when deleting page from folder_contents
 should not show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
   Wait until page contains element  css=tr[data-id="foo"] input
+  # Might still take a bit before it is clickable.
+  Sleep  1
   Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled


### PR DESCRIPTION
With plone.app.content 4.0.0a3 this takes slightly longer because we call the safe html transform.
A few robot tests on Jenkins fail more often now, and I see this locally as well, although not on every run.