### PR TITLE
Test-only fix: in test_controlpanel_relations flush the index queue.

### DIFF
--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_relations.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_relations.py
@@ -82,6 +82,9 @@ class TestRelationsControlpanel(unittest.TestCase):
         # api.relation.create(doc1, doc2, 'relatedItems')
         # api.relation.create(doc1, doc3, 'relatedItems')
 
+        # Make sure the catalog index queue is flushed.
+        self.portal.portal_catalog.searchResults({})
+
         stats, broken = get_relations_stats()
         self.assertEqual(dict(stats), {'relatedItems': 2})
         self.assertEqual(dict(broken), {})
@@ -133,6 +136,9 @@ class TestRelationsControlpanel(unittest.TestCase):
         modified(doc1)
         # api.relation.create(doc1, doc2, 'relatedItems')
         # api.relation.create(doc1, doc3, 'relatedItems')
+
+        # Make sure the catalog index queue is flushed.
+        self.portal.portal_catalog.searchResults({})
 
         stats, broken = get_relations_stats()
         self.assertEqual(dict(stats), {'relatedItems': 2})


### PR DESCRIPTION
Needed for https://github.com/plone/plone.app.uuid/pull/11
This uuid PR changes code to not do a full catalog query, but it uses some catalog index internals.
Result for two tests in CMFPlone is that the index queue is not flushed, which leads to inconsistent results.
This fixes it.

Internal testing detail only, so I did not add a news snippet.