### PR TITLE
Fix info message (char left over) in quickinstaller template

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -188,7 +188,7 @@
               </div>
               <div class="alert alert-info mt-2 mb-0"
                   role="status"
-                  tal:condition="not:product/uninstall_profile">                  >
+                  tal:condition="not:product/uninstall_profile">
                 <strong i18n:translate="">Info</strong>
                 <span i18n:translate="">This product cannot be uninstalled!</span>
             </div>

--- a/news/3430.bugfix
+++ b/news/3430.bugfix
@@ -1,0 +1,2 @@
+Fix info message (char left over) in quickinstaller template
+[laulaz]


### PR DESCRIPTION
This fixes #3430