### PR TITLE
Fix random fails in test_querystring.robot

### DIFF
--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -317,9 +317,9 @@ I expect to be in Simple mode
     Wait Until Element Is Not Visible  css=div#select2-drop-mask
 
 open the select box titled ${NAME}
+    Click Element  css=body
     ${select_criteria_selector}  Set Variable  .querystring-criteria-${NAME} .select2-container a
     Wait Until Element Is Visible  css=${select_criteria_selector}
-    Click Element  css=body
     Click Element  css=${select_criteria_selector}
 
 select index type ${INDEX}


### PR DESCRIPTION
Check if select criteria is visible after clicking in body.

See: https://jenkins.plone.org/job/plone-6.0-python-3.7-robot-chrome/689