### PR TITLE
Update list of upgraded core profiles

### DIFF
--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -93,6 +93,7 @@ ADDON_LIST = AddonList([
         profile_id='Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow',
         check_module='Products.CMFPlacefulWorkflow'
     ),
+    Addon(profile_id='Products.PlonePAS:PlonePAS'),
     Addon(
         profile_id='plone.app.caching:default',
         check_module='plone.app.caching'
@@ -109,7 +110,16 @@ ADDON_LIST = AddonList([
     Addon(profile_id='plone.app.querystring:default'),
     Addon(profile_id='plone.app.theming:default'),
     Addon(profile_id='plone.app.users:default'),
+    Addon(
+        profile_id='plone.restapi:default',
+        check_module='plone.restapi'
+    ),
+    Addon(profile_id='plone.session:default'),
     Addon(profile_id='plone.staticresources:default'),
+    Addon(
+        profile_id='plone.volto:default',
+        check_module='plone.volto'
+    ),
 ])
 
 

--- a/Products/CMFPlone/tests/robot/robodoc/README.rst
+++ b/Products/CMFPlone/tests/robot/robodoc/README.rst
@@ -62,7 +62,7 @@ or
 
 .. code:: bash
 
-   $ CONFIGURE_PACKAGES=plone.app.iterate APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.app.iterate:plone.app.iterate bin/robot-server plone.app.robotframework.PLONE_ROBOT_TESTING
+   $ CONFIGURE_PACKAGES=plone.app.iterate APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.app.iterate:default bin/robot-server plone.app.robotframework.PLONE_ROBOT_TESTING
 
 and
 

--- a/Products/CMFPlone/tests/robot/robodoc/managing-working_copy.robot
+++ b/Products/CMFPlone/tests/robot/robodoc/managing-working_copy.robot
@@ -8,7 +8,7 @@ Suite Teardown  Common Suite Teardown
 *** Variables ***
 
 @{CONFIGURE_PACKAGES}  plone.app.iterate
-@{APPLY_PROFILES}  plone.app.contenttypes:plone-content  plone.app.iterate:plone.app.iterate
+@{APPLY_PROFILES}  plone.app.contenttypes:plone-content  plone.app.iterate:default
 # ${REGISTER_TRANSLATIONS}  ${CURDIR}/../../_locales
 
 *** Test Cases ***

--- a/news/3453.bugfix
+++ b/news/3453.bugfix
@@ -1,0 +1,3 @@
+Updated the list of core profiles that are upgraded during a Plone upgrade.
+Added ``Products.PlonePAS`` and ``plone.session``, and the optional ``plone.restapi`` and ``plone.volto``.
+[maurits]


### PR DESCRIPTION
These are upgraded at the end of `@@plone-upgrade`.  The list got outdated: added `Products.PlonePAS` and `plone.session`, and the optional `plone.restapi` and `plone.volto`.
See issue #3453, which has more far fetching ideas. This PR is just the low hanging, non-controversial fruit. 

Plus minor fix in two robot tests that still applied outdated profile `plone.app.iterate:plone.app.iterate`.I noticed it because the profile list has the "new" name `plone.app.iterate:default` instead. See also https://github.com/plone/plone.app.iterate/issues/99