### PR TITLE
Python 3.13.x: `unittest.makeSuite` got removed.

### DIFF
--- a/Products/CMFPlone/exportimport/tests/testControlPanel.py
+++ b/Products/CMFPlone/exportimport/tests/testControlPanel.py
@@ -51,9 +51,8 @@ class ControlPanelXMLAdapterTests(BodyAdapterTestCase):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
-    suite.addTest(makeSuite(ControlPanelXMLAdapterTests))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(ControlPanelXMLAdapterTests),
+    ))

--- a/Products/CMFPlone/tests/testNavigationView.py
+++ b/Products/CMFPlone/tests/testNavigationView.py
@@ -439,12 +439,11 @@ class TestPhysicalBreadCrumbs(TestBaseBreadCrumbs):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestCatalogPortalTabs))
-    suite.addTest(makeSuite(TestSiteMap))
-    suite.addTest(makeSuite(TestCatalogBreadCrumbs))
-    suite.addTest(makeSuite(TestPhysicalBreadCrumbs))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCatalogPortalTabs),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSiteMap),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCatalogBreadCrumbs),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPhysicalBreadCrumbs),
+    ))

--- a/Products/CMFPlone/tests/testWebDAV.py
+++ b/Products/CMFPlone/tests/testWebDAV.py
@@ -475,13 +475,15 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
     if bbb.HAS_ZSERVER:
-        suite.addTest(makeSuite(TestDAVProperties))
-        suite.addTest(makeSuite(TestPUTObjects))
-        suite.addTest(makeSuite(TestPUTIndexHtml))
-        suite.addTest(makeSuite(TestDAVOperations))
-    return suite
+        return unittest.TestSuite((
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestDAVProperties),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestPUTObjects),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestPUTIndexHtml),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestDAVOperations),
+        ))
+
+    # return empty suite
+    return unittest.TestSuite()

--- a/news/4066.bugfix
+++ b/news/4066.bugfix
@@ -1,0 +1,2 @@
+Fix removed `unittest.makeSuite` in python 3.13
+[petschki]


### PR DESCRIPTION
I use this PR as POC for the change: https://github.com/zopefoundation/zope.security/pull/84/files and to summarize all occurrences in the core (addon) packages (and its PRs):

- [x] collective.monkeypatcher (https://github.com/plone/collective.monkeypatcher/pull/14)
- [x] plone.app.upgrades (https://github.com/plone/plone.app.upgrade/pull/331)
- [x] plone.keyring (https://github.com/plone/plone.keyring/pull/33)
- [x] plone.portlet.static (https://github.com/plone/plone.portlet.static/pull/45)
- [x] plone.protect (https://github.com/plone/plone.protect/pull/121)
- [x] plone.testing (https://github.com/plone/plone.testing/pull/100 README only)
- [x] plone.theme (https://github.com/plone/plone.theme/pull/27)
- [ ] Products.PortalTransforms (https://github.com/plone/Products.PortalTransforms/pull/70)
- [ ] z3c.relationfield (https://github.com/zopefoundation/z3c.relationfield/pull/28)