### PR TITLE
we do not need to depend on CMFEditions here

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         "plone.staticresources",
         "plone.theme",
         "plonetheme.barceloneta",
-        "Products.CMFEditions",
         "Products.DCWorkflow",
         "Products.ExtendedPathIndex",
         "Products.isurlinportal",


### PR DESCRIPTION
plone.app.iterate as a core-addon should be the only one depending on Products.CMFEditions. 
All related tests and so on should go there. It is okayish to have the exclusions by string in here. 

