### PR TITLE
[6.0] Deprecate `plone.app.widgets`

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -71,7 +71,6 @@ class NonInstallable:
             "plone.app.relationfield",
             "plone.app.theming",
             "plone.app.users",
-            "plone.app.widgets",
             "plone.app.z3cform",
             "plone.formwidget.recurrence",
             "plone.keyring",

--- a/Products/CMFPlone/patterns/settings.py
+++ b/Products/CMFPlone/patterns/settings.py
@@ -2,8 +2,8 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from borg.localrole.interfaces import IFactoryTempFolder
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.widgets.utils import get_relateditems_options
 from plone.app.z3cform.utils import call_callables
+from plone.app.z3cform.widgets.relateditems import get_relateditems_options
 from plone.base.interfaces import IImagingSchema
 from plone.base.interfaces import ILinkSchema
 from plone.base.interfaces import IPatternsSettings

--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -34,22 +34,18 @@ Scenario: Switch tabs
       and no other tab is shown
 
 Scenario: Adding a related item
-    Pass Execution  Disabled until plone.app.widgets is merged
     # Order of the next two lines is important
     # First we're creating a new item and then editing the original page
     Given a logged-in site administrator
       and at least one other item
       and an edited page
      When i click the Categorization tab
-      and i click the add related item button
-      and an overlay pops up
       and i select a related item
-      and i close the overlay
       and i save the page
      Then the related item is shown in the page
 
 Scenario: DateTime widget follows form dropdowns values
-    Pass Execution  Disabled until plone.app.widgets is merged
+    Pass Execution  Disabled because of browser native datepicker
     Given a logged-in site administrator
       and an edited page
      When i click the Dates tab
@@ -58,7 +54,7 @@ Scenario: DateTime widget follows form dropdowns values
      Then popup calendar should have the same date
 
 Scenario: Form dropdowns follows DateTime widget values
-    Pass Execution  Disabled until plone.app.widgets is merged
+    Pass Execution  Disabled because of browser native datepicker
     Given a logged-in site administrator
       and an edited page
      When i click the Dates tab
@@ -92,29 +88,14 @@ I click the ${tab} tab
     Given patterns are loaded
     Click link  ${tab}
 
-I click the add related item button
-    Click Button  xpath=//input[contains(@class, 'addreference')]
-
 I select a related item
-    Click Element  xpath=//div[contains(@class, 'overlay')]//input[@class='insertreference']
-    Wait until keyword succeeds  10s  1s  Xpath Should Match X Times  //ul[@id = 'ref_browser_items_relatedItems']/descendant::input  1
-
-I close the overlay
-   Click Element  xpath=//div[contains(@class, 'overlay')]//div[@class='close']
+    Wait For Then Click Element  jquery=.pat-relateditems-container ul.select2-choices:visible
+    Wait For Then Click Element  jquery=a.pat-relateditems-result-select:first
 
 I save the page
    Click Button  Save
 
-I select a date using the dropdowns
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_year']  2001
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_month']  January
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_day']  01
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_hour']  01
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_minute']  00
-    Select From List By Label  xpath=//select[@id='edit_form_effectiveDate_0_ampm']  AM
-
 I click the calendar icon
-
     Click Element  xpath=//span[@id='edit_form_effectiveDate_0_popup']
     Element Should Be Visible  xpath=//div[@class='calendar']
 
@@ -136,7 +117,7 @@ form dropdowns should not have the default values anymore
     Should Not Be Equal  ${dayLabel}  --
 
 the related item is shown in the page
-   Xpath Should Match X Times  //dl[@id = 'relatedItemBox']/dd  1
+    Page should contain element  css=#section-related
 
 an overlay pops up
     Wait Until Page Contains Element  xpath=//div[contains(@class, 'overlay')]//input[@class='insertreference']

--- a/news/3821.bugfix
+++ b/news/3821.bugfix
@@ -1,0 +1,2 @@
+Update `plone.app.z3cform` dependency version and deprecate `plone.app.widgets`
+[petschki]

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "plone.app.viewletmanager",
         "plone.app.vocabularies",
         "plone.app.workflow",
+        "plone.app.z3cform >= 4.1.0",
         "plone.base",
         "plone.browserlayer >= 2.1.5",
         "plone.contentrules",


### PR DESCRIPTION
backport of #3686 