### PR TITLE
Fix robot test Scenario After you fix linked page no longer show warning

### DIFF
--- a/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -95,6 +95,7 @@ a link in rich text
 should show warning when deleting page
 
   Go To  ${PLONE_URL}/foo
+  Wait Until Element Contains  xpath=//h1  Foo  10s
   Wait For Then Click Element  css=#plone-contentmenu-actions > a
   Wait For Then Click Element  css=#plone-contentmenu-actions-delete
   Wait until page contains element  css=.breach-container .breach-item

--- a/news/4025.bugfix
+++ b/news/4025.bugfix
@@ -1,0 +1,1 @@
+Fix robot test "Scenario After you fix linked page no longer show warning". @wesleybl


### PR DESCRIPTION
Wait for page Foo to load before clicking delete.

Fixes: 

```
Element 'css=.breach-container .breach-item' did not appear in 7 seconds.
```

See: https://jenkins.plone.org/job/pull-request-6.1-3.12/707/robot/report/robot_log.html#s1-s25