### PR TITLE
fix: avoid searching all users when many_users is flagged

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
@@ -53,7 +53,6 @@ class GroupMembershipControlPanel(UsersGroupsControlPanelView):
             search = form.get("form.button.Search", None) is not None
             edit = form.get("form.button.Edit", None) is not None and toDelete
             add = form.get("form.button.Add", None) is not None and toAdd
-            isBatched = form.get("b_start", None) is not None
             findAll = (
                 form.get("form.button.FindAll", None) is not None
                 and not self.many_users
@@ -64,7 +63,7 @@ class GroupMembershipControlPanel(UsersGroupsControlPanelView):
             if findAll or unbatchedAll or edit or add:
                 form["searchstring"] = ""
             self.searchString = form.get("searchstring", "")
-            if findAll or isBatched or unbatchedAll or bool(self.searchString):
+            if findAll or bool(self.searchString):
                 self.searchResults = self.getPotentialMembers(self.searchString)
 
             if search or findAll:

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.py
@@ -63,7 +63,7 @@ class GroupMembershipControlPanel(UsersGroupsControlPanelView):
             if findAll or unbatchedAll or edit or add:
                 form["searchstring"] = ""
             self.searchString = form.get("searchstring", "")
-            if findAll or bool(self.searchString):
+            if not (self.many_users) or bool(self.searchString):
                 self.searchResults = self.getPotentialMembers(self.searchString)
 
             if search or findAll:

--- a/news/3845.bugfix
+++ b/news/3845.bugfix
@@ -1,0 +1,1 @@
+avoid searching all users after group editing, when many_users is flagged @mamico


### PR DESCRIPTION
Despite the many_user flag checked, after an action for add or remove user in a group, a search is done without any filter. 
Where, for example Plone has a connected ldap with many users, this is a problem.