### PR TITLE
Plone upgrade page: show missing packages

### DIFF
--- a/Products/CMFPlone/browser/admin.py
+++ b/Products/CMFPlone/browser/admin.py
@@ -1,6 +1,8 @@
 from AccessControl import getSecurityManager
 from AccessControl.Permissions import view as View
 from collections import OrderedDict
+from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError
 from OFS.interfaces import IApplication
 from plone.base.interfaces import INonInstallable
 from plone.base.interfaces import IPloneSiteRoot
@@ -35,14 +37,18 @@ from zope.schema.interfaces import IVocabularyFactory
 from ZPublisher.BaseRequest import DefaultPublishTraverse
 
 import logging
-import pkg_resources
 
 
 try:
-    pkg_resources.get_distribution("plone.volto")
+    distribution("plone.volto")
     HAS_VOLTO = True
-except pkg_resources.DistributionNotFound:
+except PackageNotFoundError:
     HAS_VOLTO = False
+try:
+    distribution("plone.app.upgrade")
+    HAS_UPGRADE = True
+except PackageNotFoundError:
+    HAS_UPGRADE = False
 LOGGER = logging.getLogger("Products.CMFPlone")
 
 
@@ -313,6 +319,8 @@ class AddPloneSite(BrowserView):
 
 
 class Upgrade(BrowserView):
+    has_upgrade = HAS_UPGRADE
+
     def upgrades(self):
         pm = getattr(self.context, "portal_migration")
         return pm.listUpgrades()

--- a/Products/CMFPlone/browser/templates/plone-upgrade.pt
+++ b/Products/CMFPlone/browser/templates/plone-upgrade.pt
@@ -46,6 +46,12 @@
         </header>
         <article class="row mb-4">
           <div class="col-md-12 mb-3">
+            <div class="alert alert-danger" tal:condition="view/missing_packages">
+              <p><strong i18n:translate="msg_missing_packages">The following packages were previously installed, but are currently missing. This may be a problem.</strong></p>
+              <ul>
+                <li tal:repeat="package view/missing_packages">${package}</li>
+              </ul>
+            </div>
             <p class="alert alert-success p-2" tal:condition="versions/equal">
               <span i18n:translate="" tal:omit-tag="">Your site is up to date.</span>
             </p>

--- a/Products/CMFPlone/browser/templates/plone-upgrade.pt
+++ b/Products/CMFPlone/browser/templates/plone-upgrade.pt
@@ -21,6 +21,7 @@
 
 <body id="plone-upgrade-screen"
       tal:define="versions view/versions;
+                  upgrades view/upgrades;
                   report options/report|nothing;">
 
     <div class="container admin mt-5 mb-5 p-4">
@@ -101,7 +102,7 @@
           </p>
 
           <dl class="mb-4">
-            <tal:block tal:repeat="upgrade_info view/upgrades">
+            <tal:block tal:repeat="upgrade_info upgrades">
 
                 <tal:single condition="python:not isinstance(upgrade_info, list)"
                             define="info upgrade_info">
@@ -144,9 +145,20 @@
           </div>
         </div>
 
+        <p class="alert alert-danger p-2" tal:condition="not:upgrades">
+          <span i18n:translate="msg_no_upgrades">
+            No upgrade steps are available.
+          </span>
+          <strong tal:condition="not:view/has_upgrade"
+                i18n:translate="msg_plone_app_upgrade_missing">
+            The plone.app.upgrade package is missing.
+          </strong>
+        </p>
+
         <input type="hidden" name="form.submitted:boolean" value="True" />
         <button type="submit"
                 name="submit"
+                tal:attributes="disabled python:'disabled' if not upgrades else ''"
                 class="btn btn-primary"
                 i18n:translate="" >Upgrade</button>
     </form>

--- a/news/3975.bugfix.1
+++ b/news/3975.bugfix.1
@@ -1,0 +1,3 @@
+Plone upgrade page: show error when upgrade is needed but no upgrades are available.
+Especially show a note when the `plone.app.upgrade` package is not available.
+[maurits]

--- a/news/3975.bugfix.2
+++ b/news/3975.bugfix.2
@@ -1,0 +1,3 @@
+Plone upgrade page: show list of previously installed packages that are currently missing.
+For example: `plone.app.discussion` may be missing in Plone 6.1, unless you explicitly add it, or depend on the `Plone` package.
+[maurits]


### PR DESCRIPTION
Fixes issue #3975.

This does the following:

1. It shows which packages were previously installed (with GenericSetup) but are currently not available.  Example is `plone.app.discussion` which will be missing in Plone 6.1 if you only use `Products.CMFPlone`.
2. It shows an error when the site needs upgrading but there are no upgrades available.  Most likely cause is that `plone.app.upgrade` is missing, so we explicitly check this.
3. If no upgrades are there, we disable the Upgrade button.

It looks like this:

<img width="611" alt="Screenshot 2024-06-15 at 14 00 21" src="https://github.com/plone/Products.CMFPlone/assets/210587/680b863a-88de-491f-a8fa-de8a5b9b0fbb">

