### PR TITLE
Fixed plone.session resource, and evaluating expressions on resources

### DIFF
--- a/Products/CMFPlone/resources/utils.py
+++ b/Products/CMFPlone/resources/utils.py
@@ -1,6 +1,10 @@
 from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from plone.resource.file import FilesystemFile
 from plone.resource.interfaces import IResourceDirectory
+from Products.CMFCore.Expression import createExprContext
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.resources import OVERRIDE_RESOURCE_DIRECTORY_NAME
 from zExceptions import NotFound
 from zope.component import queryUtility
@@ -38,6 +42,14 @@ def get_resource(context, path):
         if overrides.isFile(filepath):
             return overrides.readFile(filepath)
 
+    if "?" in path:
+        # Example from plone.session:
+        # "acl_users/session/refresh?session_refresh=true&type=css&minutes=5"
+        # Traversing will not work then.  In this example we could split on "?"
+        # and traverse to the first part, acl_users/session/refresh, but this
+        # gives a function, and this fails when we call it below, missing a
+        # REQUEST argument
+        return
     try:
         resource = context.unrestrictedTraverse(path)
     except (NotFound, AttributeError):
@@ -71,3 +83,34 @@ def get_override_directory(context):
     if OVERRIDE_RESOURCE_DIRECTORY_NAME not in persistent_directory:
         persistent_directory.makeDirectory(OVERRIDE_RESOURCE_DIRECTORY_NAME)
     return persistent_directory[OVERRIDE_RESOURCE_DIRECTORY_NAME]
+
+
+def evaluateExpression(expression, context):
+    """Evaluate an object's TALES condition to see if it should be
+    displayed."""
+    try:
+        if expression.text and context is not None:
+            portal = getToolByName(context, "portal_url").getPortalObject()
+
+            # Find folder (code courtesy of CMFCore.ActionsTool)
+            if context is None or not hasattr(context, "aq_base"):
+                folder = portal
+            else:
+                folder = context
+                # Search up the containment hierarchy until we find an
+                # object that claims it's PrincipiaFolderish.
+                while folder is not None:
+                    if getattr(aq_base(folder), "isPrincipiaFolderish", 0):
+                        # found it.
+                        break
+                    else:
+                        folder = aq_parent(aq_inner(folder))
+
+            __traceback_info__ = (folder, portal, context, expression)
+            ec = createExprContext(folder, portal, context)
+            # add 'context' as an alias for 'object'
+            ec.setGlobal("context", context)
+            return expression(ec)
+        return True
+    except AttributeError:
+        return True

--- a/Products/CMFPlone/resources/webresource.py
+++ b/Products/CMFPlone/resources/webresource.py
@@ -1,6 +1,10 @@
+from .utils import evaluateExpression
 from .utils import get_resource
+from Products.CMFCore.Expression import Expression
 from webresource import ScriptResource
 from webresource import StyleResource
+from zope.component import queryUtility
+from zope.ramcache.interfaces import ram
 
 
 class PloneBaseResource:
@@ -9,15 +13,58 @@ class PloneBaseResource:
     def __init__(self, context, **kw):
         """Initialize with Plone context"""
         self.context = context
+        self.expression = kw.pop("expression", "")
         super().__init__(**kw)
 
     @property
     def file_data(self):
         """Fetch data from using a resource via traversal"""
         data = get_resource(self.context, self.resource)
+        if data is None:
+            # This happens with plone.session when trying to get a resource
+            # with this path:
+            # "acl_users/session/refresh?session_refresh=true&type=css&minutes=5"
+            # We could 'return b""', but let's take the resource path instead.
+            data = self.resource
         if isinstance(data, str):
             data = data.encode("utf8")
         return data
+
+    @property
+    def include(self):
+        if callable(self._include):
+            # Note: at time of writing, this is not used in core Plone.
+            # But upstream webresource has it, so let's keep it.
+            return self._include()
+        if not self._include:
+            return False
+        # We want to include the resource, but must evaluate the expression first.
+        return self.eval_expression()
+
+    @include.setter
+    def include(self, include):
+        self._include = include
+
+    def eval_expression(self):
+        if not self.expression:
+            return True
+        cache = queryUtility(ram.IRAMCache)
+        cooked_expression = None
+        if cache is not None:
+            cooked_expression = cache.query(
+                "plone.bundles.cooked_expressions",
+                key=dict(prefix=self.name),
+                default=None,
+            )
+        if cooked_expression is None or cooked_expression.text != self.expression:
+            cooked_expression = Expression(self.expression)
+            if cache is not None:
+                cache.set(
+                    cooked_expression,
+                    "plone.bundles.cooked_expressions",
+                    key=dict(prefix=self.name),
+                )
+        return evaluateExpression(cooked_expression, self.context)
 
 
 class PloneScriptResource(PloneBaseResource, ScriptResource):

--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,3 @@
+Fixed evaluating expressions on resources, and especially loading ``plone.session`` resources.
+Fixes `plone.session` issue 23 <https://github.com/plone/plone.session/issues/23>_.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/plone.session/issues/23.
Main problem there was that the code could not traverse to the plone.session css resource, resulting in a resource None, which caused a traceback, resulting in an unstyled site.

After fixing this part, I found another problem:
the `plone.session` css resource had an expression `python: member is not None`, but was still loaded for anonymous users as well.
It turned out that the expression was never checked. More correctly said: it looks like the expression of the last resource was used for all resources, even when this expression was empty.
To fix this, I had to pass the expression to the webresource, and move some code from `browser/resource.py` to `webresource.py`.

(I should probably say "bundle" wherever I say "resource", but you get the idea.)

I added tests with a couple of resource bundles with different expressions.