### PR TITLE
Avoid POSKeyError when commit occurs and we have savepoint that involves Plone Site

### DIFF
--- a/Products/CMFPlone/Portal.py
+++ b/Products/CMFPlone/Portal.py
@@ -65,7 +65,7 @@ class PloneSite(Container, SkinnableObjectManager, UniqueObject):
 
     def __setattr__(self, name, obj):
         # handle re setting an item as an attribute
-        if self._tree is not None and name in self:
+        if not name.startswith("_") and self._tree is not None and name in self:
             del self[name]
             self[name] = obj
         else:

--- a/news/4043.bugfix
+++ b/news/4043.bugfix
@@ -1,0 +1,1 @@
+Avoid POSKeyError when commit occurs and we have savepoint that involves Plone Site. @wesleybl


### PR DESCRIPTION
When ZODB handles savepoint and we have changes in Plone Site at that savepoint, it changes the `_p_estimated_size` attribute of Plone Site. This is an assignment to one of the special persistency attributes (identified by an _p_ name prefix); it should happen without access to any other attributes of obj. But obj._tree is accessed in __setattr__ of PloneSite class and results in a ZODB load which apparently fails.

See: https://github.com/plone/plone.restapi/pull/1823#issuecomment-2402855105

Backport of: #4026 to Plone 6.0