### PR TITLE
Fixed encoding issue on Python 3 for some mail servers. [6.0]

### DIFF
--- a/Products/CMFPlone/RegistrationTool.py
+++ b/Products/CMFPlone/RegistrationTool.py
@@ -7,7 +7,6 @@ from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import setSecurityManager
 from Acquisition import aq_base
 from Acquisition import aq_chain
-from email import message_from_string
 from hashlib import md5
 from plone.base import PloneMessageFactory as _
 from plone.base.interfaces import ISecuritySchema
@@ -34,6 +33,13 @@ from zope.schema import ValidationError
 import random
 import re
 
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 # - remove '1', 'l', and 'I' to avoid confusion
 # - remove '0', 'O', and 'Q' to avoid confusion

--- a/Products/CMFPlone/browser/contact_info.py
+++ b/Products/CMFPlone/browser/contact_info.py
@@ -1,4 +1,3 @@
-from email.mime.text import MIMEText
 from plone.autoform.form import AutoExtensibleForm
 from plone.base import PloneMessageFactory as _
 from plone.base.interfaces.controlpanel import IMailSchema
@@ -14,6 +13,15 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 
 import logging
+import warnings
+
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 
 log = logging.getLogger(__name__)
@@ -50,9 +58,19 @@ class ContactForm(AutoExtensibleForm, form.Form):
         self.send_feedback()
         self.success = True
 
-    def generate_mail(self, variables, encoding='utf-8'):
+    def generate_mail(self, variables, encoding=None):
         template = self.context.restrictedTraverse(self.template_mailview)
-        return template(self.context, **variables).encode(encoding)
+        result = template(self.context, **variables)
+        if encoding is not None:
+            # Maybe someone has customized 'send_message'
+            # and still expects to get an encoded answer back.
+            warnings.warn(
+                "Calling generate_mail with an encoding argument is deprecated. "
+                "You can leave it out, and get text (string) as result.",
+                DeprecationWarning,
+            )
+            result = result.encode(encoding)
+        return result
 
     def send_message(self, data):
         subject = data.get('subject')
@@ -67,8 +85,12 @@ class ContactForm(AutoExtensibleForm, form.Form):
         host = getToolByName(self.context, 'MailHost')
 
         data['url'] = portal.absolute_url()
-        message = self.generate_mail(data, encoding)
-        message = MIMEText(message, 'plain', encoding)
+        message = self.generate_mail(data)
+        if isinstance(message, bytes):
+            # Maybe someone has customized 'generate_mail'
+            # and still handles the encoding keyword argument.
+            message = message.decode(encoding)
+        message = message_from_string(message)
         message['Reply-To'] = data['sender_from_address']
 
         try:

--- a/Products/CMFPlone/browser/login/login_help.py
+++ b/Products/CMFPlone/browser/login/login_help.py
@@ -1,4 +1,3 @@
-from email import message_from_string
 from email.header import Header
 from plone.base import PloneMessageFactory as _
 from plone.base.interfaces import ILoginHelpForm
@@ -21,6 +20,14 @@ from zope.i18n import translate
 from zope.interface import implementer
 
 import logging
+
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 
 SEND_USERNAME_TEMPLATE = _("mailtemplate_username_info", default="""From: {encoded_mail_sender}

--- a/Products/CMFPlone/tests/mails.txt
+++ b/Products/CMFPlone/tests/mails.txt
@@ -6,6 +6,7 @@ Some initial setup:
   >>> from plone.testing.zope import Browser
   >>> app = layer['app']
   >>> browser = Browser(app)
+  >>> browser.handleErrors = False
 
 
 Contact form
@@ -58,12 +59,18 @@ We expect the headers to be properly header encoded (7-bit):
   >>> b'Subject: =?utf-8?q?Some_t=C3=A4st_subject=2E?=' in msg
   True
 
-The output should be encoded in a reasonable manner (in this case
-quoted-printable).  There may be some small differences in where
-exactly the lines are cut off, depending on whether you use five.pt
-(in Zope 2.13) or not, so we turn the message into one line first:
+The output should be encoded in a reasonable manner, in this case quoted-printable.
+On Python 3 there may be problems with quoted printable messages on some mail servers.
+See https://github.com/zopefoundation/Products.MailHost/issues/35
+When '\r\n' is used as line ending, all is well.
 
-  >>> msg.replace(b'=\n', b'').replace(b'\n', b' ')
+  >>> msg.count(b'\r\n') > 0
+  True
+
+There may be some small differences in where exactly the lines are cut off,
+so we turn the message into one line first:
+
+  >>> msg.replace(b'=\r\n', b'').replace(b'\r\n', b' ')
   b'...Another t=C3=A4st message...You are receiving this mail because T=C3=A4st user test@plone.test...is sending feedback about the site you administer at...'
 
 We can also decode the string, though we should still be careful about

--- a/news/3754.bugfix
+++ b/news/3754.bugfix
@@ -1,0 +1,3 @@
+Fixed encoding issue on Python 3 for some mail servers.
+This could result in missing characters in an email body.
+[maurits]


### PR DESCRIPTION
This could result in missing characters in an email body. See https://github.com/plone/Products.CMFPlone/issues/3754

Forward port of my PR #3759.