### PR TITLE
Make compatible with robotframework 3-5.

### DIFF
--- a/Products/CMFPlone/tests/robot/robodoc/config-screens.robot
+++ b/Products/CMFPlone/tests/robot/robodoc/config-screens.robot
@@ -47,7 +47,7 @@ Show Content setup screen
 
     Click element  type_id
 
-    Select From List  name=type_id  Document
+    Select From List By Label  name=type_id  Document
 
     Capture and crop page screenshot
     ...  ${CURDIR}/_robot/content-document.png

--- a/Products/CMFPlone/tests/robot/robodoc/managing_content.robot
+++ b/Products/CMFPlone/tests/robot/robodoc/managing_content.robot
@@ -27,7 +27,7 @@ add rule
     Click element  css=#form-widgets-description
     Input text  css=#form-widgets-description  this rule is meant for folders where new staff is having a go
     Click element  css=#formfield-form-widgets-event
-    Select From List  id=form-widgets-event  Object modified
+    Select From List By Label  id=form-widgets-event  Object modified
 
 
     Capture and crop page screenshot

--- a/Products/CMFPlone/tests/robot/test_actionmenu.robot
+++ b/Products/CMFPlone/tests/robot/test_actionmenu.robot
@@ -113,23 +113,6 @@ workflow link is clicked
     Click Link  xpath=//li[@id='plone-contentmenu-workflow']/a
     Click Link  xpath=(//li[@id='plone-contentmenu-workflow']/div/ul/li/a)[1]
     Page Should Contain  Item state changed.
-    # FIXME: The above 'Click Link' fails on Internet Explorer, but the
-    # following keywords 'workflow link is clicked softly' passes. Until we
-    # know why, we check if the above worked and if not, we try the other
-    # approach.
-    @{value} =  Run Keyword And Ignore Error
-    ...         Page Should Contain  Item state changed.
-    Run Keyword If  '@{value}[0]' == 'FAIL'
-    ...         workflow link is clicked softly
-
-workflow link is clicked softly
-    [Documentation]  This works on Internet Explorer, but not on Firefox...
-    Mouse Over  xpath=//*[@id='plone-contentmenu-workflow']/a
-    Click Link  xpath=//li[@id='plone-contentmenu-workflow']/a
-    Mouse Over  xpath=(//li[@id='plone-contentmenu-workflow']//a)[1]
-    Mouse Down  xpath=(//li[@id='plone-contentmenu-workflow']//a)[1]
-    Mouse Up  xpath=(//li[@id='plone-contentmenu-workflow']//a)[1]
-    Wait until page contains  Item state changed.
 
 Open Menu
     [Arguments]  ${elementId}

--- a/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -105,7 +105,7 @@ I add a new action
 
 I delete an action
   Click Button    css=section:nth-child(3) li:first-child button[name=delete]
-  Confirm Action
+  Handle alert
 
 I hide an action
   Click Button    css=section:nth-child(3) li:first-child button[name=hide]

--- a/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -119,7 +119,7 @@ the 'h1' tag is stripped when a document is saved
   Click Button  Save
   Wait until page contains  Changes saved
   Page should contain  heading
-  XPath Should Match X Times  //div[@id='content-core']//h1  0  message=h1 should have been stripped out
+  Page Should Contain Element  //div[@id='content-core']//h1  limit=0  message=h1 should have been stripped out
 
 the '${tag}' tag is preserved when a document is saved
   ${doc1_uid}=  Create content  id=doc1  title=Document 1  type=Document
@@ -128,7 +128,7 @@ the '${tag}' tag is preserved when a document is saved
   Input RichText  <${tag}>lorem ipsum</${tag}>
   Click Button  Save
   Wait until page contains  Changes saved
-  XPath Should Match X Times  //div[@id='content-core']//${tag}  1  message=the ${tag} tag should have been preserved
+  Page Should Contain Element  //div[@id='content-core']//${tag}  limit=1  message=the ${tag} tag should have been preserved
 
 the '${attribute}' attribute is preserved when a document is saved
   ${doc1_uid}=  Create content  id=doc1  title=Document 1  type=Document
@@ -137,7 +137,7 @@ the '${attribute}' attribute is preserved when a document is saved
   Input RichText  <span ${attribute}="foo">lorem ipsum</span>
   Click Button  Save
   Wait until page contains  Changes saved
-  XPath Should Match X Times  //span[@${attribute}]  1  message=the ${attribute} tag should have been preserved
+  Page Should Contain Element  //span[@${attribute}]  limit=1  message=the ${attribute} tag should have been preserved
 
 success message should contain information regarding caching
   Element Should Contain  css=.alert-warning  HTML generation is heavily cached across Plone. You may have to edit existing content or restart your server to see the changes.

--- a/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
@@ -112,14 +112,14 @@ I choose to not show '${workflow_state}' items
 the document '${title}' shows up in the navigation
   Go to  ${PLONE_URL}
   Wait until page contains  Powered by Plone
-  XPath Should Match X Times  //ul[@id='portal-globalnav']/li/a[contains(text(), '${title}')]  1  message=The global navigation should have contained the item '${title}'
+  Page Should Contain Element  //ul[@id='portal-globalnav']/li/a[contains(text(), '${title}')]  limit=1  message=The global navigation should have contained the item '${title}'
 
 the document '${title}' does not show up in the navigation
   Go to  ${PLONE_URL}
   Wait until page contains  Powered by Plone
-  XPath Should Match X Times  //ul[@id='portal-globalnav']/li/a[contains(text(), '${title}')]  0  message=The global navigation should not have contained the item '${title}'
+  Page Should Contain Element  //ul[@id='portal-globalnav']/li/a[contains(text(), '${title}')]  limit=0  message=The global navigation should not have contained the item '${title}'
 
 the document '${title}' does not show up in the sitemap
   Go to  ${PLONE_URL}/sitemap
   Wait until page contains  Powered by Plone
-  XPath Should Match X Times  //ul[@id='portal-sitemap']/li/a/span[contains(text(), '${title}')]  0  message=The sitemap should not have contained the item '${title}'
+  Page Should Contain Element  //ul[@id='portal-sitemap']/li/a/span[contains(text(), '${title}')]  limit=0  message=The sitemap should not have contained the item '${title}'

--- a/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
@@ -79,6 +79,6 @@ searching for '${search_term}' will not return any results
   Input Text  xpath=//form[@id='searchform']//input[@name='SearchableText']  ${search_term}
   Submit Form  name=searchform
   Wait until page contains  items matching your search terms
-  XPath Should Match X Times  //span[@id='search-results-number' and contains(.,'0')]  1
+  Page Should Contain Element  //span[@id='search-results-number' and contains(.,'0')]  1
 
 

--- a/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
@@ -55,7 +55,7 @@ Globaly enabled comments
 # --- WHEN -------------------------------------------------------------------
 
 I select '${content_type}' in types dropdown
-  Select from list  name=type_id  ${content_type}
+  Select from list by label  name=type_id  ${content_type}
   Wait until page contains  Globally addable
 
 Allow discussion
@@ -63,7 +63,7 @@ Allow discussion
   Click Button  Save
 
 I select '${workflow}' workflow
-  Select from list  name=new_workflow  ${workflow}
+  Select from list by label  name=new_workflow  ${workflow}
   Click Button  Save
 
 I add new Link '${id}'

--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -106,12 +106,12 @@ I save the page
    Click Button  Save
 
 I select a date using the dropdowns
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_year']  2001
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_month']  January
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_day']  01
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_hour']  01
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_minute']  00
-    Select From List  xpath=//select[@id='edit_form_effectiveDate_0_ampm']  AM
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_year']  2001
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_month']  January
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_day']  01
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_hour']  01
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_minute']  00
+    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_ampm']  AM
 
 I click the calendar icon
 

--- a/Products/CMFPlone/tests/robot/test_portlets.robot
+++ b/Products/CMFPlone/tests/robot/test_portlets.robot
@@ -28,10 +28,10 @@ a manage portlets view
     Wait until page contains  Manage portlets
 
 I add a '${portletname}' portlet to the left column
-    Select from list  xpath=//div[@id="portletmanager-plone-leftcolumn"]//select  ${portletname}
+    Select from list by label  xpath=//div[@id="portletmanager-plone-leftcolumn"]//select  ${portletname}
 
 I add a '${portletname}' portlet to the right column
-    Select from list  xpath=//div[@id="portletmanager-plone-rightcolumn"]//select  ${portletname}
+    Select from list by label  xpath=//div[@id="portletmanager-plone-rightcolumn"]//select  ${portletname}
 
 I delete a '${portlet}'' portlet from the left column
     Click Link  xpath=//div[@id="portal-column-one"]//div[@class="portletHeader" and contains(.,"${portlet}")]//a[@class="delete"]  don't wait

--- a/news/5.bugfix
+++ b/news/5.bugfix
@@ -1,0 +1,2 @@
+Make compatible with robotframework 3-5.
+[maurits]


### PR DESCRIPTION
And remove a fallback for Internet Explorer, added in 2013, which fails now:

```
Test Actionmenu
==============================================================================
Scenario: Do a workflow change                                        | FAIL |
Value of variable '@{value}[0]' is not list or list-like.
```