### PR TITLE
Do not use `UniqueObject` for `PloneSite`

### DIFF
--- a/Products/CMFPlone/Portal.py
+++ b/Products/CMFPlone/Portal.py
@@ -29,7 +29,6 @@ from Products.CMFCore.PortalObject import PortalObjectBase
 from Products.CMFCore.Skinnable import SkinnableObjectManager
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.utils import getToolByName
-from Products.CMFCore.utils import UniqueObject
 from Products.CMFPlone import bbb
 from Products.Five.component.interfaces import IObjectManagerSite
 from zope.event import notify
@@ -45,7 +44,7 @@ if bbb.HAS_ZSERVER:
 
 
 @implementer(IPloneSiteRoot, ISiteRoot, ISyndicatable, IObjectManagerSite)
-class PloneSite(Container, SkinnableObjectManager, UniqueObject):
+class PloneSite(Container, SkinnableObjectManager):
     """The Plone site object."""
 
     security = ClassSecurityInfo()

--- a/news/3823.bugfix
+++ b/news/3823.bugfix
@@ -1,0 +1,2 @@
+Do not use `UniqueObject` class for `PlonePortal`
+[petschki]


### PR DESCRIPTION
Talking at the ArtSprint in Vienna: if you have a Plone site with lowercase Id you cannot add any object with the same Id in the whole zope instance. Trying to get rid of that here.

fixes #3823