### PR TITLE
Enable warnings TTW (like a DeprecationWarning)

### DIFF
--- a/Products/CMFPlone/__init__.py
+++ b/Products/CMFPlone/__init__.py
@@ -112,6 +112,9 @@ def initialize(context):
     # Make cgi.escape available TTW
     ModuleSecurityInfo('cgi').declarePublic('escape')
 
+    # Make warnings available TTW
+    ModuleSecurityInfo('warnings').declarePublic('warn')
+
     # Apply monkey patches
     from Products.CMFPlone import patches  # noqa
 

--- a/news/3376.feature
+++ b/news/3376.feature
@@ -1,0 +1,2 @@
+Allow ``from warnings import warn`` and ``warn("message", DeprecationWarning)`` TTW, like in Python Scripts.
+[jensens]


### PR DESCRIPTION
This allows deprecacting Python Scripts. 