### PR TITLE
Remove date range search fix, which was done in Products.ZCatalog

### DIFF
--- a/Products/CMFPlone/browser/search.py
+++ b/Products/CMFPlone/browser/search.py
@@ -13,7 +13,6 @@ from zope.component import getUtility
 from zope.component import queryUtility
 from zope.i18nmessageid import MessageFactory
 from zope.publisher.browser import BrowserView
-from ZPublisher.HTTPRequest import record
 from ZTUtils import make_query
 
 import json
@@ -118,11 +117,6 @@ class Search(BrowserView):
             except AttributeError:
                 # created not a mapping
                 del query['created']
-
-        # https://github.com/plone/Products.CMFPlone/issues/3007
-        # If 'created' exists and is of type 'record', then cast it as dict
-        if 'created' in query and isinstance(query['created'], record):
-            query['created'] = dict(query['created'])
 
         # respect `types_not_searched` setting
         types = query.get('portal_type', [])

--- a/news/3432.bugfix
+++ b/news/3432.bugfix
@@ -1,0 +1,2 @@
+Remove date range search fix, which was done in Products.ZCatalog.
+[wesleybl]


### PR DESCRIPTION
`Products.ZCatalog` 6.2 fix #3007 in a more comprehensive way. So the correction made in `Products.CMFPlone` can be removed.