### PR TITLE
Explicitly disable ``Products.CMFCore.explicitacquisition`` in Plone 6.

### DIFF
--- a/Products/CMFPlone/__init__.py
+++ b/Products/CMFPlone/__init__.py
@@ -9,6 +9,9 @@ import zope.deferredimport
 
 __version__ = pkg_resources.require("Products.CMFPlone")[0].version
 
+if __version__ < '7':
+    from Products.CMFCore.explicitacquisition import PTA_ENV_KEY
+    os.environ[PTA_ENV_KEY] = os.environ.get(PTA_ENV_KEY, 'false')
 
 cmfplone_globals = globals()
 this_module = sys.modules[__name__]

--- a/news/explicitacquisition.bugfix
+++ b/news/explicitacquisition.bugfix
@@ -1,0 +1,2 @@
+Enable Products.CMFCore.explicitacquisition in Plone 7+
+[jaroel]

--- a/news/explicitacquisition.bugfix
+++ b/news/explicitacquisition.bugfix
@@ -1,2 +1,2 @@
-Enable Products.CMFCore.explicitacquisition in Plone 7+
+Explicitly disable ``Products.CMFCore.explicitacquisition`` in Plone 6.
 [jaroel]


### PR DESCRIPTION
6.0.x counterpart for #3781