### PR TITLE
[6.1] Restore the capability of the resource registry to serve OFS files as resources

### DIFF
--- a/Products/CMFPlone/resources/utils.py
+++ b/Products/CMFPlone/resources/utils.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from OFS.Image import File
 from plone.base.interfaces.resources import OVERRIDE_RESOURCE_DIRECTORY_NAME
 from plone.resource.file import FilesystemFile
 from plone.resource.interfaces import IResourceDirectory
@@ -75,9 +76,15 @@ def get_resource(context, path):
     if hasattr(aq_base(resource), "GET"):
         # for FileResource
         result = resource.GET()
-    else:
+    elif isinstance(resource, File):
+        # An OFS.Image.File object
+        result = resource.data
+    elif callable(resource):
         # any BrowserView
         result = resource()
+    else:
+        logger.info("Cannot get data from resource %r", resource)
+        result = b""
     context.REQUEST.response = response_before
     return result
 

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -1,3 +1,4 @@
+from OFS.Image import File
 from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
@@ -13,6 +14,7 @@ from Products.CMFPlone.resources import remove_bundle_on_request
 from Products.CMFPlone.resources.browser.resource import REQUEST_CACHE_KEY
 from Products.CMFPlone.resources.browser.resource import ScriptsView
 from Products.CMFPlone.resources.browser.resource import StylesView
+from Products.CMFPlone.resources.webresource import PloneScriptResource
 from Products.CMFPlone.tests import PloneTestCase
 from zope.component import getUtility
 
@@ -180,6 +182,30 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         # bundle should be skipped when rendering
         self.assertNotIn("http://foo.bar/foobar.js", results)
 
+    def test_resource_browser_static_resource(self):
+        resource = PloneScriptResource(self.portal, resource="++resource++plone-admin-ui.js")
+        self.assertIn(
+            b"window.onload", resource.file_data,
+        )
+
+    def test_resource_ofs_file(self):
+        self.portal["foo.js"] = File("foo.js", "Title", b'console.log()')
+        resource = PloneScriptResource(self.portal, resource="foo.js")
+        self.assertEqual(
+            resource.file_data, b'console.log()',
+        )
+
+    def test_resource_view(self):
+        resource = PloneScriptResource(self.portal, resource="@@ok")
+        self.assertEqual(
+            resource.file_data, b'OK',
+        )
+
+    def test_resource_bogus(self):
+        resource = PloneScriptResource(self.portal, resource="I_do_not_exist")
+        self.assertEqual(
+            resource.file_data, b'I_do_not_exist',
+        )
 
 class TestStylesViewlet(PloneTestCase.PloneTestCase):
     def test_styles_viewlet(self):

--- a/news/4022.bugfix
+++ b/news/4022.bugfix
@@ -1,0 +1,2 @@
+Resource registry: Support OFS.Image.File objects.
+[ale-rt, thet]


### PR DESCRIPTION
This was possible in Plone 5.2 and broken by the upgrade to Plone 6. Do not break if the resource is not found or callable.