### PR TITLE
Fixed encoding issue on Python 3 for some mail servers. [5.2]

### DIFF
--- a/Products/CMFPlone/RegistrationTool.py
+++ b/Products/CMFPlone/RegistrationTool.py
@@ -8,7 +8,6 @@ from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import setSecurityManager
 from Acquisition import aq_base
 from Acquisition import aq_chain
-from email import message_from_string
 from hashlib import md5
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import ISiteRoot
@@ -34,6 +33,13 @@ import random
 import re
 import six
 
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 # - remove '1', 'l', and 'I' to avoid confusion
 # - remove '0', 'O', and 'Q' to avoid confusion

--- a/Products/CMFPlone/browser/login/login_help.py
+++ b/Products/CMFPlone/browser/login/login_help.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from email import message_from_string
 from email.header import Header
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
@@ -23,6 +22,14 @@ from zope.interface import implementer
 
 import logging
 import six
+
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 
 SEND_USERNAME_TEMPLATE = _(u"mailtemplate_username_info", default=u"""From: {encoded_mail_sender}

--- a/Products/CMFPlone/tests/mails.txt
+++ b/Products/CMFPlone/tests/mails.txt
@@ -4,8 +4,10 @@ Mail related functional tests
 Some initial setup:
 
   >>> from plone.testing.zope import Browser
+  >>> import six
   >>> app = layer['app']
   >>> browser = Browser(app)
+  >>> browser.handleErrors = False
 
 
 Contact form
@@ -58,12 +60,19 @@ We expect the headers to be properly header encoded (7-bit):
   >>> b'Subject: =?utf-8?q?Some_t=C3=A4st_subject=2E?=' in msg
   True
 
-The output should be encoded in a reasonable manner (in this case
-quoted-printable).  There may be some small differences in where
-exactly the lines are cut off, depending on whether you use five.pt
-(in Zope 2.13) or not, so we turn the message into one line first:
+The output should be encoded in a reasonable manner, in this case quoted-printable.
+On Python 3 there may be problems with quoted printable messages on some mail servers.
+See https://github.com/zopefoundation/Products.MailHost/issues/35
+When '\r\n' is used as line ending, all is well.
+On Python 2 the line endings are plain '\n', but there it is no problem.
 
-  >>> msg.replace(b'=\n', b'').replace(b'\n', b' ')
+  >>> True if six.PY2 else msg.count(b'\r\n') > 0
+  True
+
+There may be some small differences in where exactly the lines are cut off,
+so we turn the message into one line first:
+
+  >>> msg.replace(b'\r\n', b'\n').replace(b'=\n', b'').replace(b'\n', b' ')
   b'...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...'
 
 We can also decode the string, though we should still be careful about

--- a/news/3754.bugfix
+++ b/news/3754.bugfix
@@ -1,0 +1,3 @@
+Fixed encoding issue on Python 3 for some mail servers.
+This could result in missing characters in an email body.
+[maurits]


### PR DESCRIPTION
This could result in missing characters in an email body. See https://github.com/plone/Products.CMFPlone/issues/3754