### PR TITLE
Fix failing test after pa.z3cfrom.widget to ..widgets move

### DIFF
--- a/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
+++ b/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt
@@ -111,7 +111,7 @@ We edit the document properties:
 
 We make sure the language is English at the beginning:
 
-    >>> browser.getControl(name='form.widgets.IDublinCore.language').displayValue
+    >>> browser.getControl(name='form.widgets.IDublinCore.language:list').displayValue
     ['English']
 
 And the content language is set to the default:
@@ -121,8 +121,8 @@ And the content language is set to the default:
 
 Now set the language to German:
 
-    >>> browser.getControl(name='form.widgets.IDublinCore.language').value = ['de']
-    >>> browser.getControl(name='form.widgets.IDublinCore.language').displayValue
+    >>> browser.getControl(name='form.widgets.IDublinCore.language:list').value = ['de']
+    >>> browser.getControl(name='form.widgets.IDublinCore.language:list').displayValue
     ['Deutsch']
 
     >>> browser.getControl('Save').click()


### PR DESCRIPTION
After fixing the https://github.com/plone/plone.app.dexterity/pull/387 deprecation warning the signature of the widget name slightly changed.
This goes together with above PR.