### PR TITLE
Cleanup patterns settings

### DIFF
--- a/Products/CMFPlone/browser/configure.zcml
+++ b/Products/CMFPlone/browser/configure.zcml
@@ -224,15 +224,6 @@
       permission="zope2.View"
       />
 
-  <!-- AtD Support -->
-  <browser:page
-      name="checkDocument"
-      for="*"
-      class=".atd.ATDProxyView"
-      attribute="checkDocument"
-      permission="zope2.View"
-      />
-
   <!-- Default Page View -->
   <browser:page
       name="default_page"

--- a/Products/CMFPlone/controlpanel/browser/tinymce.py
+++ b/Products/CMFPlone/controlpanel/browser/tinymce.py
@@ -5,7 +5,6 @@ from plone.base.interfaces import ITinyMCELayoutSchema
 from plone.base.interfaces import ITinyMCEPluginSchema
 from plone.base.interfaces import ITinyMCEResourceTypesSchema
 from plone.base.interfaces import ITinyMCESchema
-from plone.base.interfaces import ITinyMCESpellCheckerSchema
 from z3c.form import field
 from z3c.form import group
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
@@ -14,11 +13,6 @@ from z3c.form.browser.checkbox import CheckBoxFieldWidget
 class TinyMCEPluginForm(group.GroupForm):
     label = _("Plugins and Toolbar")
     fields = field.Fields(ITinyMCEPluginSchema)
-
-
-class TinyMCESpellCheckerForm(group.GroupForm):
-    label = _("Spell Checker")
-    fields = field.Fields(ITinyMCESpellCheckerSchema)
 
 
 class TinyMCEResourceTypesForm(group.GroupForm):
@@ -39,7 +33,6 @@ class TinyMCEControlPanelForm(controlpanel.RegistryEditForm):
     fields = field.Fields(ITinyMCELayoutSchema)
     groups = (
         TinyMCEPluginForm,
-        TinyMCESpellCheckerForm,
         TinyMCEResourceTypesForm,
         TinyMCEAdvancedForm,
     )

--- a/Products/CMFPlone/interfaces/__init__.py
+++ b/Products/CMFPlone/interfaces/__init__.py
@@ -31,7 +31,6 @@ deprecated(
     ITinyMCEPluginSchema="plone.base.interfaces.controlpanel:ITinyMCEPluginSchema",
     ITinyMCEResourceTypesSchema="plone.base.interfaces.controlpanel:ITinyMCEResourceTypesSchema",
     ITinyMCESchema="plone.base.interfaces.controlpanel:ITinyMCESchema",
-    ITinyMCESpellCheckerSchema="plone.base.interfaces.controlpanel:ITinyMCESpellCheckerSchema",
     ITypesSchema="plone.base.interfaces.controlpanel:ITypesSchema",
     IUserGroupsSettingsSchema="plone.base.interfaces.controlpanel:IUserGroupsSettingsSchema",
     IConfigurationChangedEvent="plone.base.interfaces.events:IConfigurationChangedEvent",

--- a/Products/CMFPlone/patterns/settings.py
+++ b/Products/CMFPlone/patterns/settings.py
@@ -156,9 +156,6 @@ class PatternSettingsAdapter:
             "pictureVariants": self.picture_variants,
             "imageCaptioningEnabled": self.image_captioning,
             "linkAttribute": "UID",
-            # This is for loading the languages on tinymce
-            "loadingBaseUrl": "{}/++plone++static/components/tinymce-builded/"
-            "js/tinymce".format(portal_url),
             "relatedItems": related_items_config,
             "prependToScalePart": "/@@images/image/",
             "prependToUrl": "{}/resolveuid/".format(site_path.rstrip("/")),

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -139,31 +139,6 @@ class TinyMCESettingsGenerator:
                 "plonelink ploneimage inserttable |" " cell row column deletetable"
             )
 
-        if settings.libraries_spellchecker_choice == "AtD":
-            mtool = getToolByName(self.context, "portal_membership")
-            member = mtool.getAuthenticatedMember()
-            member_id = member.getId()
-            if member_id:
-                if "compat3x" not in tiny_config["plugins"]:
-                    tiny_config["plugins"].append("compat3x")
-                tiny_config["external_plugins"][
-                    "AtD"
-                ] = "{}/++plone++static/tinymce-AtD-plugin/" "editor_plugin.js".format(
-                    self.nav_root_url
-                )
-                # None when Anonymous User
-                tiny_config["atd_rpc_id"] = "plone-" + member_id
-                tiny_config["atd_rpc_url"] = self.nav_root_url
-                tiny_config["atd_show_types"] = ",".join(
-                    settings.libraries_atd_show_types
-                )
-                tiny_config["atd_ignore_strings"] = ",".join(
-                    settings.libraries_atd_ignore_strings
-                )
-                toolbar_additions.append("AtD")
-        elif settings.libraries_spellchecker_choice == "AtD":
-            tiny_config["browser_spellcheck"] = True
-
         if toolbar_additions:
             tiny_config["toolbar"] += " | {}".format(" ".join(toolbar_additions))
 

--- a/Products/CMFPlone/tests/test_patternsettings.py
+++ b/Products/CMFPlone/tests/test_patternsettings.py
@@ -22,15 +22,6 @@ class TestTinyMCESettings(unittest.TestCase):
         )
         return json.loads(adapter.tinymce()["data-pat-tinymce"])
 
-    def test_atd_included(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(ITinyMCESchema, prefix="plone")
-        settings.libraries_spellchecker_choice = "AtD"
-        login(self.layer["portal"], TEST_USER_NAME)
-        conf = self.get_conf()
-        self.assertTrue("compat3x" in conf["tiny"]["plugins"])
-        self.assertTrue("AtD" in conf["tiny"]["external_plugins"])
-
     def test_style_formats(self):
         conf = self.get_conf()
         self.assertEqual(len(conf["tiny"]["style_formats"]), 5)

--- a/news/3765-1.bugfix
+++ b/news/3765-1.bugfix
@@ -1,0 +1,1 @@
+Mockup TinyMCE settings: Remove unused loadingBaseUrl option.

--- a/news/3765-2.bugfix
+++ b/news/3765-2.bugfix
@@ -1,0 +1,1 @@
+Mockup TinyMCE settings: Remove deprecated AtD plugin settings.

--- a/news/3765-3.bugfix
+++ b/news/3765-3.bugfix
@@ -1,0 +1,1 @@
+Mockup TinyMCE settings: Remove unused AtD related views.

--- a/news/3765-4.bugfix
+++ b/news/3765-4.bugfix
@@ -1,0 +1,1 @@
+Mockup TinyMCE settings: Remove unused ITinyMCESpellCheckerSchema and ITinyMCESpellCheckerForm.


### PR DESCRIPTION
This PR removes the "After the deadline" plugin, which is dead code.
It removes the relevant code parts without a deprecation warning, which is probably not acceptable.
How should I proceed here? Deprecate it for 6.0 and let it be removed for 6.1? Or should this breaking change to into 7.0?

It's not an urgent issue but would remove some code which is most probably unused. 

Together:
https://github.com/plone/Products.CMFPlone/pull/3765
https://github.com/plone/plone.base/pull/33
~~https://github.com/plone/plone.api/pull/504~~ merged
https://github.com/plone/plone.app.upgrade/pull/328

Jenkins:
https://jenkins.plone.org/job/pull-request-6.1-3.11/156/