### PR TITLE
Fix detection of initial login time

### DIFF
--- a/Products/CMFPlone/browser/login/password_reset.py
+++ b/Products/CMFPlone/browser/login/password_reset.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityManagement import getSecurityManager
+from DateTime import DateTime
 from email.header import Header
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.memoize import view
@@ -108,8 +109,9 @@ class PasswordResetView(BrowserView):
             # with the given userid
             user = getSecurityManager().getUser()
 
-        login_time = user.getProperty('login_time', None)
-        if login_time is None:
+        default = DateTime('2000/01/01')
+        login_time = user.getProperty('login_time', default)
+        if login_time == default:
             notify(UserInitialLoginInEvent(user))
         else:
             notify(UserLoggedInEvent(user))

--- a/news/3447.bugfix
+++ b/news/3447.bugfix
@@ -1,0 +1,1 @@
+Fix detection of initial login time [MrTango]


### PR DESCRIPTION
If one has set login_time member properties via generic setup, this is usually set to 2000-01-01 and this value is used to detect initial login in PlonePAS.tool.memberhship.MembershipTool.loginUser() but in CMFPlone the detection compares to None which is tru is a new Plone side but if one ever has set properties via generic setup, this is never None for new users.