### PR TITLE
Rename passwordreset into password-reset

### DIFF
--- a/Products/CMFPlone/browser/login/configure.zcml
+++ b/Products/CMFPlone/browser/login/configure.zcml
@@ -121,7 +121,7 @@
         />
 
     <browser:page
-        name="passwordreset"
+        name="password-reset"
         for="*"
         class=".password_reset.PasswordResetView"
         permission="zope.Public"

--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -38,7 +38,7 @@ LOGIN_TEMPLATE_IDS = [
     'mail_password_form',
     'member_search_results',
     'pwreset_finish',
-    'passwordreset',
+    'password-reset',
     'register',
     'registered',
     'require_login',

--- a/Products/CMFPlone/browser/login/password_reset.py
+++ b/Products/CMFPlone/browser/login/password_reset.py
@@ -71,7 +71,7 @@ class PasswordResetToolView(BrowserView):
         )
 
     def construct_url(self, randomstring):
-        return '{}/passwordreset/{}'.format(
+        return '{}/password-reset/{}'.format(
             self.portal_state().navigation_root_url(), randomstring)
 
     def expiration_timeout(self):

--- a/Products/CMFPlone/tests/emaillogin.rst
+++ b/Products/CMFPlone/tests/emaillogin.rst
@@ -231,7 +231,7 @@ Now get the link::
 
     >>> import quopri
     >>> msg = quopri.decodestring(msg)
-    >>> url_index = msg.index(b'http://nohost/plone/passwordreset/')
+    >>> url_index = msg.index(b'http://nohost/plone/password-reset/')
     >>> address = msg[url_index:].split()[0].decode()
 
 Now that we have the address, we will reset our password::
@@ -271,7 +271,7 @@ The email is sent to the correct email address::
 Now get the link::
 
     >>> msg = quopri.decodestring(msg)
-    >>> url_index = msg.index(b'http://nohost/plone/passwordreset/')
+    >>> url_index = msg.index(b'http://nohost/plone/password-reset/')
     >>> address = msg[url_index:].split()[0].decode()
 
 Now that we have the address, we will reset our password::

--- a/Products/CMFPlone/tests/pwreset_browser.rst
+++ b/Products/CMFPlone/tests/pwreset_browser.rst
@@ -206,7 +206,7 @@ then we extract the address that lets us reset our password:
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)
   >>> address = msg[url_index:].strip().split()[0].decode()
   >>> address # doctest: +ELLIPSIS
-  u'http://nohost/plone/passwordreset/...'
+  u'http://nohost/plone/password-reset/...'
   >>> b"If you didn't expect to receive this email" in msg
   True
 
@@ -417,7 +417,7 @@ We need to be careful to keep this working in both Python 2 and 3 without invali
 It is best to convert msgtext to text first.
 
   >>> msgtext = msgtext.decode()
-  >>> address = re.search(r'(http://nohost/plone/passwordreset/[a-z0-9]+\?userid=[\w]*)\s', msgtext).groups()[0]
+  >>> address = re.search(r'(http://nohost/plone/password-reset/[a-z0-9]+\?userid=[\w]*)\s', msgtext).groups()[0]
 
 Now that we have the address, we will reset our password:
 
@@ -499,7 +499,7 @@ then we extract the address that lets us reset our password:
   >>> b"Please activate it by visiting" in msgtext
   True
   >>> msgtext = msgtext.decode()
-  >>> address = re.search(r'(http://nohost/plone/passwordreset/[a-z0-9]+\?userid=[\w]*)\s', msgtext).groups()[0]
+  >>> address = re.search(r'(http://nohost/plone/password-reset/[a-z0-9]+\?userid=[\w]*)\s', msgtext).groups()[0]
 
 Now that we have the address, we will reset our password:
 
@@ -517,7 +517,7 @@ Log out
 
   >>> browser.getLink('Log out').click()
 
-Test passwordreset BrowserView
+Test password-reset BrowserView
 
     Setup Plone email sender
 

--- a/Products/CMFPlone/tests/test_login_help.py
+++ b/Products/CMFPlone/tests/test_login_help.py
@@ -70,7 +70,7 @@ class TestLoginHelp(unittest.TestCase):
         self.assertEqual(len(self.portal.MailHost.messages), 1)
         message = self.portal.MailHost.messages[0]
         self.assertIn(b'To: foo@plone.org', message)
-        self.assertIn(b'http://nohost/plone/passwordreset/', message)
+        self.assertIn(b'http://nohost/plone/password-reset/', message)
 
 
 class TestLoginHelpFunctional(unittest.TestCase):

--- a/news/3538.breaking
+++ b/news/3538.breaking
@@ -1,0 +1,2 @@
+Rename *passwordreset* view into *password-reset* to be aligned with restapi and Volto names
+[cekk]


### PR DESCRIPTION
Related to https://github.com/plone/plone.volto/pull/61

Can be nice to have the same name in both Plone and Volto.
I prefer "password-reset" but if Plone endpoint is more important for backward compatibility, we can change it in Volto.