### PR TITLE
Show warning in Site Setup when using unsupported Plone/Python version [5.2]

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/overview.pt
+++ b/Products/CMFPlone/controlpanel/browser/overview.pt
@@ -23,6 +23,69 @@
 
     <div class="portalMessage warning"
          role="status"
+         tal:condition="view/python2_warning">
+        <strong i18n:translate="">
+            Warning
+        </strong>
+        <span tal:omit-tag="" i18n:translate="text_python2_warning">
+            You are using Python 2.
+            This should only be used temporarily while preparing to migrate to Python 3.
+        </span>
+    </div>
+
+    <div class="portalMessage warning"
+         role="status"
+         tal:condition="view/python_warning">
+        <strong i18n:translate="">
+            Warning
+        </strong>
+        <span tal:omit-tag="" i18n:translate="text_python_warning">
+            You are using a Python version that is not supported.
+        </span>
+    </div>
+
+    <div class="portalMessage warning"
+         role="status"
+         tal:condition="view/plone_maintenance_warning">
+        <strong i18n:translate="">
+            Warning
+        </strong>
+        <span tal:omit-tag="" i18n:translate="text_plone_maintenance_warning">
+            You are using a Plone version that is out of maintenance support.
+        </span>
+    </div>
+
+    <div class="portalMessage warning"
+         role="status"
+         tal:condition="view/plone_security_warning">
+        <strong i18n:translate="">
+            Warning
+        </strong>
+        <span tal:omit-tag="" i18n:translate="text_plone_security_warning">
+            You are using a Plone version that is out of security support.
+        </span>
+    </div>
+
+    <div class="portalMessage warning"
+         role="status"
+         tal:condition="view/version_warning">
+        <strong i18n:translate="">
+            Warning
+        </strong>
+        <span tal:omit-tag="" i18n:translate="text_plone_release_schedule">
+            Go to the
+            <tal:link i18n:name="plone_release_schedule_link">
+                <a href="https://plone.org/download/release-schedule"
+                    i18n:translate="text_plone_release_schedule_link"
+                >Plone release schedule</a>
+            </tal:link>
+            for more information.
+        </span>
+    </div>
+
+
+    <div class="portalMessage warning"
+         role="status"
          tal:condition="view/upgrade_warning">
         <strong i18n:translate="">
             Warning

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+from datetime import date
 from plone.app.testing import PLONE_INTEGRATION_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+
 import mock
 import unittest
 
@@ -24,6 +26,29 @@ def mock_getUtility4(iface):
     return {'plone.app.event.portal_timezone': 'Europe/Amsterdam'}
 
 
+class MockVersionInfo(object):
+    def __init__(self, major, minor, micro=0):
+        self.major = major
+        self.minor = minor
+        self.micro = micro
+
+
+mock_python2 = MockVersionInfo(2, 7)
+mock_python36 = MockVersionInfo(3, 6)
+mock_python37 = MockVersionInfo(3, 7)
+mock_python38 = MockVersionInfo(3, 8)
+mock_python39 = MockVersionInfo(3, 9)
+
+
+class MockDate(object):
+
+    def __init__(self, today):
+        self._today = today
+
+    def today(self):
+        return self._today
+
+
 class TestControlPanel(unittest.TestCase):
 
     layer = PLONE_INTEGRATION_TESTING
@@ -32,6 +57,139 @@ class TestControlPanel(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    @mock.patch('sys.version_info',
+                new=mock_python2)
+    def test_python2_warning(self):
+        # Test the warnings that get shows when using Python 2.7.
+        # Python 2 should only be used temporarily, so we always warn.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertTrue(view.python2_warning())
+        self.assertFalse(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using Python 2.", view())
+
+    @mock.patch('sys.version_info',
+                new=mock_python36)
+    def test_python36_warning(self):
+        # Test the warnings that get shows when using Python 3.6.
+        # Python 3.6 is already end-of-life at the time of writing this test,
+        # so we always warn.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertTrue(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    # We want to mock datetime.date.today, but that gives a TypeError:
+    # can't set attributes of built-in/extension type 'datetime.date'
+    # So use a class as wrapper, and patch the date used in the module.
+    @mock.patch('sys.version_info',
+                new=mock_python37)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2023, 6, 1)))
+    def test_python37_warning_early(self):
+        # Test the warnings that get shows when using Python 3.7.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertFalse(view.python_warning())
+        self.assertFalse(view.version_warning())
+
+    @mock.patch('sys.version_info',
+                new=mock_python37)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2023, 7, 1)))
+    def test_python37_warning_late(self):
+        # Test the warnings that get shows when using Python 3.7.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertTrue(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch('sys.version_info',
+                new=mock_python38)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2024, 10, 1)))
+    def test_python38_warning_early(self):
+        # Test the warnings that get shows when using Python 3.8.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertFalse(view.python_warning())
+        # We *do* already get a warning for a different reason:
+        # Plone 5.2 is out of maintenance support.
+        self.assertTrue(view.version_warning())
+
+    @mock.patch('sys.version_info',
+                new=mock_python38)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2024, 11, 1)))
+    def test_python38_warning_late(self):
+        # Test the warnings that get shows when using Python 3.8.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertTrue(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch('sys.version_info',
+                new=mock_python39)
+    def test_python39_warning(self):
+        # Test the warnings that get shows when using Python 3.9.
+        # 3.9 is too new, so we always warn.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.python2_warning())
+        self.assertTrue(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch('sys.version_info',
+                new=mock_python38)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2023, 10, 1)))
+    def test_plone_warnings_early(self):
+        # Test the warnings that get shows for the Plone version itself.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertFalse(view.plone_maintenance_warning())
+        self.assertFalse(view.plone_security_warning())
+        self.assertFalse(view.version_warning())
+
+    @mock.patch('sys.version_info',
+                new=mock_python38)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2024, 10, 1)))
+    def test_plone_warnings_middle(self):
+        # Test the warnings that get shows for the Plone version itself.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertTrue(view.plone_maintenance_warning())
+        self.assertFalse(view.plone_security_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn(
+            "You are using a Plone version that is out of maintenance support.",
+            view(),
+        )
+
+    @mock.patch('sys.version_info',
+                new=mock_python38)
+    @mock.patch('Products.CMFPlone.controlpanel.browser.overview.date',
+                new=MockDate(date(2024, 11, 1)))
+    def test_plone_warnings_late(self):
+        # Test the warnings that get shows for the Plone version itself.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse('@@overview-controlpanel')
+        self.assertTrue(view.plone_maintenance_warning())
+        self.assertTrue(view.plone_security_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn(
+            "You are using a Plone version that is out of security support.",
+            view(),
+        )
 
     @mock.patch('Products.CMFPlone.controlpanel.browser.overview.getUtility',
                 new=mock_getUtility1)

--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,4 @@
+Show warning in Site Setup when using an unsupported Plone or Python version.
+This is based on dates in the `Plone release schedule <https://plone.org/download/release-schedule>`_
+and the `Status of Python versions <https://devguide.python.org/versions/>`_.
+[maurits]


### PR DESCRIPTION
This is based on dates in the [Plone release schedule](https://plone.org/download/release-schedule) and the [Status of Python versions](https://devguide.python.org/versions/).

I want something similar in Plone 6.0, but there are no definitive dates there yet, so let's leave that for now.

This is how it looks on 5.2 when I temporarily hack it so all warnings are shown.  This gets ugly, but I have no problems with that.

![Screenshot 2023-03-28 at 18 47 42](https://user-images.githubusercontent.com/210587/228356824-fa95c1ce-4fb0-4ae7-9a65-208b0179d216.png)
