### PR TITLE
Added a workaround that allows the catalog to be cleared and rebuilt

### DIFF
--- a/Products/CMFPlone/Portal.py
+++ b/Products/CMFPlone/Portal.py
@@ -235,6 +235,11 @@ class PloneSite(Container, SkinnableObjectManager, UniqueObject):
     def reindexObjectSecurity(self, skip_self=False):
         pass
 
+    def UID(self):
+        # XXX: workaround that allows the catalog to be cleared and rebuilt,
+        # see https://github.com/plone/Products.CMFPlone/issues/3312
+        return
+
 
 # Remove the IContentish interface so we don't listen to events that won't
 # apply to the site root, ie handleUidAnnotationEvent


### PR DESCRIPTION
Fixes #3312

I did not add a towncrier entry on purpose: I think this is already covered by the existing dx site root PLIP entry