### PR TITLE
Fix test Scenario: Select All items

### DIFF
--- a/Products/CMFPlone/tests/robot/test_folder_contents.robot
+++ b/Products/CMFPlone/tests/robot/test_folder_contents.robot
@@ -60,7 +60,7 @@ I click the '${link_name}' link
 
 I select all the elements
     Wait until page contains element  css=.pat-structure .select-all
-    Wait until page contains element  css=.itemRow
+    Sleep  1s
     ${select_all_selector}  Set Variable  .pat-structure .select-all
     Wait Until Element Is Visible  css=${select_all_selector}
     Click Element  css=${select_all_selector}

--- a/news/3929.internal
+++ b/news/3929.internal
@@ -1,0 +1,1 @@
+Fix test Scenario: Select All items. @wesleybl


### PR DESCRIPTION
Fix intermittent failure in test robot. Sometimes waiting for the element with the `itemRow` class fails despite it being on the screen. So we wait 1 second instead of waiting for the element.

Fix: https://jenkins.plone.org/job/pull-request-6.1-3.10/2/robot/report/robot_log.html#s1-s9-t1