### PR TITLE
Don't set "path" for Plone site root

### DIFF
--- a/Products/CMFPlone/browser/search.py
+++ b/Products/CMFPlone/browser/search.py
@@ -2,11 +2,11 @@ from DateTime import DateTime
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.base.batch import Batch
+from plone.base.interfaces.siteroot import IPloneSiteRoot
 from plone.base.interfaces import ISearchSchema
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.browser.navtree import getNavigationRoot
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.ZCTextIndex.ParseTree import ParseError
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getMultiAdapter

--- a/Products/CMFPlone/browser/search.py
+++ b/Products/CMFPlone/browser/search.py
@@ -6,6 +6,7 @@ from plone.base.interfaces import ISearchSchema
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.browser.navtree import getNavigationRoot
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.ZCTextIndex.ParseTree import ParseError
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getMultiAdapter
@@ -142,8 +143,8 @@ class Search(BrowserView):
         query['portal_type'] = self.filter_types(types)
         # respect effective/expiration date
         query['show_inactive'] = False
-        # respect navigation root
-        if 'path' not in query:
+        # respect navigation root if we're not at the site root.
+        if 'path' not in query and not IPloneSiteRoot.providedBy(self.context):
             query['path'] = getNavigationRoot(self.context)
 
         if 'sort_order' in query and not query['sort_order']:

--- a/news/3753.bugfix
+++ b/news/3753.bugfix
@@ -1,0 +1,2 @@
+Removed path query from search view when context is site root.
+[malthe]


### PR DESCRIPTION
It doesn't make sense to add a path query targeting the site root – that's a "noop", only making things slower.

Note that this also helps [collective.multilingual](https://github.com/collective/collective.multilingual/) which has "path" as one of its default exclusion query arguments (that is, if path is provided, we don't add a language filter.)