### PR TITLE
Bugfix for getIcon indexer and conflicting "image" id

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -20,6 +20,7 @@ from plone.base.utils import safe_text
 from plone.i18n.normalizer.base import mapUnicode
 from plone.indexer import indexer
 from plone.indexer.interfaces import IIndexableObject
+from plone.namedfile.interfaces import IImage
 from Products.CMFCore.CatalogTool import _mergedLocalRoles
 from Products.CMFCore.CatalogTool import CatalogTool as BaseTool
 from Products.CMFCore.indexing import processQueue
@@ -234,7 +235,8 @@ def getIcon(obj):
     when obj is an image or has a lead image
     or has an image field with name 'image': true else false
     """
-    return bool(getattr(obj.aq_base, "image", False))
+    img_field = getattr(obj.aq_base, "image", False)
+    return bool(IImage.providedBy(img_field))
 
 
 @indexer(Interface)

--- a/Products/CMFPlone/tests/testCatalogTool.py
+++ b/Products/CMFPlone/tests/testCatalogTool.py
@@ -10,6 +10,7 @@ from plone.app.textfield import RichTextValue
 from plone.indexer.wrapper import IndexableObjectWrapper
 from plone.uuid.interfaces import IAttributeUUID
 from plone.uuid.interfaces import IUUID
+from plone.namedfile.file import NamedImage
 from Products.CMFCore.indexing import processQueue
 from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFPlone.CatalogTool import CatalogTool
@@ -1413,6 +1414,21 @@ class TestIndexers(PloneTestCase):
         wrapped = IndexableObjectWrapper(self.doc, self.portal.portal_catalog)
         self.assertTrue(wrapped.UID)
         self.assertTrue(uuid == wrapped.UID)
+
+    def test_getIcon(self):
+        from Products.CMFPlone.CatalogTool import getIcon
+
+        get_icon = getIcon.callable
+        self.assertFalse(get_icon(self.folder))
+        # Create an item inside the test folder
+        self.folder.invokeFactory("Image", "image", title="Image")
+        # Do not get the "image" content item
+        self.assertFalse(get_icon(self.folder))
+        # Return False if item doesn't have an image
+        self.assertFalse(get_icon(self.folder.image))
+        self.folder.image.image=NamedImage(dummy.Image())
+        # Item has a proper image, return True
+        self.assertTrue(get_icon(self.folder.image))
 
 
 class TestObjectProvidedIndexExtender(unittest.TestCase):

--- a/news/3916.bugfix
+++ b/news/3916.bugfix
@@ -1,0 +1,2 @@
+When indexing for `getIcon`, check that the returned `image` is an instance of `plone.namedfile.interfaces.IImage`
+[frapell]


### PR DESCRIPTION
This PR fixes https://github.com/plone/Products.CMFPlone/issues/3916