### PR TITLE
Fix URLs in TinyMCE external_plugins settings

### DIFF
--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -171,7 +171,13 @@ class TinyMCESettingsGenerator:
             parts = plugin.split("|")
             if len(parts) != 2:
                 continue
-            tiny_config["external_plugins"][parts[0]] = parts[1]
+            url = parts[1].strip()
+            if not url:
+                continue
+            if url.find("//", 0, 8) == -1:
+                # assuming relative/absolute w/out url scheme
+                url = f"{self.nav_root_url}/{url}"
+            tiny_config["external_plugins"][parts[0]] = url
 
         tiny_config["style_formats"] = self.get_all_style_formats()
         if settings.formats:

--- a/Products/CMFPlone/tests/test_patternsettings.py
+++ b/Products/CMFPlone/tests/test_patternsettings.py
@@ -44,6 +44,47 @@ class TestTinyMCESettings(unittest.TestCase):
         conf = self.get_conf()
         self.assertEqual(conf['tiny']['foo'], 'bar')
 
+    def test_external_plugins(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ITinyMCESchema, prefix="plone")
+        settings.custom_plugins = [
+            "plugin1|https://example.com/plugin1.js",
+            "plugin2|//example.com/plugin2.js",
+            "plugin3|/plugin3.js",
+            "plugin4|plugin4.js",
+            "plugin5|  plugin5.js  ",
+            "plugin6|../plugin6.js",
+            "plugin7|",
+            "plugin8",
+        ]
+        conf = self.get_conf()
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin1"],
+            "https://example.com/plugin1.js",
+        )
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin2"],
+            "//example.com/plugin2.js",
+        )
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin3"],
+            "http://nohost/plone//plugin3.js",
+        )
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin4"],
+            "http://nohost/plone/plugin4.js",
+        )
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin5"],
+            "http://nohost/plone/plugin5.js",
+        )
+        self.assertEqual(
+            conf["tiny"]["external_plugins"]["plugin6"],
+            "http://nohost/plone/../plugin6.js",
+        )
+        self.assertNotIn("plugin7", conf["tiny"]["external_plugins"])
+        self.assertNotIn("plugin8", conf["tiny"]["external_plugins"])
+
 
 class TestPatternSettingsView(unittest.TestCase):
     """Ensure that the basic redirector setup is successful.

--- a/news/3767.bugfix
+++ b/news/3767.bugfix
@@ -1,0 +1,8 @@
+Mockup TinyMCE settings: Fix URLs in TinyMCE external_plugins settings.
+
+Add the portal URL to external_plugins values for relative and absolute
+URLs.
+
+Before this fix external plugins could not be found if they were not added with
+the full path or a full URL. The path is different for virtual hosted sites and
+sites directly served from Zope.


### PR DESCRIPTION
Mockup TinyMCE settings: Add the portal URL to external_plugins values for relative and absolute URLs.

Before this fix external plugins could not be found if they were not added with the full path or a full URL. The path is different for virtual hosted sites and sites directly served from Zope.