### PR TITLE
Fix TypeError when adding a portlet

### DIFF
--- a/Products/CMFPlone/browser/navigation.py
+++ b/Products/CMFPlone/browser/navigation.py
@@ -45,7 +45,7 @@ def get_view_url(context):
     item_url = get_url(context)
     name = get_id(context)
 
-    if getattr(context, 'portal_type', {}) in view_action_types:
+    if item_url and getattr(context, 'portal_type', {}) in view_action_types:
         item_url += '/view'
         name += '/view'
 

--- a/news/3303.bugfix
+++ b/news/3303.bugfix
@@ -1,0 +1,1 @@
+Fix TypeError when adding a portlet. [daggelpop]


### PR DESCRIPTION
This happens when trying to add a portlet to a File (in this case, a PDF).
`collective.documentviewer` is installed, so `plone.types_use_view_action_in_listings` has been set to `['File']`.
In that case, it's possible for `get_url(context)`  to return `None`, which generates a TypeError when trying to append `"/view"` to it.


```
2021-08-17 14:46:20,888 ERROR   [Zope.SiteErrorLog:251][waitress] 1629204380.890.105086271994 http://localhost:8080/Plone/sample.pdf/++contextportlets++plone.rightcolumn/+/plone.portlet.static.Static
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 155, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 337, in publish_module
  Module ZPublisher.WSGIPublisher, line 255, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 61, in call_object
  Module plone.app.portlets.browser.formhelper, line 61, in __call__
  Module z3c.form.form, line 239, in __call__
  Module z3c.form.form, line 281, in render
  Module z3c.form.form, line 163, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 88, in __call__
  Module z3c.pt.pagetemplate, line 173, in render
  Module chameleon.zpt.template, line 306, in render
  Module chameleon.template, line 209, in render
  Module chameleon.template, line 187, in render
  Module eb14e9df84488d38439ba5c51eba5854, line 242, in render
  Module 68ae6b70a8bfa67fd83815652e8c0cfc, line 1001, in render_master
  Module z3c.pt.expressions, line 70, in render_content_provider
  Module zope.viewlet.manager, line 155, in update
  Module zope.viewlet.manager, line 161, in _updateViewlets
  Module plone.app.layout.viewlets.common, line 650, in update
  Module Products.CMFPlone.browser.navigation, line 237, in breadcrumbs
  Module Products.CMFPlone.browser.navigation, line 228, in breadcrumbs
  Module Products.CMFPlone.browser.navigation, line 49, in get_view_url
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```