### PR TITLE
Robot tests: be more specific when clicking some elements.

### DIFF
--- a/Products/CMFPlone/tests/robot/keywords.robot
+++ b/Products/CMFPlone/tests/robot/keywords.robot
@@ -33,3 +33,7 @@ patterns are loaded
 a folder with a document '${title}'
   ${folder_uid}=  Create content  type=Folder  title=folder
   Create content  type=Document  container=${folder_uid}  title=${title}
+
+folder contents pattern loaded
+    Page should contain element  css=.pat-structure
+    Wait For Condition  return !!document.querySelector('.pat-structure div.navbar')

--- a/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -76,6 +76,7 @@ Input RichText
   # See https://robotframework.org/robotframework/2.6.1/libraries/BuiltIn.html#Wait%20Until%20Keyword%20Succeeds
   Sleep  1
   Wait until keyword succeeds  5s  1s  Execute Javascript  tinyMCE.activeEditor.setContent('${input}');
+  Sleep  1
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -75,8 +75,15 @@ Input RichText
   # or fatal exceptions are not caught by this keyword."
   # See https://robotframework.org/robotframework/2.6.1/libraries/BuiltIn.html#Wait%20Until%20Keyword%20Succeeds
   Sleep  1
-  Wait until keyword succeeds  5s  1s  Execute Javascript  tinyMCE.activeEditor.setContent('${input}');
-  Sleep  1
+  Wait until keyword succeeds  5s  1s  Set and Check TinyMCE Content  ${input}
+
+Set and Check TinyMCE Content
+  [Arguments]  ${input}
+  # Simply check if tinyMCE.getContent() isn't empty when we set an input
+  Execute Javascript   tinyMCE.activeEditor.setContent('${input}');
+  Sleep  0.5
+  ${check}=  Execute Javascript  return tinyMCE.activeEditor.getContent();
+  Should not be empty  ${check}
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/Products/CMFPlone/tests/robot/test_folder_contents.robot
+++ b/Products/CMFPlone/tests/robot/test_folder_contents.robot
@@ -53,7 +53,6 @@ a folder with four pages
 
 the folder contents view
     Go to  ${PLONE_URL}/my-folder/folder_contents
-    Page should contain element  css=.pat-structure
     Given folder contents pattern loaded
 
 I click the '${link_name}' link
@@ -107,6 +106,3 @@ Should be above
     ${locator1-position} =  Get vertical position  ${locator1}
     ${locator2-position} =  Get vertical position  ${locator2}
     Should be true  ${locator1-position} < ${locator2-position}
-
-folder contents pattern loaded
-    Wait For Condition  return !!document.querySelector('.pat-structure div.navbar')

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -100,6 +100,7 @@ should show warning when deleting page
 
 should show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
+  Given folder contents pattern loaded
   Wait For Then Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled
@@ -113,6 +114,7 @@ should show warning when deleting page from folder_contents
 
 should not show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
+  Given folder contents pattern loaded
   Wait For Then Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled

--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -93,7 +93,7 @@ a link in rich text
 should show warning when deleting page
 
   Go To  ${PLONE_URL}/foo
-  Wait For Then Click Element  css=#plone-contentmenu-actions a
+  Wait For Then Click Element  css=#plone-contentmenu-actions > a
   Wait For Then Click Element  css=#plone-contentmenu-actions-delete
   Wait until page contains element  css=.breach-container .breach-item
 
@@ -113,7 +113,6 @@ should show warning when deleting page from folder_contents
 
 should not show warning when deleting page from folder_contents
   Go To  ${PLONE_URL}/folder_contents
-  Wait until page contains element  css=tr[data-id="foo"] input
   Wait For Then Click Element  css=tr[data-id="foo"] input
   Checkbox Should Be Selected  css=tr[data-id="foo"] input
   Wait until keyword succeeds  30  1  Page should not contain element  css=#btn-delete.disabled
@@ -127,7 +126,7 @@ should not show warning when deleting page from folder_contents
 
 should not show warning when deleting page
   Go To  ${PLONE_URL}/foo
-  Wait For Then Click Element  css=#plone-contentmenu-actions a
+  Wait For Then Click Element  css=#plone-contentmenu-actions > a
   Wait For Then Click Element  css=#plone-contentmenu-actions-delete
   Page should not contain element  css=.breach-container .breach-item
 

--- a/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -260,13 +260,13 @@ I '${action}' the form
 I enter wrong credentials
     Input text  __ac_name  wrong
     Input text  __ac_password  user
-    Click Button  css=div.modal-footer button
+    Wait For Then Click Element  css=div.modal-footer button
 
 I enter valid credentials
     Wait until page contains element  name=__ac_name
     Input text for sure  __ac_name  ${SITE_OWNER_NAME}
     Input text for sure  __ac_password  ${SITE_OWNER_PASSWORD}
-    Click Button  css=div.modal-footer button
+    Wait For Then Click Element  css=div.modal-footer button
 
 I enter valid user data
     Wait until page contains element  name=form.widgets.password_ctl

--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -271,18 +271,20 @@ I open the Selection Widget
 
 I delete one selection
     #deletes one element
-    Wait For Then Click Element  css=a.select2-search-choice-close
+    Wait For Then Click Element  jquery=a.select2-search-choice-close:visible
 
 I delete my selection
     #deletes two elements
-    Wait For Then Click Element  css=a.select2-search-choice-close
+    Wait For Then Click Element  jquery=a.select2-search-choice-close:visible:first
     Sleep  0.1
-    Wait For Then Click Element  css=a.select2-search-choice-close
+    Wait For Then Click Element  jquery=a.select2-search-choice-close:visible
 
 I search in ${NAME} subfolder in the related items widget
     mark results
-    Wait For Then Click Element  css=ul.select2-choices
+    Wait For Then Click Element  jquery=.pat-relateditems-container ul.select2-choices:visible
     Wait Until Page Contains  ${NAME}
+    # I have seen this fail sometimes, where the screen shot showed the NAME just fine.
+    Sleep  0.1
     Click Element  //a[contains(concat(' ', normalize-space(@class), ' '), ' pat-relateditems-result-select ')]//span[contains(text(),'${NAME}')]
 
 I expect to be in Advanced mode
@@ -309,7 +311,7 @@ I expect to be in Simple mode
 
 open the select box titled ${NAME}
     Click Element  css=body
-    Wait For Then Click Element  css=.querystring-criteria-${NAME} .select2-container
+    Wait For Then Click Element  jquery=.querystring-criteria-${NAME} .select2-container:first
 
 select index type ${INDEX}
     ${input_selector}  Set Variable  .select2-drop-active[style*="display: block;"] input

--- a/news/3582.bugfix
+++ b/news/3582.bugfix
@@ -1,0 +1,2 @@
+Robot tests: be more specific when clicking some elements.
+[maurits]


### PR DESCRIPTION
Test these together:

```
https://github.com/plone/plone.app.robotframework/pull/140
https://github.com/plone/plone.schemaeditor/pull/94
https://github.com/plone/Products.CMFPlone/pull/3590
```

The plone.app.robotframework PR is stricter: when you click an element, this element should exist only once. This leads to seven failures in CMFPlone, which I fix here.