### PR TITLE
Patch: do not publish CMFCore folder filter methods. [5.2]

### DIFF
--- a/Products/CMFPlone/patches/publishing.py
+++ b/Products/CMFPlone/patches/publishing.py
@@ -2,11 +2,12 @@
 # From Products.PloneHotfix20160419
 # Plus extras for properties.
 # Plus Products.PloneHotfix20210518.
+# Plus https://github.com/zopefoundation/Products.CMFCore/security/advisories/GHSA-4hpj-8rhv-9x87
 from OFS.PropertyManager import PropertyManager
 #from OFS.ZDOM import Document
 #from OFS.ZDOM import Node
+from Products.CMFCore.PortalFolder import PortalFolderBase
 from Products.CMFPlone.Portal import PloneSite
-
 
 try:
     from plone.dexterity.content import Item
@@ -97,3 +98,10 @@ property_methods = (
 
 for method_name in property_methods:
     delete_method_docstring(PropertyManager, method_name)
+
+folder_filter_methods = (
+    'encodeFolderFilter',
+    'decodeFolderFilter',
+)
+for method_name in folder_filter_methods:
+    delete_method_docstring(PortalFolderBase, method_name)

--- a/news/3826.bugfix
+++ b/news/3826.bugfix
@@ -1,0 +1,2 @@
+Do not publish unused CMFCore folder filter methods.
+[maurits]


### PR DESCRIPTION
See https://github.com/zopefoundation/Products.CMFCore/security/advisories/GHSA-4hpj-8rhv-9x87

These methods are not used in Plone itself.