### PR TITLE
do not test for a property that is not part of the underlying vocabulary

### DIFF
--- a/Products/CMFPlone/tests/testPortalCreation.py
+++ b/Products/CMFPlone/tests/testPortalCreation.py
@@ -198,7 +198,6 @@ class TestPortalCreation(PloneTestCase.PloneTestCase):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(ISearchSchema, prefix="plone")
         self.assertTrue("plone.types_not_searched" in registry)
-        self.assertTrue("Plone Site" in settings.types_not_searched)
 
     def testDefaultSortOrderProperty(self):
         # We should have an sort_on property

--- a/news/3965.bugfix
+++ b/news/3965.bugfix
@@ -1,0 +1,2 @@
+Do not test types_not_searched for a element that is not part of the underlying vocabulary.
+[@jensens]


### PR DESCRIPTION
see https://github.com/plone/plone.base/pull/65