### PR TITLE
Require Python 3.8 or higher.

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -151,8 +151,8 @@ def allowedRolesAndUsers(obj):
 @indexer(Interface)
 def object_provides(obj):
     return tuple(
-        [i.__identifier__ for i in providedBy(obj).flattened()
-         if i.__identifier__ not in DENIED_INTERFACES]
+        i.__identifier__ for i in providedBy(obj).flattened()
+         if i.__identifier__ not in DENIED_INTERFACES
     )
 
 

--- a/Products/CMFPlone/Portal.py
+++ b/Products/CMFPlone/Portal.py
@@ -116,7 +116,7 @@ class PloneSite(Container, SkinnableObjectManager, UniqueObject):
 
     # From PortalObjectBase
     def __init__(self, id, title=''):
-        super(PloneSite, self).__init__(id, title=title)
+        super().__init__(id, title=title)
         components = PersistentComponents('++etc++site')
         components.__parent__ = self
         self.setSiteManager(components)
@@ -135,7 +135,7 @@ class PloneSite(Container, SkinnableObjectManager, UniqueObject):
             pass
         self.setupCurrentSkin(REQUEST)
 
-        super(PloneSite, self).__before_publishing_traverse__(arg1, arg2)
+        super().__before_publishing_traverse__(arg1, arg2)
 
     # Concept from OFS.OrderSupport
     @security.protected(permissions.AccessContentsInformation)

--- a/Products/CMFPlone/WorkflowTool.py
+++ b/Products/CMFPlone/WorkflowTool.py
@@ -258,7 +258,7 @@ class WorkflowTool(PloneBaseTool, BaseTool):
                                 objects_by_path[absurl] = (o.modified(), o)
 
         results = objects_by_path.values()
-        return tuple([obj[1] for obj in sorted(results)])
+        return tuple(obj[1] for obj in sorted(results))
 
     security.declareProtected(ManagePortal, 'getChainForPortalType')
 

--- a/Products/CMFPlone/browser/icons.py
+++ b/Products/CMFPlone/browser/icons.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from lxml import etree
 from OFS.Image import File
 from plone.registry.interfaces import IRegistry

--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -251,7 +251,7 @@ class RequireLoginView(BrowserView):
             url = f'{portal.absolute_url():s}/login'
             came_from = self.request.get('came_from', None)
             if came_from:
-                url += '?came_from={:s}'.format(parse.quote(came_from))
+                url += f'?came_from={parse.quote(came_from):s}'
         else:
             url = f'{portal.absolute_url():s}/insufficient-privileges'
 

--- a/Products/CMFPlone/browser/login/login_help.py
+++ b/Products/CMFPlone/browser/login/login_help.py
@@ -54,7 +54,7 @@ class RequestResetPassword(form.Form):
     render = ViewPageTemplateFile('templates/subform_render.pt')
 
     def updateActions(self):
-        super(RequestResetPassword, self).updateActions()
+        super().updateActions()
         self.actions['reset'].addClass('btn-primary')
 
     def updateWidgets(self):
@@ -107,7 +107,7 @@ class RequestUsername(form.Form):
     render = ViewPageTemplateFile('templates/subform_render.pt')
 
     def updateActions(self):
-        super(RequestUsername, self).updateActions()
+        super().updateActions()
         self.actions['get_username'].addClass('btn-primary')
 
     @button.buttonAndHandler(
@@ -188,7 +188,7 @@ class RequestUsername(form.Form):
         mail_settings = registry.forInterface(IMailSchema, prefix="plone")
         from_ = mail_settings.email_from_name
         mail = mail_settings.email_from_address
-        return '"{}" <{}>'.format(self.encode_mail_header(from_), mail)
+        return f'"{self.encode_mail_header(from_)}" <{mail}>'
 
 
 @implementer(ILoginHelpForm)

--- a/Products/CMFPlone/browser/login/password_reset.py
+++ b/Products/CMFPlone/browser/login/password_reset.py
@@ -48,7 +48,7 @@ class PasswordResetToolView(BrowserView):
         mail_settings = registry.forInterface(IMailSchema, prefix="plone")
         from_ = mail_settings.email_from_name
         mail = mail_settings.email_from_address
-        return '"{}" <{}>'.format(self.encode_mail_header(from_).encode(), mail)
+        return f'"{self.encode_mail_header(from_).encode()}" <{mail}>'
 
     def registered_notify_subject(self):
         portal_name = self.portal_state().portal_title()

--- a/Products/CMFPlone/browser/test_rendering.py
+++ b/Products/CMFPlone/browser/test_rendering.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_redirection.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_redirection.py
@@ -139,8 +139,8 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         now = DateTime('2022-02-03')
         for i in range(1000):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
                 now=now,
             )
         redirects = RedirectionSet()
@@ -182,8 +182,8 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         portal_path = self.layer['portal'].absolute_url_path()
         for i in range(1000):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
             )
         view = getMultiAdapter(
             (self.layer['portal'], self.layer['request']),
@@ -225,13 +225,13 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         portal_path = self.layer['portal'].absolute_url_path()
         for i in range(1000):
             storage.add(
-                '{:s}/foo1/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo1/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
             )
         for i in range(1000):
             storage.add(
-                '{:s}/foo2/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo2/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
             )
 
         redirects = RedirectionSet()
@@ -282,14 +282,14 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         portal_path = self.layer['portal'].absolute_url_path()
         for i in range(100):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
                 manual=False,
             )
         for i in range(100, 300):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
                 manual=True,
             )
 
@@ -333,8 +333,8 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         time0 = DateTime('2001-01-01')
         for i in range(400):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
                 now=time0 + i,
             )
 
@@ -802,8 +802,8 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         now = DateTime('2019/01/27 10:00:00 GMT-3')
         for i in range(2000):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
-                '{:s}/bar/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
+                f'{portal_path:s}/bar/{str(i):s}',
                 now=now,
                 manual=True,
             )
@@ -839,7 +839,7 @@ class RedirectionControlPanelFunctionalTest(unittest.TestCase):
         now = DateTime('2019/01/27 10:00:00 GMT-3')
         for i in range(10):
             storage.add(
-                '{:s}/foo/{:s}'.format(portal_path, str(i)),
+                f'{portal_path:s}/foo/{str(i):s}',
                 f'{portal_path:s}/test-folder',
                 now=now,
                 manual=True,

--- a/Products/CMFPlone/patches/unicodehacks.py
+++ b/Products/CMFPlone/patches/unicodehacks.py
@@ -14,11 +14,11 @@ def _nulljoin(valuelist):
 
 def new__call__(self, econtext):
     try:
-        return self._expr % tuple([var(econtext) for var in self._vars])
+        return self._expr % tuple(var(econtext) for var in self._vars)
     except UnicodeDecodeError:
         pass
-    return self._expr % tuple([_unicode_replace(var(econtext))
-                               for var in self._vars])
+    return self._expr % tuple(_unicode_replace(var(econtext))
+                               for var in self._vars)
 
 
 class FasterStringIO(list):

--- a/Products/CMFPlone/relationhelper.py
+++ b/Products/CMFPlone/relationhelper.py
@@ -62,7 +62,7 @@ def get_relations_stats():
             rel = relation_catalog.resolveRelationToken(token)
         except ObjectMissingError:
             broken['Object is missing'] += 1
-            logger.info('Token {} has no object.'.format(token))
+            logger.info(f'Token {token} has no object.')
             continue
 
         if rel.isBroken():
@@ -84,7 +84,7 @@ def get_all_relations():
         try:
             rel = relation_catalog.resolveRelationToken(token)
         except ObjectMissingError:
-            logger.info('Token {} has no object.'.format(token))
+            logger.info(f'Token {token} has no object.')
             continue
 
         if rel.from_object and rel.to_object:

--- a/Products/CMFPlone/resources/utils.py
+++ b/Products/CMFPlone/resources/utils.py
@@ -30,7 +30,7 @@ def get_production_resource_directory():
     timestamp = production_folder.readFile("timestamp.txt")
     if isinstance(timestamp, bytes):
         timestamp = timestamp.decode()
-    return "{}/++unique++{}".format(PRODUCTION_RESOURCE_DIRECTORY, timestamp)
+    return f"{PRODUCTION_RESOURCE_DIRECTORY}/++unique++{timestamp}"
 
 
 def get_resource(context, path):

--- a/Products/CMFPlone/tests/testInterfaces.py
+++ b/Products/CMFPlone/tests/testInterfaces.py
@@ -297,5 +297,5 @@ import unittest
 def test_suite():
     suite = unittest.TestSuite()
     for test in tests:
-        suite.addTest(unittest.makeSuite(test))
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test))
     return suite

--- a/Products/CMFPlone/tests/testSearch.py
+++ b/Products/CMFPlone/tests/testSearch.py
@@ -366,5 +366,5 @@ def test_suite():
     above
     """
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestSection))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestSection))
     return suite

--- a/Products/CMFPlone/tests/testSecurity.py
+++ b/Products/CMFPlone/tests/testSecurity.py
@@ -156,7 +156,7 @@ class TestFunctional(unittest.TestCase):
         browser.handleErrors = False
         browser.addHeader(
             "Authorization",
-            "Basic {0}:{1}".format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            f"Basic {SITE_OWNER_NAME}:{SITE_OWNER_PASSWORD}",
         )
         return browser
 

--- a/Products/CMFPlone/tests/test_expressions.py
+++ b/Products/CMFPlone/tests/test_expressions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
@@ -29,7 +28,7 @@ import unittest
 path = os.path.dirname(__file__)
 
 
-class DummyView(object):
+class DummyView:
 
     __name__ = "dummy-view"
     _authenticator = "secret"

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -400,7 +400,7 @@ def _unrestricted_rename(container, id, new_id):
             action='manage_main'))
     ob = container._getOb(id)
     if not ob.cb_isMoveable():
-        raise CopyError('Not Supported {}'.format(escape(id)))
+        raise CopyError(f'Not Supported {escape(id)}')
     try:
         ob._notifyOfCopyTo(container, op=1)
     except:

--- a/news/3635.bugfix
+++ b/news/3635.bugfix
@@ -1,0 +1,1 @@
+Require Python 3.8 or higher.  [maurits]

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    python_requires='>=3.8',
     keywords='Plone CMF Python Zope CMS Webapplication',
     author='Plone Foundation',
     author_email='releasemanager@plone.org',


### PR DESCRIPTION
We already dropped official support for 3.7. This makes it concrete.
Actually the syntax is unchanged. `pyupgrade` made no extra changes when using `--py38-plus`.