### PR TITLE
Fix deprecated imports

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/syndication.py
+++ b/Products/CMFPlone/controlpanel/browser/syndication.py
@@ -1,5 +1,5 @@
 from plone.app.registry.browser import controlpanel
-from plone.app.z3cform.widget import SelectFieldWidget
+from plone.app.z3cform.widgets.select import Select2FieldWidget
 from plone.base.interfaces.syndication import ISiteSyndicationSettings
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
@@ -17,7 +17,7 @@ class SyndicationControlPanelForm(controlpanel.RegistryEditForm):
 
     def updateFields(self):
         super().updateFields()
-        self.fields["site_rss_items"].widgetFactory = SelectFieldWidget
+        self.fields["site_rss_items"].widgetFactory = Select2FieldWidget
 
     def getSyndicationSettingsButtonShown(self):
         actions = getToolByName(self.context, "portal_actions")

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -1,8 +1,8 @@
 from lxml import html
-from plone.app.layout.navigation.root import getNavigationRootObject
 from plone.app.theming.utils import theming_policy
 from plone.base.interfaces import IFilterSchema
 from plone.base.interfaces import ITinyMCESchema
+from plone.base.navigationroot import get_navigation_root_object
 from plone.base.utils import safe_text
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
@@ -22,7 +22,7 @@ class TinyMCESettingsGenerator:
         self.filter_settings = getUtility(IRegistry).forInterface(
             IFilterSchema, prefix="plone", check=False
         )
-        self.nav_root = getNavigationRootObject(
+        self.nav_root = get_navigation_root_object(
             self.context,
             get_portal(),
         )

--- a/news/3830.bugfix
+++ b/news/3830.bugfix
@@ -1,0 +1,2 @@
+Fix deprecated imports.
+[petschki]


### PR DESCRIPTION
Note: the `Select2FieldWidget` import only works in `p.a.z3cform` master branch wich targets `CMFPlone` master branch (=6.1)