### PR TITLE
Do not use deprecated base_hasattr in utils.py. [6.0]

### DIFF
--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_maintenance.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_maintenance.py
@@ -1,4 +1,3 @@
-from pkg_resources import get_distribution
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.zope import Browser
@@ -6,9 +5,6 @@ from plone.testing.zope import login
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_FUNCTIONAL_TESTING
 
 import unittest
-
-
-has_zope4 = get_distribution("Zope2").version.startswith("4")
 
 
 class MaintenanceControlPanelFunctionalTest(unittest.TestCase):

--- a/Products/CMFPlone/utils.py
+++ b/Products/CMFPlone/utils.py
@@ -163,11 +163,11 @@ def isExpired(content):
     # convert to a DateTime
 
     # Try DC accessor first
-    if base_hasattr(content, "ExpirationDate"):
+    if base_utils.base_hasattr(content, "ExpirationDate"):
         expiry = content.ExpirationDate
 
     # Try the direct way
-    if not expiry and base_hasattr(content, "expires"):
+    if not expiry and base_utils.base_hasattr(content, "expires"):
         expiry = content.expires
 
     # See if we have a callable
@@ -675,13 +675,13 @@ def _check_for_collision(contained_by, id, **kwargs):
     # Check for an existing object.
     if id in contained_by:
         existing_obj = getattr(contained_by, id, None)
-        if base_hasattr(existing_obj, "portal_type"):
+        if base_utils.base_hasattr(existing_obj, "portal_type"):
             return _(
                 "There is already an item named ${name} in this folder.",
                 mapping={"name": id},
             )
 
-    if base_hasattr(contained_by, "checkIdAvailable"):
+    if base_utils.base_hasattr(contained_by, "checkIdAvailable"):
         # This used to be called from the check_id skin script,
         # which would check the permission automatically,
         # and the code would catch the Unauthorized exception.
@@ -690,7 +690,7 @@ def _check_for_collision(contained_by, id, **kwargs):
                 return _("${name} is reserved.", mapping={"name": id})
 
     # containers may implement this hook to further restrict ids
-    if base_hasattr(contained_by, "checkValidId"):
+    if base_utils.base_hasattr(contained_by, "checkValidId"):
         try:
             contained_by.checkValidId(id)
         except ConflictError:

--- a/news/3998.bugfix
+++ b/news/3998.bugfix
@@ -1,0 +1,2 @@
+Do not use deprecated `base_hasattr` in `utils.py`.
+[maurits]


### PR DESCRIPTION
This was moved to plone.base.utils, so utils.py should not be using its own deprecated import.

In fact, this gives a strange error when running the `Products.validation` tests in the coredev 6.0 buildout:

```
$ bin/test -s Products.validation
...
Error in test test_isValidId_plone (Products.validation.tests.test_validation.TestValidation.test_isValidId_plone)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.11.9/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.11.9/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.11.9/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.validation/Products/validation/tests/test_validation.py", line 154, in test_isValidId_plone
    self.assertEqual(v('good', obj), 1)
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.validation/Products/validation/validators/IdValidator.py", line 69, in __call__
    result = check_id(instance, id, required=kwargs.get('required'))
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.CMFPlone/Products/CMFPlone/utils.py", line 641, in check_id
    result = _check_for_collision(contained_by, id, **kwargs)
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.CMFPlone/Products/CMFPlone/utils.py", line 684, in _check_for_collision
    if base_hasattr(contained_by, "checkIdAvailable"):
NameError: name 'base_hasattr' is not defined
```

One strange thing here is that the error only shows up when you run these packae tests in isolation.  A full `bin/test` in coredev 6.0 works.