### PR TITLE
Apply Barceloneta upgrades when upgrading Plone.

### DIFF
--- a/Products/CMFPlone/MigrationTool.py
+++ b/Products/CMFPlone/MigrationTool.py
@@ -121,6 +121,7 @@ ADDON_LIST = AddonList([
         profile_id='plone.volto:default',
         check_module='plone.volto'
     ),
+    Addon(profile_id='plonetheme.barceloneta:default'),
 ])
 
 

--- a/news/3726.bugfix
+++ b/news/3726.bugfix
@@ -1,0 +1,2 @@
+Apply Barceloneta upgrades when upgrading Plone.
+[maurits]


### PR DESCRIPTION
An upgrade step was added in plonetheme.barceloneta in September 2022. Also an upgrade step in plone.app.upgrade to re-apply the registry from plonetheme.barceloneta. But in portal_setup Upgrades the package was still marked as upgradable, because its own upgrade step was not run. Just run any upgrade automatically from now on.