### PR TITLE
On Zope root, create Volto site by default.

### DIFF
--- a/Products/CMFPlone/browser/templates/plone-overview.pt
+++ b/Products/CMFPlone/browser/templates/plone-overview.pt
@@ -86,16 +86,25 @@
             </p>
             <form id="add-plone-site"
                     method="get"
-                    action="#"
-                    tal:define="site_number python: '' if not sites else len(sites) + 1"
-                    tal:attributes="action string:${context/absolute_url}/@@plone-addsite">
+                    tal:define="site_number python: '' if not sites else len(sites) + 1;
+                                action string:${context/absolute_url}/@@plone-addsite"
+                    action="${action}">
                 <input type="hidden" name="site_id" value="Plone${site_number}" />
                 <button type="submit"
                         class="btn btn-${python:'success' if sites else 'primary'}"
                         i18n:translate="">Create a new Plone site</button>
+                <tal:comment condition="nothing">
+                  When we have Volto, the button above will create a Volto site,
+                  and we need an extra button below to create a Classic Plone site.
+                </tal:comment>
                 <a class="btn btn-secondary"
                     i18n:translate=""
-                    tal:attributes="href string:${context/absolute_url}/@@plone-addsite?site_id=Plone${site_number}&amp;advanced=1"
+                    tal:condition="view/has_volto"
+                    href="${action}?site_id=Plone${site_number}&amp;classic=1"
+                    >Create Classic Plone site</a>
+                <a class="btn btn-secondary"
+                    i18n:translate=""
+                    href="${action}?site_id=Plone${site_number}&amp;advanced=1"
                     >Advanced</a>
             </form>
         </div>

--- a/news/3344.feature
+++ b/news/3344.feature
@@ -1,0 +1,2 @@
+On Zope root, create Volto site by default.
+[maurits]


### PR DESCRIPTION
When the `plone.volto` package is not available, the buttons are the same as before,
and will create a Classic Plone site.

When `plone.volto` is there, you get an extra button for Classic:

<img width="522" alt="Screenshot 2021-10-27 at 10 12 57" src="https://user-images.githubusercontent.com/210587/139029106-0a8289fb-3caa-44d9-82f7-cc5349b8af9d.png">

- 'Create a new Plone site' will create a Volto site.
- 'Create Classic Plone site' will create a Classic site.
- Advanced still gives you all options. The extra Volto profiles are selected when available.

We could pick different colors.

When installing Volto, we install the caching and Barcelonata profiles just like a Classic site,
although we could choose to not install Barceloneta.
As extra, we install `plone.volto:default` and `plone.volto:default-homepage`.
(Technically, `default-homepage` would already pull in `default`, but let's do this explicitly.)
