### PR TITLE
Compatibility with latest z3c.form

### DIFF
--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -90,22 +90,22 @@ class LoginForm(form.EditForm):
                 pass
 
     def updateWidgets(self):
+        super().updateWidgets(prefix='')
+
         auth = self._get_auth()
 
         if auth:
-            fieldname_name = auth.get('name_cookie', '__ac_name')
-            fieldname_password = auth.get('pw_cookie', '__ac_password')
+            widgetname_login = auth.get('name_cookie', '__ac_name')
+            widgetname_password = auth.get('pw_cookie', '__ac_password')
         else:
-            fieldname_name = '__ac_name'
-            fieldname_password = '__ac_password'
+            widgetname_login = '__ac_name'
+            widgetname_password = '__ac_password'
 
-        self.fields['ac_name'].__name__ = fieldname_name
-        self.fields['ac_password'].__name__ = fieldname_password
-
-        super().updateWidgets(prefix='')
+        self.widgets['ac_name'].name = widgetname_login
+        self.widgets['ac_password'].name = widgetname_password
 
         if self.use_email_as_login():
-            self.widgets[fieldname_name].label = _('label_email',
+            self.widgets['ac_name'].label = _('label_email',
                                                    default='Email')
         self.widgets['came_from'].mode = HIDDEN_MODE
         self.widgets['came_from'].value = self.get_came_from()

--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -102,7 +102,9 @@ class LoginForm(form.EditForm):
             widgetname_password = '__ac_password'
 
         self.widgets['ac_name'].name = widgetname_login
+        self.widgets['ac_name'].id = widgetname_login
         self.widgets['ac_password'].name = widgetname_password
+        self.widgets['ac_password'].id = widgetname_password
 
         if self.use_email_as_login():
             self.widgets['ac_name'].label = _('label_email',

--- a/news/3459.feature
+++ b/news/3459.feature
@@ -1,0 +1,2 @@
+Compatibility with z3c.form >= 4
+[petschki]


### PR DESCRIPTION
due to the `create_according_to_list` util here https://github.com/zopefoundation/z3c.form/blob/master/src/z3c/form/util.py#L226 the shortName of the widgets has to be in the list of fields.keys() (https://github.com/zopefoundation/z3c.form/blob/master/src/z3c/form/field.py#L282) ... changing the `field.__name__` before updateWidgets results in skipping those widgets -> login_form is empty.