### PR TITLE
Moved recently_modified/published skin templates to browser views

### DIFF
--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -293,4 +293,18 @@
       permission="zope.Public"
       />
 
+  <browser:page
+      for="*"
+      name="recently_modified"
+      template="templates/recently_modified.pt"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="*"
+      name="recently_published"
+      template="templates/recently_published.pt"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/Products/CMFPlone/browser/templates/recently_modified.pt
+++ b/Products/CMFPlone/browser/templates/recently_modified.pt
@@ -12,45 +12,43 @@
 <body>
 
 <metal:main fill-slot="main"
-     tal:define="results python:container.portal_catalog(sort_on='modified',sort_order='reverse',review_state='published');
+     tal:define="path context/@@plone_portal_state/navigation_root_path;
+                 results python:container.portal_catalog(sort_on='modified',sort_order='reverse',path=path);
                  Batch python:modules['Products.CMFPlone'].Batch;
-                 DateTime python:modules['DateTime'].DateTime;
                  b_start python:request.get('b_start',0);
-                 toLocalizedTime nocall:context/@@plone/toLocalizedTime;
-                 normalize nocall:context/@@plone/normalizeString;">
+                 normalizeString nocall:context/@@plone/normalizeString;
+                 toLocalizedTime nocall:context/@@plone/toLocalizedTime;">
 
     <h1 class="documentFirstHeading"
-        i18n:translate="heading_recently_published">
-        Published items
+        i18n:translate="heading_recently_modified">
+        Modified items
     </h1>
 
-    <div i18n:translate="description_recently_published" class="documentDescription">
-        All published items, latest first.
+    <div i18n:translate="description_recently_modified" class="documentDescription">
+        All recently modified items, latest first.
     </div>
 
     <div id="content-core"
-         tal:define="site_properties context/portal_properties/site_properties;
-                     isAnon context/@@plone_portal_state/anonymous;
+         tal:define="isAnon context/@@plone_portal_state/anonymous;
                      portal context/@@plone_portal_state/portal;
-                     show_about python:not isAnon or context.portal_registry['plone.allow_anon_views_about'];
-                     image_scale portal/@@image_scale">
+                     show_about python:not isAnon or context.portal_registry['plone.allow_anon_views_about'];">
         <form name="searchresults" action="" method="post" tal:condition="results"
-                          tal:define="batch python:Batch(results, 20, int(b_start), orphan=1)">
-
+                          tal:define="batch python:Batch(results, 20, int(b_start), orphan=1);
+                                      image_scale portal/@@image_scale">
+            <ul>
             <tal:results tal:repeat="result batch">
 
-                <article>
-                    <header
-                       tal:define="item_class python:'contenttype-' + normalize(result.portal_type);
-                                   item_wf_state result/review_state;
-                                   item_wf_state_class python:'state-' + normalize(item_wf_state);">
-                        <a tal:attributes="href result/getURL">
+                <li tal:define="description result/Description">
+                    <header tal:define="item_wf_state result/review_state;
+                                        item_wf_state_class python:'state-' + normalizeString(item_wf_state);
+                                        item_type_class python:'contenttype-' + normalizeString(result.portal_type)">
+                          <a tal:attributes="href result/getURL">
                             <img tal:condition="python:result.getIcon"
                                  tal:replace="structure python: image_scale.tag(result, 'image', scale='tile', css_class='thumb-tile')">
-                            <span tal:content="result/pretty_title_or_id"
-                                  tal:attributes="class string:$item_class $item_wf_state_class">
+                        	<span tal:content="result/pretty_title_or_id"
+                                  tal:attributes="class string:$item_type_class $item_wf_state_class"  >
                                   Title</span>
-                        </a>
+                          </a>
 
                         <span class="discreet" i18n:translate="text_creator_date" tal:condition="show_about">
                             by
@@ -66,27 +64,21 @@
                         </span>
                     </header>
 
-                    <p class="discreet">
-                        <a href="/view"
-                           tal:content="result/Description"
-                           tal:attributes="href result/getURL">
+                    <p tal:condition="description"
+                        tal:content="description">
                         Description
-                        </a>
                     </p>
-                </article>
+
+                </li>
 
             </tal:results>
-
-            <div class="spacer">
-            &nbsp;
-            </div>
-
+            </ul>
             <div metal:use-macro="context/batch_macros/macros/navigation" />
 
         </form>
 
-        <p tal:condition="not: results" i18n:translate="text_no_new_items">
-            No items have been published.
+        <p tal:condition="not: results" i18n:translate="text_no_new_modified_items">
+            No items have been modified.
         </p>
     </div>
 

--- a/Products/CMFPlone/browser/templates/recently_published.pt
+++ b/Products/CMFPlone/browser/templates/recently_published.pt
@@ -12,45 +12,43 @@
 <body>
 
 <metal:main fill-slot="main"
-     tal:define="path context/@@plone_portal_state/navigation_root_path;
-                 results python:container.portal_catalog(sort_on='modified',sort_order='reverse',path=path);
+     tal:define="results python:container.portal_catalog(sort_on='modified',sort_order='reverse',review_state='published');
                  Batch python:modules['Products.CMFPlone'].Batch;
-                 DateTime python:modules['DateTime'].DateTime;
                  b_start python:request.get('b_start',0);
-                 normalizeString nocall:context/@@plone/normalizeString;
-                 toLocalizedTime nocall:context/@@plone/toLocalizedTime;">
+                 toLocalizedTime nocall:context/@@plone/toLocalizedTime;
+                 normalize nocall:context/@@plone/normalizeString;">
 
     <h1 class="documentFirstHeading"
-        i18n:translate="heading_recently_modified">
-        Modified items
+        i18n:translate="heading_recently_published">
+        Published items
     </h1>
 
-    <div i18n:translate="description_recently_modified" class="documentDescription">
-        All recently modified items, latest first.
+    <div i18n:translate="description_recently_published" class="documentDescription">
+        All published items, latest first.
     </div>
 
     <div id="content-core"
-         tal:define="site_properties context/portal_properties/site_properties;
-                     isAnon context/@@plone_portal_state/anonymous;
+         tal:define="isAnon context/@@plone_portal_state/anonymous;
                      portal context/@@plone_portal_state/portal;
-                     show_about python:not isAnon or context.portal_registry['plone.allow_anon_views_about'];">
+                     show_about python:not isAnon or context.portal_registry['plone.allow_anon_views_about'];
+                     image_scale portal/@@image_scale">
         <form name="searchresults" action="" method="post" tal:condition="results"
-                          tal:define="batch python:Batch(results, 20, int(b_start), orphan=1);
-                                      image_scale portal/@@image_scale">
-            <ul>
+                          tal:define="batch python:Batch(results, 20, int(b_start), orphan=1)">
+
             <tal:results tal:repeat="result batch">
 
-                <li tal:define="description result/Description">
-                    <header tal:define="item_wf_state result/review_state;
-                                        item_wf_state_class python:'state-' + normalizeString(item_wf_state);
-                                        item_type_class python:'contenttype-' + normalizeString(result.portal_type)">
-                          <a tal:attributes="href result/getURL">
+                <article>
+                    <header
+                       tal:define="item_class python:'contenttype-' + normalize(result.portal_type);
+                                   item_wf_state result/review_state;
+                                   item_wf_state_class python:'state-' + normalize(item_wf_state);">
+                        <a tal:attributes="href result/getURL">
                             <img tal:condition="python:result.getIcon"
                                  tal:replace="structure python: image_scale.tag(result, 'image', scale='tile', css_class='thumb-tile')">
-                        	<span tal:content="result/pretty_title_or_id"
-                                  tal:attributes="class string:$item_type_class $item_wf_state_class"  >
+                            <span tal:content="result/pretty_title_or_id"
+                                  tal:attributes="class string:$item_class $item_wf_state_class">
                                   Title</span>
-                          </a>
+                        </a>
 
                         <span class="discreet" i18n:translate="text_creator_date" tal:condition="show_about">
                             by
@@ -66,21 +64,27 @@
                         </span>
                     </header>
 
-                    <p tal:condition="description"
-                        tal:content="description">
+                    <p class="discreet">
+                        <a href="/view"
+                           tal:content="result/Description"
+                           tal:attributes="href result/getURL">
                         Description
+                        </a>
                     </p>
-
-                </li>
+                </article>
 
             </tal:results>
-            </ul>
+
+            <div class="spacer">
+            &nbsp;
+            </div>
+
             <div metal:use-macro="context/batch_macros/macros/navigation" />
 
         </form>
 
-        <p tal:condition="not: results" i18n:translate="text_no_new_modified_items">
-            No items have been modified.
+        <p tal:condition="not: results" i18n:translate="text_no_new_items">
+            No items have been published.
         </p>
     </div>
 

--- a/Products/CMFPlone/profiles/default/skins.xml
+++ b/Products/CMFPlone/profiles/default/skins.xml
@@ -7,14 +7,11 @@
     directory="Products.CMFPlone:skins/plone_images"/>
  <object name="plone_scripts" meta_type="Filesystem Directory View"
     directory="Products.CMFPlone:skins/plone_scripts"/>
- <object name="plone_templates" meta_type="Filesystem Directory View"
-    directory="Products.CMFPlone:skins/plone_templates"/>
  <object name="plone_wysiwyg" meta_type="Filesystem Directory View"
     directory="Products.CMFPlone:skins/plone_wysiwyg"/>
  <skin-path name="Plone Default">
   <layer name="custom"/>
   <layer name="plone_wysiwyg"/>
-  <layer name="plone_templates"/>
   <layer name="plone_scripts"/>
   <layer name="plone_images"/>
  </skin-path>

--- a/Products/CMFPlone/skins/plone_templates/recently_modified.pt.metadata
+++ b/Products/CMFPlone/skins/plone_templates/recently_modified.pt.metadata
@@ -1,2 +1,0 @@
-[default]
-title=Recently modified

--- a/Products/CMFPlone/skins/plone_templates/recently_published.pt.metadata
+++ b/Products/CMFPlone/skins/plone_templates/recently_published.pt.metadata
@@ -1,2 +1,0 @@
-[default]
-title=Recently published

--- a/news/3515.bugfix.1
+++ b/news/3515.bugfix.1
@@ -1,0 +1,2 @@
+Moved ``recently_modified`` and ``recently_published`` skin templates to browser views.
+[maurits]


### PR DESCRIPTION
This gets rid of the `plone_templates` skin layer.
Part of https://github.com/plone/Products.CMFPlone/issues/3515
Needs an [upgrade step](https://github.com/plone/plone.app.upgrade/pull/290).