### PR TITLE
Explicitly include zcml of more packages.

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -5,53 +5,72 @@
            xmlns:i18n="http://namespaces.zope.org/i18n"
            i18n_domain="plone">
 
+  <!-- basic zope/cmf -->
   <include package="zope.app.locales" />
   <include package="Products.CMFCore" />
   <include package="Products.GenericSetup" />
-  <include package="plone.app.contentmenu" />
+
+  <!-- plone.* -->
+  <include package="plone.batching" />
+  <include package="plone.browserlayer" />
+  <include package="plone.contentrules" />
+  <include package="plone.dexterity" />
+  <include package="plone.folder" />
+  <include package="plone.i18n" />
+  <include package="plone.indexer" />
+  <include package="plone.locking" />
+  <include package="plone.memoize" />
+  <include package="plone.outputfilters" />
+  <include package="plone.portlets" />
+  <include package="plone.protect" />
+  <include package="plone.registry" />
+  <include package="plone.resource" />
+  <include package="plone.schema" />
+  <include package="plone.session" />
+  <include package="plone.staticresources" />
+  <include package="plone.subrequest" />
+  <include package="plone.theme" />
+
+  <!-- plone.app.* -->
   <include package="plone.app.content" />
+  <include package="plone.app.contentlisting" />
+  <include package="plone.app.contentmenu" />
   <include package="plone.app.contentrules" />
   <include package="plone.app.contenttypes" />
   <include package="plone.app.customerize" />
+  <include package="plone.app.dexterity" />
   <include package="plone.app.discussion" />
   <include package="plone.app.i18n" />
   <include package="plone.app.layout" />
   <include package="plone.app.linkintegrity" />
   <include package="plone.app.locales" />
+  <include package="plone.app.multilingual" />
   <include package="plone.app.portlets" />
   <include package="plone.app.redirector" />
   <include package="plone.app.registry" />
   <include package="plone.app.theming" />
-  <include zcml:condition="installed plone.app.upgrade" package="plone.app.upgrade" />
   <include package="plone.app.users" />
   <include package="plone.app.uuid" />
   <include package="plone.app.viewletmanager" />
   <include package="plone.app.vocabularies" />
   <include package="plone.app.workflow" />
-  <include package="plone.batching" />
-  <include package="plone.dexterity" />
-  <include package="plone.memoize" />
-  <include package="plone.outputfilters" />
-  <include package="plone.session" />
-  <include package="plone.protect" />
-  <include package="plone.indexer" />
 
-  <include package="plone.staticresources" />
+  <!-- plone extra -->
+  <include package="plone.portlet.static" />
+  <include package="plone.portlet.collection" />
+  <include package="plonetheme.barceloneta" />
 
-  <!-- viewlets zope 3 layers support for themes -->
-  <include package="plone.browserlayer" />
-  <include package="plone.theme" />
-
-  <!-- multilingual -->
-  <include package="plone.app.multilingual" />
+  <!-- conditional -->
+  <include zcml:condition="installed plone.rest" package="plone.rest" />
+  <include zcml:condition="installed plone.restapi" package="plone.restapi" />
+  <include zcml:condition="installed plone.app.caching" package="plone.app.caching" />
+  <include zcml:condition="installed plone.app.iterate" package="plone.app.iterate" />
+  <include zcml:condition="installed plone.volto" package="plone.volto" />
+  <include zcml:condition="installed plone.app.upgrade" package="plone.app.upgrade" />
 
   <include package=".controlpanel" />
   <include package=".resources" />
   <include package=".patterns" />
-
-  <!-- extra portlets -->
-  <include package="plone.portlet.static" />
-  <include package="plone.portlet.collection" />
 
   <!-- local role PAS plugin -->
   <include package="borg.localrole" />

--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -64,11 +64,6 @@
   <include package="plonetheme.barceloneta" />
 
   <!-- conditional -->
-  <include zcml:condition="installed plone.rest" package="plone.rest" />
-  <include zcml:condition="installed plone.restapi" package="plone.restapi" />
-  <include zcml:condition="installed plone.app.caching" package="plone.app.caching" />
-  <include zcml:condition="installed plone.app.iterate" package="plone.app.iterate" />
-  <include zcml:condition="installed plone.volto" package="plone.volto" />
   <include zcml:condition="installed plone.app.upgrade" package="plone.app.upgrade" />
 
   <include package=".resources" />

--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -10,6 +10,9 @@
   <include package="Products.CMFCore" />
   <include package="Products.GenericSetup" />
 
+  <!-- Our controlpanel config defines several permissions, so load it early. -->
+  <include package=".controlpanel" />
+
   <!-- plone.* -->
   <include package="plone.batching" />
   <include package="plone.browserlayer" />
@@ -68,7 +71,6 @@
   <include zcml:condition="installed plone.volto" package="plone.volto" />
   <include zcml:condition="installed plone.app.upgrade" package="plone.app.upgrade" />
 
-  <include package=".controlpanel" />
   <include package=".resources" />
   <include package=".patterns" />
 

--- a/Products/CMFPlone/controlpanel/configure.zcml
+++ b/Products/CMFPlone/controlpanel/configure.zcml
@@ -2,12 +2,10 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five">
 
+  <include file="permissions.zcml" />
   <include package="plone.app.registry" />
-
   <include package=".bbb" />
   <include package=".browser" />
-
   <include file="events.zcml" />
-  <include file="permissions.zcml" />
 
 </configure>

--- a/Products/CMFPlone/meta.zcml
+++ b/Products/CMFPlone/meta.zcml
@@ -23,7 +23,12 @@
     <include package="Products.CMFCore" file="meta.zcml" />
     <include package="Products.GenericSetup" file="meta.zcml" />
 
+    <include package="plone.dexterity" file="meta.zcml" />
+    <include package="plone.resource" file="meta.zcml" />
+    <include package="plone.app.dexterity" file="meta.zcml" />
     <include package="plone.app.portlets" file="meta.zcml" />
+    <include package="plone.contentrules" file="meta.zcml" />
+    <include package="plone.session" file="meta.zcml" />
 
     <!-- plone.autoinclude's `autoIncludePlugins` directive finds
          and executes ZCML files from any installed packages

--- a/Products/CMFPlone/overrides.zcml
+++ b/Products/CMFPlone/overrides.zcml
@@ -4,8 +4,13 @@
            i18n_domain="plone">
 
     <include package="Products.CMFCore" file="overrides.zcml" />
+    <include package="five.localsitemanager" file="overrides.zcml" />
     <include package="plone.i18n" file="overrides.zcml" />
     <include package="plone.app.portlets" file="overrides.zcml" />
+    <!-- <include package="plone.z3cform" file="overrides.zcml" /> -->
+    <!-- <include package="plone.app.z3cform" file="overrides.zcml" /> -->
+    <include package="plone.app.multilingual" file="overrides.zcml" />
+    <include package="plone.app.dexterity" file="overrides.zcml" />
 
     <utility
         provides="Products.PageTemplates.interfaces.IUnicodeEncodingConflictResolver"

--- a/Products/CMFPlone/overrides.zcml
+++ b/Products/CMFPlone/overrides.zcml
@@ -7,8 +7,6 @@
     <include package="five.localsitemanager" file="overrides.zcml" />
     <include package="plone.i18n" file="overrides.zcml" />
     <include package="plone.app.portlets" file="overrides.zcml" />
-    <!-- <include package="plone.z3cform" file="overrides.zcml" /> -->
-    <!-- <include package="plone.app.z3cform" file="overrides.zcml" /> -->
     <include package="plone.app.multilingual" file="overrides.zcml" />
     <include package="plone.app.dexterity" file="overrides.zcml" />
 

--- a/news/3188.bugfix
+++ b/news/3188.bugfix
@@ -1,0 +1,4 @@
+Explicitly include zcml of more packages.
+Reorder the zcml loading.
+Require ``plone.resource``.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         'plone.portlets',
         'plone.protect >= 3.0.0',
         'plone.registry',
+        'plone.resource',
         'plone.schema',
         'plone.session',
         'plone.staticresources',


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3188.
All packages in the `install_requires` that have zcml, should be loaded explicitly.

Also reorder the zcml loading more logically: first `plone.*`, then `plone.app.*`.

Require `plone.resource`: this is used by various packages, but only required by `plone.staticresources`, which did not seem right to me.