### PR TITLE
Fix robot test "When page is linked show warning"

### DIFF
--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -77,15 +77,14 @@ a link in rich text
   Click Button  css=button[aria-label="Insert/edit link"]
 
   Given patterns are loaded
-  # Somehow this does not work:
-  # Wait For Then Click Element  css=.pat-relateditems .select2-input.select2-default
   Wait until element is visible  css=.pat-relateditems .select2-input.select2-default
   Click Element  css=.pat-relateditems .select2-input.select2-default
   Wait until element is visible  css=.pat-relateditems-result.one-level-up a.pat-relateditems-result-browse
   Click Element  css=.pat-relateditems-result.one-level-up a.pat-relateditems-result-browse
   Wait until element is visible  xpath=(//span[contains(., 'Foo')])
+  Sleep  2s
   Click Element  xpath=(//span[contains(., 'Foo')])
-  Wait until page contains  Foo
+  Wait until element is visible  css=.pat-relateditems-item-title
   Wait For Then Click Element  css=.modal-footer .btn-primary
   Wait For Then Click Element  css=#form-buttons-save
 

--- a/news/3902.internal
+++ b/news/3902.internal
@@ -1,0 +1,1 @@
+Fix robot test "When page is linked show warning". @wesleybl


### PR DESCRIPTION
I'm noticing that the `When page is linked show warning` test is failing sometimes. This test consists of creating content 1, selecting it as a link in content 2, trying to delete content 1, showing the message that it is related to content 2.

When the error occurs, it does not show the message that content 1 is related to content 2. It is as if content 1 was not related to any content. I suspect that in the test, another content was selected as a link, instead of content 1. This is because when the test tries to click on content 1 to select as a link, the list of objects is being loaded and moving on the screen. Then we wait some time for the content to remain still on the screen before clicking.