### PR TITLE
Clear the resource viewlet cache on relevant changes

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.pt
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.pt
@@ -68,7 +68,6 @@
         <span class="content"
               i18n:translate="">
             Resources are fast and hashes are cached in Plone.
-            Changes in resource settings are not applied directly.
         </span>
       </div>
     </form>

--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -2,6 +2,7 @@ from App.config import getConfiguration
 from plone.base import PloneMessageFactory as _
 from plone.base.interfaces import IBundleRegistry
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.resources.browser.resource import clear_resource_viewlet_caches
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getUtility
@@ -149,4 +150,5 @@ class ResourceRegistryControlPanelView(BrowserView):
             self._switch_cache(False)
         else:
             raise ValueError("Invalid form data")
+        clear_resource_viewlet_caches()
         self.request.response.redirect(self.request["ACTUAL_URL"])

--- a/Products/CMFPlone/controlpanel/browser/resourceregistry.py
+++ b/Products/CMFPlone/controlpanel/browser/resourceregistry.py
@@ -2,7 +2,7 @@ from App.config import getConfiguration
 from plone.base import PloneMessageFactory as _
 from plone.base.interfaces import IBundleRegistry
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.resources.browser.resource import clear_resource_viewlet_caches
+from Products.CMFPlone.resources.browser.resource import update_resource_registry_mtime
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getUtility
@@ -150,5 +150,5 @@ class ResourceRegistryControlPanelView(BrowserView):
             self._switch_cache(False)
         else:
             raise ValueError("Invalid form data")
-        clear_resource_viewlet_caches()
+        update_resource_registry_mtime()
         self.request.response.redirect(self.request["ACTUAL_URL"])

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -10,6 +10,7 @@ from Products.CMFCore.utils import getToolByName
 from time import time
 from zope.component import getMultiAdapter
 from zope.component import getUtility
+from zope.component import queryUtility
 from zope.component.hooks import getSite
 
 import hashlib
@@ -329,6 +330,9 @@ def update_resource_registry_mtime():
     See discussion in https://github.com/plone/Products.CMFPlone/issues/3505
     and https://github.com/plone/Products.CMFPlone/pull/3771
     """
-    registry = getUtility(IRegistry)
+    registry = queryUtility(IRegistry)
+    if registry is None:
+        # This can happen for example during site creation.
+        return
     setattr(registry, _RESOURCE_REGISTRY_MTIME, time())
     logger.info("Updated resource registry mtime.")

--- a/Products/CMFPlone/resources/configure.zcml
+++ b/Products/CMFPlone/resources/configure.zcml
@@ -3,5 +3,6 @@
     i18n_domain="plone.registry">
 
     <include package=".browser" />
+    <subscriber handler=".eventhandlers.check_registry_update" />
 
 </configure>

--- a/Products/CMFPlone/resources/eventhandlers.py
+++ b/Products/CMFPlone/resources/eventhandlers.py
@@ -1,4 +1,4 @@
-from Products.CMFPlone.resources.browser.resource import clear_resource_viewlet_caches
+from Products.CMFPlone.resources.browser.resource import update_resource_registry_mtime
 from Products.GenericSetup.interfaces import IProfileImportedEvent
 from zope.component import adapter
 
@@ -13,4 +13,4 @@ def check_registry_update(event):
     """
     if not (event.full_import or "plone.app.registry" in event.steps):
         return
-    clear_resource_viewlet_caches()
+    update_resource_registry_mtime()

--- a/Products/CMFPlone/resources/eventhandlers.py
+++ b/Products/CMFPlone/resources/eventhandlers.py
@@ -1,0 +1,16 @@
+from Products.CMFPlone.resources.browser.resource import clear_resource_viewlet_caches
+from Products.GenericSetup.interfaces import IProfileImportedEvent
+from zope.component import adapter
+
+
+@adapter(IProfileImportedEvent)
+def check_registry_update(event):
+    """Check if a profile import may have updated the configuration registry.
+
+    Main concern for now is: the resource registries may have changed.
+    This means the resource viewlet caches should be cleared.
+    See discussion in https://github.com/plone/Products.CMFPlone/issues/3505
+    """
+    if not (event.full_import or "plone.app.registry" in event.steps):
+        return
+    clear_resource_viewlet_caches()

--- a/news/3505.bugfix
+++ b/news/3505.bugfix
@@ -1,0 +1,4 @@
+Clear the resource viewlet cache when changing the resource registry or activating an add-on.
+This avoids needing a restart before seeing changes when you run in production mode.
+Fixes [issue 3505](https://github.com/plone/Products.CMFPlone/issues/3505).
+[maurits]

--- a/news/3505.bugfix
+++ b/news/3505.bugfix
@@ -1,4 +1,5 @@
-Clear the resource viewlet cache when changing the resource registry or activating an add-on.
+Add a last modification time of the resource registry.
+We update this when changing anything related: when changing the resource registry in its control panel or activating an add-on.
 This avoids needing a restart before seeing changes when you run in production mode.
 Fixes [issue 3505](https://github.com/plone/Products.CMFPlone/issues/3505).
 [maurits]


### PR DESCRIPTION
Do this when changing the resource registry or activating an add-on.

This avoids needing a restart before seeing changes when you run in production mode. Fixes [issue 3505](https://github.com/plone/Products.CMFPlone/issues/3505).