### PR TITLE
Fixed TinyMCE menubar settings when creating new Plone Site.

### DIFF
--- a/Products/CMFPlone/interfaces/controlpanel.py
+++ b/Products/CMFPlone/interfaces/controlpanel.py
@@ -489,7 +489,7 @@ class ITinyMCEPluginSchema(Interface):
         missing_value=[],
         default=[
             u'edit', u'table', u'format',
-            u'tools' u'view', u'insert'])
+            u'tools', u'view', u'insert'])
 
     menu = schema.Text(
         title=_('label_tinymce_menu', 'Menu'),

--- a/news/3785.bugfix
+++ b/news/3785.bugfix
@@ -1,0 +1,4 @@
+Fixed TinyMCE menubar settings when creating new Plone Site.
+It contained "toolsview" instead of "tools" and "view" due to a missing comma.
+Nothing goes wrong in Plone 5, but it causes those two menus to miss in Plone 6.
+[maurits]


### PR DESCRIPTION
It contained "toolsview" instead of "tools" and "view" due to a missing comma. Nothing goes wrong in Plone 5, but it causes those two menus to miss in Plone 6. Fixes https://github.com/plone/Products.CMFPlone/issues/3785