### PR TITLE
Update content filtering options for TinyMCE

### DIFF
--- a/Products/CMFPlone/patterns/settings.py
+++ b/Products/CMFPlone/patterns/settings.py
@@ -1,9 +1,8 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from borg.localrole.interfaces import IFactoryTempFolder
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.z3cform.utils import call_callables
-from plone.app.z3cform.widgets.relateditems import get_relateditems_options
+from plone.app.z3cform.widgets.contentbrowser import get_contentbrowser_options
 from plone.base.interfaces import IImagingSchema
 from plone.base.interfaces import ILinkSchema
 from plone.base.interfaces import IPatternsSettings
@@ -117,9 +116,6 @@ class PatternSettingsAdapter:
         settings = generator.settings
         folder = aq_inner(self.context)
 
-        # Test if we are currently creating an Archetype object
-        if IFactoryTempFolder.providedBy(aq_parent(folder)):
-            folder = aq_parent(aq_parent(aq_parent(folder)))
         if not IFolderish.providedBy(folder):
             folder = aq_parent(folder)
 
@@ -137,7 +133,7 @@ class PatternSettingsAdapter:
         server_url = self.request.get("SERVER_URL", "")
         site_path = portal_url[len(server_url) :]
 
-        related_items_config = get_relateditems_options(
+        contentbrowser_config = get_contentbrowser_options(
             context=self.context,
             value=None,
             separator=";",
@@ -145,7 +141,7 @@ class PatternSettingsAdapter:
             vocabulary_view="@@getVocabulary",
             field_name=None,
         )
-        related_items_config = call_callables(related_items_config, self.context)
+        contentbrowser_config = call_callables(contentbrowser_config, self.context)
 
         configuration = {
             "base_url": self.context.absolute_url(),
@@ -156,7 +152,8 @@ class PatternSettingsAdapter:
             "pictureVariants": self.picture_variants,
             "imageCaptioningEnabled": self.image_captioning,
             "linkAttribute": "UID",
-            "relatedItems": related_items_config,
+            # we keep "relatedItems" option but use the new contentbrowser_options
+            "relatedItems": contentbrowser_config,
             "prependToScalePart": "/@@images/image/",
             "prependToUrl": "{}/resolveuid/".format(site_path.rstrip("/")),
             "inline": settings.inline,

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -177,22 +177,13 @@ class TinyMCESettingsGenerator:
 
         # add safe_html settings, which are used in backend for filtering:
         if not self.filter_settings.disable_filtering:
-            valid_tags = self.filter_settings.valid_tags
+            # we just enable the general html5 filtering set from TinyMCE
+            # (See https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#schema)
+            # and add the "nasty_tags" as "invalid_elements"
+            tiny_config["schema"] = "html5"
+            # filter out invalid elements early
             nasty_tags = self.filter_settings.nasty_tags
-            custom_attributes = self.filter_settings.custom_attributes
-            safe_attributes = [safe_text(attr) for attr in html.defs.safe_attrs]
-            valid_attributes = safe_attributes + custom_attributes
-            # valid_elements : 'a[href|target=_blank],strong/b,div[align],br'
-            tiny_valid_elements = []
-            for tag in valid_tags:
-                tag_str = "{}[{}]".format(tag, "|".join(valid_attributes))
-                tiny_valid_elements.append(tag_str)
-            # We want to remove the nasty tag including the content in the
-            # backend, so TinyMCE should allow them here.
-            for tag in nasty_tags:
-                tag_str = "{}[{}]".format(tag, "|".join(valid_attributes))
-                tiny_valid_elements.append(tag_str)
-            tiny_config["valid_elements"] = ",".join(tiny_valid_elements)
+            tiny_config["invalid_elements"] = ",".join(nasty_tags)
 
         if settings.other_settings:
             try:

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -1,11 +1,8 @@
-from lxml import html
 from plone.app.theming.utils import theming_policy
 from plone.base.interfaces import IFilterSchema
 from plone.base.interfaces import ITinyMCESchema
 from plone.base.navigationroot import get_navigation_root_object
-from plone.base.utils import safe_text
 from plone.registry.interfaces import IRegistry
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_portal
 from zope.component import getUtility
 

--- a/news/3204.bugfix
+++ b/news/3204.bugfix
@@ -1,0 +1,3 @@
+Update `pat-tinymce` options: implement reduced `extended_valid_elements` option instead of a full `valid_elements` matrix.
+This reduces page download size significantly when loading forms with TinyMCE.
+[petschki]


### PR DESCRIPTION
fixes #3204 

This reduces the loaded page size for forms with tinymce
(tested with `curl --user admin:admin -so /dev/null http://localhost:8080/Plone/edit -w "%{size_download}"`)

Before: 128.620 Bytes
After: 75.674 Bytes