### PR TITLE
Implement `pat-checklist` to group membership management

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -91,7 +91,7 @@
                   tal:condition="view/groupMembers">
                 <thead>
                   <tr>
-                      <th>
+                      <th style="width:1rem;">
                           <span class="form-check"><input class="form-check-input toggle-all"
                                   type="checkbox"
                                   name="selectButton"
@@ -206,7 +206,7 @@
                     </thead>
                     <tbody class="pat-checklist">
                       <tr tal:condition="batch">
-                        <th><span class="form-check"><input class="noborder form-check-input toggle-all"
+                        <th style="width:1rem;"><span class="form-check"><input class="noborder form-check-input toggle-all"
                                     type="checkbox"
                                     name="selectButton"
                                     title="Select all items"

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -87,7 +87,7 @@
                               batchformkeys python:['searchstring','_authenticator','groupname','form.submitted'];
                               many_users view/many_users">
               <h2 i18n:translate="heading_groupmembers_current">Current group members</h2>
-              <table class="table table-responsive table-bordered table-striped" summary="Group Members Listing"
+              <table class="table table-responsive table-bordered table-striped pat-checklist" summary="Group Members Listing"
                   tal:condition="view/groupMembers">
                 <thead>
                   <tr>
@@ -204,7 +204,7 @@
                         </th>
                       </tr>
                     </thead>
-                    <tbody>
+                    <tbody class="pat-checklist">
                       <tr tal:condition="batch">
                         <th><span class="form-check"><input class="noborder form-check-input toggle-all"
                                     type="checkbox"

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -119,7 +119,7 @@
 
                         <tal:block tal:condition="python: view.isGroup(this_user)">
                           <td>
-                            <img src="group.png" alt="" />
+                            <img tal:replace="structure python:icons.tag('people')">
                             <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())" >
                               <span tal:replace="this_user/getGroupTitleOrName | default" />
                               (<span tal:replace="this_user/id" />)
@@ -129,7 +129,7 @@
 
                         <tal:block tal:condition="python: not view.isGroup(this_user)">
                           <td>
-                            <img src="user.png" alt="" />
+                            <img tal:replace="structure python:icons.tag('person')">
                             <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
                                                         title this_user/getId">
                                 <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
@@ -234,7 +234,7 @@
 
                           <td>
                               <tal:block tal:condition="python:not view.isGroup(this_user)">
-                                  <img src="user.png" alt="" />
+                                  <img tal:replace="structure python:icons.tag('person')">
                                   <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
                                                               title this_user/getId">
                                     <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
@@ -244,7 +244,7 @@
                                   </a>
                               </tal:block>
                               <tal:block tal:condition="python: view.isGroup(this_user)">
-                                  <img src="group.png" alt="" />
+                                  <img tal:replace="structure python:icons.tag('people')">
                                   <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())">
                                       <span tal:replace="this_user/getGroupTitleOrName | default" />
                                       (<span tal:replace="this_user/id | default" />)

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
@@ -85,10 +85,10 @@
                                 groupId group/getId;"
                     tal:attributes="class python:'odd' if oddrow else 'even'">
                     <td>
+                        <img tal:replace="structure python:icons.tag('people')">
                         <a href="@@usergroup-groupdetails"
                            tal:attributes="href string:@@usergroup-groupdetails?groupname=${groupId}">
-                        <tal:block replace="structure portal/group.png"/>&nbsp;<span
-                                     tal:replace="group/getGroupTitleOrName">group name</span>
+                           <span tal:replace="group/getGroupTitleOrName">group name</span>
                         </a>
                     </td>
 
@@ -161,7 +161,7 @@
                     </td>
 
                     <td>
-                        <img src="group.png" alt="" />
+                        <img tal:replace="structure python:icons.tag('people')">
                         <a href="" tal:attributes="href python:'@@usergroup-groupdetails?'+mq(groupname=obj.getGroupName())"
                                   tal:content="obj/getGroupTitleOrName | default">
                               <span i18n:translate="link_groupname_not_available">

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
@@ -52,16 +52,24 @@
 
     <div id="content-core">
 
+      <p class="lead mt-4" i18n:translate="">Group membership</p>
+
       <div class="autotabs">
-        <nav class="autotoc-nav">
-          <a href="${portal_url}/@@user-information?${userquery}"
-             i18n:translate="title_personal_information_form">Personal Information</a>
-          <a href="${portal_url}/@@user-preferences?${userquery}"
-             i18n:translate="">Personal Preferences</a>
-          <a class="active"
-             href="${portal_url}/@@usergroup-usermembership?${userquery}"
-             i18n:translate="label_group_memberships">Group Memberships</a>
-        </nav>
+        <ul class="autotoc-nav nav nav-tabs">
+          <li class="nav-item">
+            <a class="nav-link" href="${portal_url}/@@user-information?${userquery}"
+            i18n:translate="title_personal_information_form">Personal Information</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="${portal_url}/@@user-preferences?${userquery}"
+            i18n:translate="">Personal Preferences</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active" class="active"
+               href="${portal_url}/@@usergroup-usermembership?${userquery}"
+               i18n:translate="label_group_memberships">Group Memberships</a>
+          </li>
+        </ul>
 
         <form method="post"
               tal:attributes="action string:$portal_url/$template_id?userid=${userid}">
@@ -86,11 +94,11 @@
 
 
                     <td class="listingCheckbox">
-                        <input type="checkbox"
-                               class="noborder notify"
+                        <span class="form-check"><input type="checkbox"
+                               class="noborder notify form-check-input"
                                name="delete:list"
                                tal:attributes="value groupId;
-                                               disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" />
+                                               disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" /></span>
                     </td>
                 </tr>
             </tal:block>
@@ -106,11 +114,11 @@
           <h2 tal:condition="many_groups" i18n:translate="heading_search_groups">Search for groups</h2>
           <h2 tal:condition="not:many_groups" i18n:translate="heading_assign_to_groups">Assign to groups</h2>
 
-          <table class="table overflow-auto table-bordered table-striped text-center" summary="Groups">
+          <table class="table overflow-auto table-bordered table-striped pat-checklist" summary="Groups">
             <tr>
               <th colspan="2" tal:condition="many_groups">
                 <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
-                      <input class="quickSearch"
+                      <input class="quickSearch form-control"
                              type="text"
                              name="searchstring"
                              value=""
@@ -127,16 +135,13 @@
             </tr>
             <tal:block condition="python:results">
                 <tr>
-                  <th>
-                      <input class="noborder"
+                  <th style="width:1.5rem;">
+                      <span class="form-check"><input class="form-check-input toggle-all"
                              type="checkbox"
-                             src="select_all_icon.png"
                              name="selectButton"
                              title="Select all items"
-                             onClick="toggleSelect(this, 'add:list');"
-                             tal:attributes="src string:${context/portal_url}/select_all_icon.png"
                              alt="Select all items"
-                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/></span>
                   </th>
                   <th i18n:translate="listingheader_group_name">Group Name</th>
                 </tr>
@@ -145,14 +150,14 @@
                       tal:attributes="class python:'odd' if oddrow else 'even'">
 
                     <td class="listingCheckbox">
-                      <input type="checkbox"
-                             class="noborder"
+                      <span class="form-check"><input type="checkbox"
+                             class="form-check-input"
                              name="add:list"
                              value="value"
-                                 tal:define="calcId obj/getGroupId | obj/getId;
-                                             canAddToGroup python:member.canAddToGroup(calcId) and ('Manager' not in obj.getRoles() or view.is_zope_manager)"
-                                 tal:attributes="value calcId;
-                                                 disabled python:canAddToGroup and default or 'disabled'" />
+                             tal:define="calcId obj/getGroupId | obj/getId;
+                                         canAddToGroup python:member.canAddToGroup(calcId) and ('Manager' not in obj.getRoles() or view.is_zope_manager)"
+                             tal:attributes="value calcId;
+                                             disabled python:canAddToGroup and default or 'disabled'" /></span>
                     </td>
 
                     <td>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
@@ -71,7 +71,7 @@
           </li>
         </ul>
 
-        <form method="post"
+        <form method="post" class="mt-3"
               tal:attributes="action string:$portal_url/$template_id?userid=${userid}">
 
           <h2 i18n:translate="heading_memberships_current">Current group memberships</h2>
@@ -104,12 +104,11 @@
             </tal:block>
           </table>
           <p tal:condition="not:groups" i18n:translate="text_user_not_in_any_group">This user does not belong to any group.</p>
-          <button class="btn btn-alert"
+          <button class="btn btn-danger mb-4"
                  type="submit"
                  name="form.button.Delete"
-                 value="Remove from selected groups"
-                 i18n:attributes="value label_remove_selected_groups;"
-                 tal:condition="groups" />
+                 i18n:translate="label_remove_selected_groups"
+                 tal:condition="groups">Remove from selected groups</button>
 
           <h2 tal:condition="many_groups" i18n:translate="heading_search_groups">Search for groups</h2>
           <h2 tal:condition="not:many_groups" i18n:translate="heading_assign_to_groups">Assign to groups</h2>
@@ -199,10 +198,8 @@
           <button class="btn btn-primary"
                  type="submit"
                  name="form.button.Add"
-                 value="Add user to selected groups"
                  tal:condition="batch"
-                 i18n:translate=""
-                 i18n:attributes="value label_add_user_to_group;">Add user to selected groups</button>
+                 i18n:translate="label_add_user_to_group">Add user to selected groups</button>
           <input tal:replace="structure context/@@authenticator/authenticator" />
 
         </form>

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
@@ -218,7 +218,7 @@ class TestSiteAdministratorRoleFunctional(unittest.TestCase):
             self.portal_url + '/@@usergroup-usermembership?userid=%s' % self.normal_user)
         contents = self._simplify_white_space(self.browser.contents)
         self.assertTrue(
-            '<input type="checkbox" class="noborder" name="add:list" '
+            '<input type="checkbox" class="form-check-input" name="add:list" '
             'value="Administrators" disabled="disabled" />' in contents
         )
 

--- a/news/3740.bugfix
+++ b/news/3740.bugfix
@@ -1,0 +1,2 @@
+Implement `pat-checklist` for groupuser management.
+[petschki]


### PR DESCRIPTION
fixes #3740 

`pat-checklist` implementation is here https://github.com/plone/mockup/pull/1296 and needs to be merged and released in plone.staticresources.

Note: there are some other small BS5 related updates like `form-check` and missing remove button or translations in `@@usergroup-usermembership` as continuation of #3741 