### PR TITLE
Content ID check should be more strict (it allows to break objects)

### DIFF
--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -1030,6 +1030,11 @@ def _check_for_collision(contained_by, id, **kwargs):
                 u'There is already an item named ${name} in this folder.',
                 mapping={u'name': id})
 
+    # containers may have a field / attribute of the same name
+    # see original fix in https://github.com/plone/plone.base/issues/35
+    if base_hasattr(contained_by, id):
+        return _("${name} is reserved.", mapping={"name": id})
+    
     if base_hasattr(contained_by, 'checkIdAvailable'):
         # This used to be called from the check_id skin script,
         # which would check the permission automatically,

--- a/news/3847.bugfix
+++ b/news/3847.bugfix
@@ -1,0 +1,2 @@
+Check for container field / attribute when trying to create content with same id
+[laulaz]


### PR DESCRIPTION
The [same fix](https://github.com/plone/plone.base/issues/35) is already there for Plone 6.