### PR TITLE
Fixed adding control panel action via ZMI. [5.2]

### DIFF
--- a/Products/CMFPlone/PloneControlPanel.py
+++ b/Products/CMFPlone/PloneControlPanel.py
@@ -227,7 +227,7 @@ class PloneControlPanel(PloneBaseTool, UniqueObject,
                   description='',
                   REQUEST=None,
                   ):
-        # Add an action to our list.
+        """Add an action to our list."""
         if not name:
             raise ValueError('A name is required.')
 

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -87,7 +87,9 @@ class TestAttackVectorsFunctional(PloneTestCase):
     def test_registerConfiglet_1(self):
         VECTOR = "/plone/portal_controlpanel/registerConfiglet?id=cake&name=Cakey&action=woo&permission=View&icon_expr="
         res = self.publish(VECTOR)
-        self.assertEqual(404, res.status)
+        self.assertEqual(302, res.status)
+        self.assertTrue(res.headers['location'].startswith(
+            'http://nohost/plone/acl_users/credentials_cookie_auth/require_login'))
 
     def test_registerConfiglet_2(self):
         VECTOR = "/plone/portal_controlpanel/registerConfiglet?id=cake&name=Cakey&action=woo&permission=View&icon_expr="

--- a/news/1959.bugfix
+++ b/news/1959.bugfix
@@ -1,0 +1,2 @@
+Fixed adding control panel action via ZMI.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/1959 for Plone 5.2.