### PR TITLE
Fix circular dependency in p.a.theming on ZCML level

### DIFF
--- a/Products/CMFPlone/controlpanel/permissions.zcml
+++ b/Products/CMFPlone/controlpanel/permissions.zcml
@@ -51,11 +51,6 @@
       />
 
   <permission
-      id="plone.app.controlpanel.Themes"
-      title="Plone Site Setup: Themes"
-      />
-
-  <permission
       id="plone.app.controlpanel.Types"
       title="Plone Site Setup: Types"
       />

--- a/news/3747.bugfix
+++ b/news/3747.bugfix
@@ -1,0 +1,4 @@
+fix circular depndency in `plone.app.theming` on ZCML level.
+Move permission over there.
+[jensens]
+


### PR DESCRIPTION
Move its controlpanel permission over there. see https://github.com/plone/plone.app.theming/pull/217
Needs test/merge together with this issue.