### PR TITLE
move condition to parent element

### DIFF
--- a/Products/CMFPlone/browser/templates/search.pt
+++ b/Products/CMFPlone/browser/templates/search.pt
@@ -294,10 +294,10 @@
 
                       <a href="${python:(item_url + '/view') if item_type in use_view_action else item_url}"
                           class="state-${item/review_state}"
+                          tal:condition="python: show_images and hasIcon"
                           tal:define="item_url item/getURL;
                                     item_type item/PortalType">
                           <img class="thumb-icon"
-                            tal:condition="python: show_images and hasIcon"
                             tal:replace="structure python: image_scale.tag(item, 'image', scale=search_image_scale, css_class='thumb-icon')">
                       </a>
 

--- a/news/3919.bugfix
+++ b/news/3919.bugfix
@@ -1,1 +1,1 @@
-Fixes case where empty links would be present in the search results for content that does not have an icon.
+Fixes case where empty links would be present in the search results for content that does not have an icon. @ewohnlich 

--- a/news/3919.bugfix
+++ b/news/3919.bugfix
@@ -1,0 +1,1 @@
+Fixes case where empty links would be present in the search results for content that does not have an icon.


### PR DESCRIPTION
This fixes #3919 where the search results page would sometimes have an 'empty' anchor tag.