### PR TITLE
Implement bundle depends on multiple comma separated names

### DIFF
--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -182,7 +182,7 @@ class ResourceBase:
                     integrity=not external,
                 )
             if record.csscompilation:
-                depends = check_dependencies(name, record.depends, js_names)
+                depends = check_dependencies(name, record.depends, css_names)
                 if depends == "__broken__":
                     continue
                 external = record.csscompilation.startswith("http")

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -109,13 +109,48 @@ class ResourceBase:
         request_enabled_bundles, request_disabled_bundles = self._request_bundles()
 
         # collect names
-        js_names = {name for name, rec in records.items() if rec.jscompilation}
-        css_names = {name for name, rec in records.items() if rec.csscompilation}
-        all_names = {
+        js_names = [name for name, rec in records.items() if rec.jscompilation]
+        css_names = [name for name, rec in records.items() if rec.csscompilation]
+        all_names = [
             name
             for name, rec in records.items()
             if rec.jscompilation or rec.csscompilation
-        }
+        ]
+
+        def check_dependencies(bundle_name, depends, bundles):
+            # "depends" can be a comma separated string of dependent
+            # bundle names
+            depend_names = depends.split(",") if depends else []
+            valid_dependencies = []
+
+            for name in depend_names:
+                if name in bundles:
+                    valid_dependencies.append(name)
+                    continue
+                if name in all_names:
+                    # ignore dependency on bundle outside "bundles"
+                    continue
+
+                msg = f"Bundle '{bundle_name}' has a non existing dependeny on '{name}'. "
+
+                if name in GRACEFUL_DEPENDENCY_REWRITE:
+                    # gracefully rewrite old bundle names
+                    graceful_depends = GRACEFUL_DEPENDENCY_REWRITE[name]
+                    logger.error(
+                            msg
+                            + f"Bundle dependency graceful rewritten to '{graceful_depends}' "
+                            + "Fallback will be removed in Plone 7."
+                        )
+                    valid_dependencies.append(graceful_depends)
+                    continue
+
+                # if the dependency does not exist, skip the bundle
+                logger.error(
+                    msg + "Bundle ignored - This may break your site!"
+                )
+                return "__broken__"
+
+            return valid_dependencies
 
         # register
         for name, record in records.items():
@@ -126,24 +161,9 @@ class ResourceBase:
             include = include and name not in request_disabled_bundles
 
             if record.jscompilation:
-                depends = record.depends or ""
-                if depends and depends not in js_names:
-                    if depends in all_names:
-                        depends = None
-                    else:
-                        msg = f"Bundle '{name}' has a non existing dependeny on '{record.depends}'. "
-                        if depends not in GRACEFUL_DEPENDENCY_REWRITE:
-                            logger.error(
-                                msg + "Bundle ignored (JS) - This may break your site!"
-                            )
-                            continue
-                        graceful_depends = GRACEFUL_DEPENDENCY_REWRITE[depends]
-                        logger.error(
-                            msg
-                            + f"Bundle dependency (JS) graceful rewritten to '{graceful_depends}' "
-                            + "Fallback will be removed in Plone 7."
-                        )
-                        depends = graceful_depends
+                depends = check_dependencies(name, record.depends, js_names)
+                if depends == "__broken__":
+                    continue
                 external = record.jscompilation.startswith("http")
                 PloneScriptResource(
                     context=self.context,
@@ -162,24 +182,9 @@ class ResourceBase:
                     integrity=not external,
                 )
             if record.csscompilation:
-                depends = record.depends or ""
-                if depends and depends not in css_names:
-                    if depends in all_names:
-                        depends = None
-                    else:
-                        msg = f"Bundle '{name}' has a non existing dependeny on '{record.depends}'. "
-                        if depends not in GRACEFUL_DEPENDENCY_REWRITE:
-                            logger.error(
-                                msg + "Bundle ignored (CSS) - This may break your site!"
-                            )
-                            continue
-                        graceful_depends = GRACEFUL_DEPENDENCY_REWRITE[depends]
-                        logger.error(
-                            msg
-                            + f"Bundle dependency (CSS) graceful rewritten to '{graceful_depends}' "
-                            + "Fallback will be removed in Plone 7."
-                        )
-                        depends = graceful_depends
+                depends = check_dependencies(name, record.depends, js_names)
+                if depends == "__broken__":
+                    continue
                 external = record.csscompilation.startswith("http")
                 PloneStyleResource(
                     context=self.context,

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -159,6 +159,31 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         result = scripts.render()
         self.assertNotIn("http://test.foo/test.css", result)
 
+    def test_bundle_depends(self):
+        bundle = self._make_test_bundle()
+        bundle.depends = "plone"
+        view = ScriptsView(self.app, self.app.REQUEST, None, None)
+        view.update()
+        results = view.render()
+        self.assertIn("http://foo.bar/foobar.js", results)
+
+    def test_bundle_depends_on_multiple(self):
+        bundle = self._make_test_bundle()
+        bundle.depends = "plone,eventedit"
+        view = ScriptsView(self.app, self.app.REQUEST, None, None)
+        view.update()
+        results = view.render()
+        self.assertIn("http://foo.bar/foobar.js", results)
+
+    def test_bundle_depends_on_missing(self):
+        bundle = self._make_test_bundle()
+        bundle.depends = "nonexistsinbundle"
+        view = ScriptsView(self.app, self.app.REQUEST, None, None)
+        view.update()
+        results = view.render()
+        # bundle should be skipped when rendering
+        self.assertNotIn("http://foo.bar/foobar.js", results)
+
 
 class TestStylesViewlet(PloneTestCase.PloneTestCase):
     def test_styles_viewlet(self):

--- a/news/3570.feature
+++ b/news/3570.feature
@@ -1,0 +1,2 @@
+Resource bundle dependency on multiple comma separated names.
+[petschki]

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         'setuptools>=36.2',
         'transaction',
         'plone.autoinclude',
-        'webresource',
+        'webresource>=1.1',
         'ZODB3',
         'Zope[wsgi] >= 4.0',
         'zope.app.locales >= 3.6.0',


### PR DESCRIPTION
Came accross this when using an addon (https://github.com/bluedynamics/bda.plone.cart/blob/master/src/bda/plone/cart/profiles/default/registry.xml#L18) ... this obviously worked in the Plone 5 RR. Fortunately `webresource` supports a list for `depends` attribute: https://github.com/conestack/webresource/blob/master/webresource/_api.py#L115