### PR TITLE
No longer hide plone.app.caching from Add-ons control panel.

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -60,7 +60,6 @@ class NonInstallable:
             "Products.CMFEditions",
             "Products.NuPlone",
             "borg.localrole",
-            "plone.app.caching",
             "plone.app.dexterity",
             "plone.app.event",
             "plone.app.intid",

--- a/news/139.bugfix
+++ b/news/139.bugfix
@@ -1,0 +1,3 @@
+No longer hide plone.app.caching from Add-ons control panel.
+It is a core add-on, so you should be able to activate it if you add the package later.
+[maurits]


### PR DESCRIPTION
It is a core add-on, so you should be able to activate it if you add the package later.

This is part of https://github.com/plone/plone.app.caching/issues/139

Test this together with https://github.com/plone/plone.app.caching/pull/142