### PR TITLE
Use five.registerPackage so an editable install with pip works. [6.1]

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -2,11 +2,13 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:cmf="http://namespaces.zope.org/cmf"
+    xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone"
     >
 
+  <five:registerPackage package="." initialize=".initialize" />
   <!-- basic zope/cmf -->
   <include package="zope.app.locales" />
   <include package="Products.CMFCore" />

--- a/news/4002.bugfix
+++ b/news/4002.bugfix
@@ -1,0 +1,2 @@
+Use `five.registerPackage` so an editable install with `pip` works.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/4002