### PR TITLE
Fix duplicate "content" id in controlpanels

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupdetails.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupdetails.pt
@@ -17,7 +17,7 @@
 
 
   <!-- When no group is specified, this gets used as the add group page page -->
-  <article id="content" tal:condition="not:view/group">
+  <tal:not_group tal:condition="not:view/group">
       <metal:block metal:use-macro="template/macros/props">
           <metal:title metal:fill-slot="content-title">
               <h1 class="documentFirstHeading"
@@ -39,9 +39,9 @@
               </div>
           </metal:name>
       </metal:block>
-  </article>
+  </tal:not_group>
 
-  <article id="content" tal:condition="view/group | nothing">
+  <tal:group tal:condition="view/group | nothing">
     <metal:block define-macro="props">
 
       <a href="${portal_url}/@@usergroup-groupprefs"
@@ -211,7 +211,7 @@
         </div>
       </div>
     </metal:block>
-  </article>
+  </tal:group>
 
 </metal:main>
 

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupmembership.pt
@@ -13,7 +13,7 @@
                  errors python:request.get('errors', {});
                  portal_roles view/portal_roles;">
 
-  <article id="content">
+  <tal:content>
 
     <tal:ifnogroups tal:condition="not:view/group | nothing">
       <h1 class="documentFirstHeading"
@@ -332,7 +332,7 @@
       </tal:defs>
     </tal:ifgroups>
 
-  </article>
+  </tal:content>
 
 </metal:main>
 </body>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_groupsoverview.pt
@@ -21,7 +21,7 @@
                         batchformkeys python:['searchstring','_authenticator'];
                         portal_url context/portal_url;">
 
-  <article id="content">
+  <tal:content>
     <header>
         <h1 class="documentFirstHeading"
             i18n:translate="">Groups</h1>
@@ -207,7 +207,7 @@
             </div>
         </form>
     </div>
-  </article>
+  </tal:content>
 
 </metal:main>
 </body>

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usermembership.pt
@@ -31,7 +31,7 @@
                  batch python:Batch(view.searchResults, b_size, int(b_start));
                  batchformkeys python:['searchstring','_authenticator', 'userid'];">
 
-  <article id="content" tal:define="many_groups view/many_groups">
+  <tal:many_groups tal:define="many_groups view/many_groups">
 
     <a href=""
        class="link-parent"
@@ -206,7 +206,7 @@
 
       </div>
     </div>
-  </article>
+  </tal:many_groups>
 
 </metal:main>
 

--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.pt
@@ -17,7 +17,7 @@
                 portal_roles view/portal_roles;
                 portal_url context/portal_url;">
 
-    <article id="content">
+    <tal:content>
 
     <header>
 
@@ -225,7 +225,7 @@
       </div>
     </div>
 
-  </article>
+  </tal:content>
 
 </metal:main>
 

--- a/news/3964.bugfix
+++ b/news/3964.bugfix
@@ -1,0 +1,2 @@
+Removes duplicate `<article id="content">` in controlpanel templates
+[@szakitibi]


### PR DESCRIPTION
The master template already defines an `<article id="content">` - see here:

https://github.com/plone/Products.CMFPlone/blob/59c028fd633ce360b926f5b8dc5da068d310a80f/Products/CMFPlone/browser/templates/main_template.pt#L85

The preferences main template used for controlpanels is also based on master template, as a result there is two `<article id="content">` in some of the controlpanels. For example check the source for https://classic.demo.plone.org/@@usergroup-groupprefs or https://classic.demo.plone.org/@@usergroup-userprefs.