### PR TITLE
Add plone.synchronize as dependency on 5.2.

### DIFF
--- a/news/157.bugfix
+++ b/news/157.bugfix
@@ -1,0 +1,3 @@
+Add plone.synchronize as dependency, because plone.dexterity 2.10.5 has removed this dependency.
+Core Plone does not need the package anymore, but in case someone uses it, it is not nice to lose it in a bugfix release of Plone.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         'plone.session',
         'plone.staticresources',
         'plone.subrequest',
+        'plone.synchronize',
         'plone.theme',
         'plonetheme.barceloneta',
         'Products.CMFCore',


### PR DESCRIPTION
plone.dexterity 2.10.5 has removed this dependency, by taking over the single function it contains.
See https://github.com/plone/plone.dexterity/pull/157
Core Plone does not need the package anymore, but in case someone uses it, it is not nice to lose it in a bugfix release of Plone.
I could have made a branch of plone.dexterity for Plone 5.2, but that is a hassle.
Adding the dependency in CMFPlone 5.2 is easier.
For clarity: we won't add this in CMFPlone 6.0.