### PR TITLE
Remove adapter for index location

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -255,11 +255,6 @@ def mime_type(obj):
     return aq_base(obj).getPrimaryField().getContentType(obj)
 
 
-@indexer(Interface)
-def location(obj):
-    return obj.getField('location').get(obj)
-
-
 @implementer(IPloneCatalogTool)
 class CatalogTool(PloneBaseTool, BaseTool):
     """Plone's catalog tool"""

--- a/Products/CMFPlone/catalog.zcml
+++ b/Products/CMFPlone/catalog.zcml
@@ -17,7 +17,6 @@
     <adapter factory=".CatalogTool.is_folderish"           name="is_folderish" />
     <adapter factory=".CatalogTool.is_default_page"        name="is_default_page" />
     <adapter factory=".CatalogTool.getIcon"                name="getIcon" />
-    <adapter factory=".CatalogTool.location"               name="location" />
     <adapter factory=".CatalogTool.mime_type"              name="mime_type" />
 
 </configure>

--- a/news/3347.bugfix
+++ b/news/3347.bugfix
@@ -1,0 +1,1 @@
+Remove adapter for index location. [wesleybl]


### PR DESCRIPTION
Adapter for index `location` only worked with Archetypes content, as it used `getField` method. This caused that, when an `location` index  was created in the catalog, the indexing would not work for Dexterity contents, since the adapter trie to use the `getField` method on a Dexterity content.

Fixes #3347 in Plone 6