### PR TITLE
Don't create default content folders for Volto

### DIFF
--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -160,10 +160,8 @@ class AddPloneSite(BrowserView):
     # Let's have a separate list for Volto.
     volto_default_extension_profiles = (
         'plone.app.caching:default',
-        # We could choose to not install Barceloneta:
         'plonetheme.barceloneta:default',
         'plone.volto:default',
-        'plone.volto:default-homepage'
     )
 
     def profiles(self):
@@ -294,6 +292,7 @@ class AddPloneSite(BrowserView):
             else:
                 # we have a keymanager, check csrf protection manually now
                 checkCSRF(self.request)
+
             site = addPloneSite(
                 context, site_id,
                 title=form.get('title', ''),

--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -117,7 +117,7 @@ def zmi_constructor(context):
 
 def addPloneSite(context, site_id, title='Plone site', description='',
                  profile_id=_DEFAULT_PROFILE,
-                 content_profile_id=_CONTENT_PROFILE, snapshot=False,
+                 content_profile_id=None, snapshot=False,
                  extension_ids=(), setup_content=True,
                  default_language='en', portal_timezone='UTC'):
     """Add a PloneSite to the context."""
@@ -154,7 +154,20 @@ def addPloneSite(context, site_id, title='Plone site', description='',
 
         # Install default content types profile if user do not select "example content"
         # during site creation.
-        content_types_profile = content_profile_id if setup_content else _TYPES_PROFILE
+        content_types_profile = (
+            content_profile_id
+            if setup_content and content_profile_id
+            else _TYPES_PROFILE
+        )
+        if setup_content:
+            if content_profile_id:
+                content_types_profile = content_profile_id
+            elif "plone.volto:default" in extension_ids:
+                content_types_profile = "plone.volto:default-homepage"
+            else:
+                content_types_profile = _CONTENT_PROFILE
+        else:
+            content_types_profile = _TYPES_PROFILE
 
         setup_tool.runAllImportStepsFromProfile(f'profile-{content_types_profile}')
 

--- a/news/3628.bugfix
+++ b/news/3628.bugfix
@@ -1,0 +1,1 @@
+Don't create news, events, and users folders for Volto sites. [davisagli]


### PR DESCRIPTION
When creating a Volto site, don't add the news, events, or users folders. They are not set up in a way that makes sense for Volto. (They are Folders, which is a disabled content type. For Volto they should be Documents with a listing block.)

In the future we can add default content that makes sense for Volto, but for now let's just avoid adding the existing default content that doesn't make sense.

Fixes #3628 