### PR TITLE
Cleanup viewlets.xml to not mention viewlets that no longer exist.

### DIFF
--- a/Products/CMFPlone/profiles/default/viewlets.xml
+++ b/Products/CMFPlone/profiles/default/viewlets.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <object>
-  <order manager="plone.portaltop"
-         skinname="Plone Default"
-  >
 
-  </order>
   <order manager="plone.portalheader"
          skinname="Plone Default"
   >
     <viewlet name="plone.anontools" />
     <viewlet name="plone.membertools" />
     <viewlet name="plone.logo" />
-    <viewlet name="plone.favicon" />
     <viewlet name="plone.searchbox" />
     <viewlet name="plone.app.i18n.locales.languageselector" />
     <viewlet name="plone.app.multilingual.languageselector" />
@@ -37,7 +32,7 @@
     <viewlet name="plone.contributors" />
     <viewlet name="plone.rights" />
     <viewlet name="plone.keywords" />
-    <viewlet name="plone.belowcontentbody.relateditems" />
+    <viewlet name="plone.relateditems" />
   </order>
   <order manager="plone.belowcontent"
          skinname="Plone Default"
@@ -57,10 +52,5 @@
   >
     <viewlet name="plone.colophon" />
     <viewlet name="plone.site_actions" />
-  </hidden>
-  <hidden manager="plone.belowcontent"
-          skinname="Plone Default"
-  >
-    <viewlet name="plone.manage_portlets_fallback" />
   </hidden>
 </object>

--- a/news/3911.bugfix
+++ b/news/3911.bugfix
@@ -1,0 +1,2 @@
+Cleanup `viewlets.xml` to not mention viewlets that no longer exist.
+[maurits]


### PR DESCRIPTION
Nothing really goes wrong with non-existing viewlets, but it is confusing. Fixes https://github.com/plone/Products.CMFPlone/issues/3911

Forward port of the already merged PR #3912.