### PR TITLE
Add plone.app.caching to list of add-ons to upgrade

### DIFF
--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -88,6 +88,7 @@ class AddonList(list):
 ADDON_LIST = AddonList([
     Addon(profile_id='Products.CMFEditions:CMFEditions'),
     Addon(profile_id='Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'),
+    Addon(profile_id='plone.app.caching:default'),
     Addon(profile_id='plone.app.contenttypes:default'),
     Addon(profile_id='plone.app.dexterity:default'),
     Addon(profile_id='plone.app.discussion:default'),

--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -102,7 +102,7 @@ ADDON_LIST = AddonList([
     Addon(profile_id='plone.app.discussion:default'),
     Addon(profile_id='plone.app.event:default'),
     Addon(
-        profile_id='plone.app.iterate:plone.app.iterate',
+        profile_id='plone.app.iterate:default',
         check_module='plone.app.iterate'
     ),
     Addon(profile_id='plone.app.multilingual:default'),

--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -85,15 +85,26 @@ class AddonList(list):
 # List of upgradeable packages.  Obvious items to add here, are all
 # core packages that actually have upgrade steps.
 # Good start is portal_setup.listProfilesWithUpgrades()
+# Please use 'check_module' for packages that are not direct dependencies
+# of Products.CMFPlone, but of the Plone package.
 ADDON_LIST = AddonList([
     Addon(profile_id='Products.CMFEditions:CMFEditions'),
-    Addon(profile_id='Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow'),
-    Addon(profile_id='plone.app.caching:default'),
+    Addon(
+        profile_id='Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow',
+        check_module='Products.CMFPlacefulWorkflow'
+    ),
+    Addon(
+        profile_id='plone.app.caching:default',
+        check_module='plone.app.caching'
+    ),
     Addon(profile_id='plone.app.contenttypes:default'),
     Addon(profile_id='plone.app.dexterity:default'),
     Addon(profile_id='plone.app.discussion:default'),
     Addon(profile_id='plone.app.event:default'),
-    Addon(profile_id='plone.app.iterate:plone.app.iterate'),
+    Addon(
+        profile_id='plone.app.iterate:plone.app.iterate',
+        check_module='plone.app.iterate'
+    ),
     Addon(profile_id='plone.app.multilingual:default'),
     Addon(profile_id='plone.app.querystring:default'),
     Addon(profile_id='plone.app.theming:default'),

--- a/news/82.bugfix
+++ b/news/82.bugfix
@@ -1,0 +1,2 @@
+Add ``plone.app.caching`` to the list of add-ons that is upgraded when upgrading Plone.
+[maurits]


### PR DESCRIPTION
This list gets upgraded when calling `@@upgrade-plone`.
In PR https://github.com/plone/plone.app.caching/pull/83 I add the first upgrade step.
