### PR TITLE
Update help text for redirector target path

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/redirects-controlpanel.pt
+++ b/Products/CMFPlone/controlpanel/browser/redirects-controlpanel.pt
@@ -124,7 +124,7 @@
             </div>
 
             <small class="formHelp form-text text-muted" i18n:translate="help_target_path">
-              Enter the absolute path of the target. The path must start with '/'.
+              Enter the absolute path of the target.
               Target must exist or be an existing alternative url path to the target.
             </small>
 

--- a/news/4007.bugfix
+++ b/news/4007.bugfix
@@ -1,0 +1,1 @@
+Fix help text for redirect target path. @davisagli


### PR DESCRIPTION
plone.app.redirector supports redirecting to external URLs, so we shouldn't say the target has to start with a slash.