### PR TITLE
PLIP 3339: Replace z3c.autoinclude with plone.autoinclude.

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -98,10 +98,10 @@
       trusted="y"
       />
 
-  <!-- include plone plugins with z3c.autoinclude -->
-  <includePlugins
+  <!-- include plone plugins with plone.autoinclude -->
+  <autoIncludePlugins
       zcml:condition="not-have disable-autoinclude"
-      package="plone"
+      target="plone"
       file="configure.zcml"
       />
 

--- a/Products/CMFPlone/meta.zcml
+++ b/Products/CMFPlone/meta.zcml
@@ -25,15 +25,14 @@
 
     <include package="plone.app.portlets" file="meta.zcml" />
 
-    <!-- z3c.autoinclude's `includePlugins` directive finds
+    <!-- plone.autoinclude's `autoIncludePlugins` directive finds
          and executes ZCML files from any installed packages
          that provide an entry point to declare themselves a
          plone plugin -->
-    <include package="z3c.autoinclude" file="meta.zcml" />
-
-    <includePlugins
+    <include package="plone.autoinclude" file="meta.zcml" />
+    <autoIncludePlugins
         zcml:condition="not-have disable-autoinclude"
-        package="plone"
+        target="plone"
         file="meta.zcml"
         />
 

--- a/Products/CMFPlone/overrides.zcml
+++ b/Products/CMFPlone/overrides.zcml
@@ -12,10 +12,10 @@
         component="Products.CMFPlone.unicodeconflictresolver.UTF8EncodingConflictResolver"
         />
 
-    <!-- include plone plugins with z3c.autoinclude -->
-    <includePluginsOverrides
+    <!-- include plone plugins with plone.autoinclude -->
+    <autoIncludePluginsOverrides
         zcml:condition="not-have disable-autoinclude"
-        package="plone"
+        target="plone"
         file="overrides.zcml"
         />
 

--- a/news/3339.breaking
+++ b/news/3339.breaking
@@ -1,0 +1,3 @@
+PLIP 3339: Replace ``z3c.autoinclude`` with ``plone.autoinclude``.
+Note: ``includeDependencies`` is no longer supported.
+[maurits, tschorr]

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'pyScss',
         'setuptools>=36.2',
         'transaction',
-        'z3c.autoinclude',
+        'plone.autoinclude',
         'ZODB3',
         'Zope[wsgi] >= 4.0',
         'zope.app.locales >= 3.6.0',


### PR DESCRIPTION
Note: `includeDependencies` is no longer supported.

Part of PLIP #3339.
Used by this [PLIP config](https://github.com/plone/buildout.coredev/blob/6.0/plips/plip-3339-plone-autoinclude.cfg).
