### PR TITLE
Add data-bundle attributes on javascript and styles resources

### DIFF
--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -187,6 +187,7 @@ class ResourceBase:
                     async_=record.load_async or None,
                     defer=record.load_defer or None,
                     integrity=not external,
+                    **{'data-bundle': name},
                 )
             if record.csscompilation:
                 depends = check_dependencies(name, record.depends, css_names)
@@ -206,6 +207,7 @@ class ResourceBase:
                     url=record.csscompilation if external else None,
                     media="all",
                     rel="stylesheet",
+                    **{'data-bundle': name},
                 )
 
         # Collect theme data

--- a/news/3707.feature
+++ b/news/3707.feature
@@ -1,0 +1,1 @@
+Add data-bundle attributes on javascript and styles resources.  [aormazabal]

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'Products.statusmessages',
         'setuptools>=36.2',
         'plone.autoinclude',
-        'webresource>=1.1',
+        'webresource>=1.2',
         'Zope[wsgi] >= 5.0',
         'zope.app.locales >= 3.6.0',
         'zope.cachedescriptors',


### PR DESCRIPTION
Is useful to have these attributes in resources to filter them through Diazo rules.
Sometimes you need to remove or show this resources, for styling motivations.

It could be possible with the last change in webresource library. Webresource v.1.2

Added attribute on Resource declaration

            PloneStyleResource(
               ...,
                **{'data-bundle': name}
            )

