### PR TITLE
Fix regression from #3665 (missing content types)

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -154,22 +154,21 @@ def addPloneSite(context, site_id, title='Plone site', description='',
 
         # Install default content types profile if user do not select "example content"
         # during site creation.
-        content_types_profile = (
-            content_profile_id
-            if setup_content and content_profile_id
-            else _TYPES_PROFILE
-        )
         if setup_content:
             if content_profile_id:
-                content_types_profile = content_profile_id
+                content_profiles = [content_profile_id]
             elif "plone.volto:default" in extension_ids:
-                content_types_profile = "plone.volto:default-homepage"
+                content_profiles = [
+                    _TYPES_PROFILE,
+                    "plone.volto:default-homepage",
+                ]
             else:
-                content_types_profile = _CONTENT_PROFILE
+                content_profiles = [_CONTENT_PROFILE]
         else:
-            content_types_profile = _TYPES_PROFILE
+            content_profiles = [_TYPES_PROFILE]
 
-        setup_tool.runAllImportStepsFromProfile(f'profile-{content_types_profile}')
+        for profile_id in content_profiles:
+            setup_tool.runAllImportStepsFromProfile(f'profile-{profile_id}')
 
         props = dict(
             title=title,


### PR DESCRIPTION
My change in #3665 accidentally skipped installing the plone.app.contenttypes:default profile, so let's fix that.