### PR TITLE
Fix random failure in test_querystring.robot

### DIFF
--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -321,7 +321,9 @@ open the select box titled ${NAME}
     Click Element  css=.querystring-criteria-${NAME} .select2-container a
 
 select index type ${INDEX}
-    Input Text  jquery=.select2-drop-active[style*="display: block;"] input   text=${INDEX}
+    ${input_selector}  Set Variable  .select2-drop-active[style*="display: block;"] input
+    Wait Until Element Is Visible  jquery=${input_selector}
+    Input Text  jquery=${input_selector}   text=${INDEX}
     Press Key  jquery=:focus  \\13
 
 we expect ${NUM} hits


### PR DESCRIPTION
Wait for the input to be visible, before trying to put a value on it.

This fixes the error:

```
Element with locator 'jquery=.select2-drop-active[style*="display: block;"] input' not found.
```

See: https://jenkins.plone.org/job/pull-request-6.0-3.9/555