### PR TITLE
Fix possible `Pdata` objects in `OFS.File` resources

### DIFF
--- a/Products/CMFPlone/resources/utils.py
+++ b/Products/CMFPlone/resources/utils.py
@@ -77,8 +77,8 @@ def get_resource(context, path):
         # for FileResource
         result = resource.GET()
     elif isinstance(resource, File):
-        # An OFS.Image.File object
-        result = resource.data
+        # An OFS.Image.File object. use bytes() to resolve possible Pdata objects
+        return bytes(resource.data)
     elif callable(resource):
         # any BrowserView
         result = resource()

--- a/news/4038.bugfix
+++ b/news/4038.bugfix
@@ -1,0 +1,2 @@
+Fix uploading themes with large resources in theming control panel.
+[petschki]


### PR DESCRIPTION
If you upload a theme in the theming controlpanel and the CSS or JS files are big, you get a `OFS.Pdata` object from `resource.data` ... this can be resolved by using `bytes(resource.data)`