### PR TITLE
Load adapter for index location, only if Archetypes is installed

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -276,9 +276,14 @@ def mime_type(obj):
     return aq_base(obj).getPrimaryField().getContentType(obj)
 
 
-@indexer(Interface)
-def location(obj):
-    return obj.getField('location').get(obj)
+# BBB: This adapter is for compatibility and should be removed in Plone 6.
+try:
+    from Products.Archetypes.interfaces import IBaseObject
+    @indexer(IBaseObject)
+    def location(obj):
+        return obj.getField('location').get(obj)
+except ImportError:
+    pass
 
 
 @implementer(IPloneCatalogTool)

--- a/Products/CMFPlone/catalog.zcml
+++ b/Products/CMFPlone/catalog.zcml
@@ -1,4 +1,7 @@
-<configure xmlns="http://namespaces.zope.org/zope" i18n_domain="plone">
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="plone">
 
     <!-- Register the default indexable object wrapper -->
     <adapter
@@ -17,7 +20,8 @@
     <adapter factory=".CatalogTool.is_folderish"           name="is_folderish" />
     <adapter factory=".CatalogTool.is_default_page"        name="is_default_page" />
     <adapter factory=".CatalogTool.getIcon"                name="getIcon" />
-    <adapter factory=".CatalogTool.location"               name="location" />
+    <!-- BBB: This adapter is for compatibility and should be removed in Plone 6. -->
+    <adapter factory=".CatalogTool.location"               name="location" zcml:condition="installed Products.Archetypes"/>
     <adapter factory=".CatalogTool.mime_type"              name="mime_type" />
 
 </configure>

--- a/Products/CMFPlone/tests/testCatalogTool.py
+++ b/Products/CMFPlone/tests/testCatalogTool.py
@@ -359,6 +359,22 @@ class TestCatalogIndexing(PloneTestCase):
         brains = self.catalog(foo='FOO')
         self.assertEqual(len(brains), 1)
 
+    def test_indexing_location_to_dexterity(self):
+        # BBB: 'Products.CMFPlone.CatalogTool.location' only works for Archetypes.
+        # It should be removed in Plone 6. When it is removed, this test can be removed
+        # as well.
+        doc = self.folder.doc
+        from plone.dexterity.interfaces import IDexterityContent
+        if not IDexterityContent.providedBy(doc):
+            return
+        self.catalog.addIndex("location", "FieldIndex")
+        doc.location = "home"
+        doc.reindexObject()
+        results = self.catalog(location="home")
+        self.assertTrue(results)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, doc.id)
+
 
 class TestCatalogSearching(PloneTestCase):
 

--- a/news/3347.bugfix
+++ b/news/3347.bugfix
@@ -1,0 +1,1 @@
+Load adapter for index location, only if Archetypes is installed. [wesleybl]


### PR DESCRIPTION
Adapter for index `location` only works on Archetypes content, as it uses the `getField` method. This caused that, when an `location` index  was created in the catalog, the indexing would not work for Dexterity contents, since the adapter trie to use the `getField` method on a Dexterity content.

Fix #3347 