### PR TITLE
1letter/issue#3031

### DIFF
--- a/Products/CMFPlone/profiles/default/controlpanel.xml
+++ b/Products/CMFPlone/profiles/default/controlpanel.xml
@@ -57,13 +57,6 @@
     i18n:attributes="title">
   <permission>Set own properties</permission>
  </configlet>
- <configlet title="Change Password" action_id="MemberPassword" appId="Plone"
-    category="Member" condition_expr="python:member.canPasswordSet()"
-    icon_expr="string:lock"
-    url_expr="string:${portal_url}/password_form" visible="True"
-    i18n:attributes="title">
-  <permission>Set own password</permission>
- </configlet>
  <configlet title="Mail" action_id="MailHost" appId="MailHost"
     category="plone-general" condition_expr=""
     icon_expr="string:envelope-open"

--- a/Products/CMFPlone/profiles/default/controlpanel.xml
+++ b/Products/CMFPlone/profiles/default/controlpanel.xml
@@ -50,13 +50,6 @@
     i18n:attributes="title">
   <permission>Plone Site Setup: Users and Groups</permission>
  </configlet>
- <configlet title="Personal Preferences" action_id="MemberPrefs" appId="Plone"
-    category="Member" condition_expr=""
-    icon_expr="string:person"
-    url_expr="string:${portal_url}/@@personal-preferences" visible="True"
-    i18n:attributes="title">
-  <permission>Set own properties</permission>
- </configlet>
  <configlet title="Mail" action_id="MailHost" appId="MailHost"
     category="plone-general" condition_expr=""
     icon_expr="string:envelope-open"

--- a/Products/CMFPlone/tests/testControlPanel.py
+++ b/Products/CMFPlone/tests/testControlPanel.py
@@ -13,8 +13,8 @@ class TestControlPanel(unittest.TestCase):
         # get the expected default groups and configlets
         self.groups = ['Plone', 'Products']
         self.configlets = ['QuickInstaller', 'MailHost',
-                           'UsersGroups', 'MemberPrefs', 'PortalSkin',
-                           'MemberPassword', 'ZMI', 'SecuritySettings',
+                           'UsersGroups', 'PortalSkin',
+                           'ZMI', 'SecuritySettings',
                            'NavigationSettings', 'SearchSettings',
                            'errorLog', 'PloneReconfig', 'TypesSettings',
                            'FilterSettings',

--- a/news/3031.bugfix
+++ b/news/3031.bugfix
@@ -1,0 +1,5 @@
+Remove Configlets, Change Member Password and Member Prefs not needed in Overview Controlpanel
+both Views available via User Control Panel
+
+the deleton of "Change Member Password" Configlet remove also the issue #3031
+[1letter]


### PR DESCRIPTION
This PR remove two Configlets:

- the "Change Password" Configlet 
- the "Member Prefs" Configlet

Both are not really needed in the Controlpanel Overview. The Views behind the Configlets are available via Usercontrolpanel. That make more sense.
The Condition of "Change Password" Configlet had a Bug an throw an Error, another reason to remove the Panel.
