### PR TITLE
Update prefsmaintemplate.pt - i18n prefsmaintemplate.pt fix

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/prefsmaintemplate.pt
+++ b/Products/CMFPlone/controlpanel/browser/prefsmaintemplate.pt
@@ -42,7 +42,7 @@
                                 <img tal:condition="icon_url"
                                     src="" alt="" class="icon"
                                     tal:attributes="src configlet/icon;
-                                                    alt configlet/title"
+                                                    alt"
                                     i18n:attributes="alt">
                                 <tal:icon tal:condition="not: icon_url"
                                           tal:replace="structure python:icons.tag(configlet['icon'] or 'plone-controlpanel', tag_alt=configlet['title'])" />

--- a/news/3920.bugfix
+++ b/news/3920.bugfix
@@ -1,0 +1,2 @@
+i18n fix for prefsmaintemplate.pt
+[yurj]


### PR DESCRIPTION
To correct "zope.tal.taldefs.I18NError: attribute [alt] cannot both be part of tal:attributes and have a msgid in i18n:attributes" as in https://github.com/plone/Products.CMFPlone/commit/cbb726858c848075a8de73e37b7c0b5b6b189824 for 6.1.X