### PR TITLE
 Allow bundles to be rendered after all other.

### DIFF
--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -19,22 +19,24 @@ from Products.CMFPlone.tests import PloneTestCase
 from zope.component import getUtility
 
 
+def _make_test_bundle(
+    name="foobar",
+    depends="",
+):
+    registry = getUtility(IRegistry)
+
+    bundles = registry.collectionOfInterface(IBundleRegistry, prefix="plone.bundles")
+    bundle = bundles.add(name)
+    bundle.name = name
+    bundle.jscompilation = f"http://foo.bar/{name}.js"
+    bundle.csscompilation = f"http://foo.bar/{name}.css"
+    bundle.depends = depends
+    return bundle
+
+
 class TestScriptsViewlet(PloneTestCase.PloneTestCase):
-    def _make_test_bundle(self):
-        registry = getUtility(IRegistry)
-
-        bundles = registry.collectionOfInterface(
-            IBundleRegistry, prefix="plone.bundles"
-        )
-        bundle = bundles.add("foobar")
-        bundle.name = "foobar"
-        bundle.jscompilation = "http://foo.bar/foobar.js"
-        bundle.csscompilation = "http://foo.bar/foobar.css"
-        bundle.resources = ["foobar"]
-        return bundle
-
     def test_bundle_defernot_asyncnot(self):
-        self._make_test_bundle()
+        _make_test_bundle()
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
         view.update()
         rendered = view.render()
@@ -42,7 +44,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertTrue("defer=" not in rendered)
 
     def test_bundle_defer_asyncnot(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.load_async = False
         bundle.load_defer = True
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
@@ -52,7 +54,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertTrue("defer=" in rendered)
 
     def test_bundle_defernot_async(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.load_async = True
         bundle.load_defer = False
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
@@ -62,7 +64,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertTrue("defer=" not in rendered)
 
     def test_bundle_defer_async(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.load_async = True
         bundle.load_defer = True
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
@@ -80,7 +82,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
 
     def test_scripts_data_bundle_attr(self):
         scripts = ScriptsView(self.layer["portal"], self.layer["request"], None)
-        self._make_test_bundle()
+        _make_test_bundle()
         scripts.update()
         result = scripts.render()
         self.assertIn('data-bundle="foobar"', result)
@@ -111,7 +113,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         scripts = ScriptsView(self.layer["portal"], subreq, None)
 
         # add some bundle to test with
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.enabled = False
         scripts.update()
         result = scripts.render()
@@ -131,7 +133,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         scripts = ScriptsView(self.layer["portal"], subreq, None)
 
         # add some bundle to test with
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.enabled = False
         scripts.update()
         result = scripts.render()
@@ -151,14 +153,14 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         scripts = ScriptsView(self.layer["portal"], subreq, None)
 
         # add some bundle to test with
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.enabled = True
         scripts.update()
         result = scripts.render()
         self.assertNotIn("http://test.foo/test.css", result)
 
     def test_bundle_depends(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.depends = "plone"
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
         view.update()
@@ -166,7 +168,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertIn("http://foo.bar/foobar.js", results)
 
     def test_bundle_depends_on_multiple(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.depends = "plone,eventedit"
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
         view.update()
@@ -174,7 +176,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         self.assertIn("http://foo.bar/foobar.js", results)
 
     def test_bundle_depends_on_missing(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.depends = "nonexistsinbundle"
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
         view.update()
@@ -208,7 +210,7 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         )
 
     def test_relative_uri_resource(self):
-        bundle = self._make_test_bundle()
+        bundle = _make_test_bundle()
         bundle.jscompilation = "//foo.bar/foobar.js"
         view = ScriptsView(self.app, self.app.REQUEST, None, None)
         view.update()

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -1,3 +1,4 @@
+from lxml import etree
 from OFS.Image import File
 from plone.app.testing import logout
 from plone.app.testing import setRoles
@@ -167,6 +168,47 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         results = view.render()
         self.assertIn("http://foo.bar/foobar.js", results)
 
+    def test_js_bundle_depends_all(self):
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        _make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # last.
+        _make_test_bundle(name="last", depends="all")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        _make_test_bundle(name="b")
+
+        view = ScriptsView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        scripts = parsed.xpath("//script")
+
+        # The last element is our JS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/last.js",
+            scripts[-1].attrib["src"],
+        )
+
+        # The first resource is our JS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/a.js",
+            scripts[0].attrib["src"],
+        )
+
+        # The second resource is our JS, which was defined with unspecified
+        # dependency last.
+        self.assertEqual(
+            "http://foo.bar/b.js",
+            scripts[1].attrib["src"],
+        )
+
     def test_bundle_depends_on_multiple(self):
         bundle = _make_test_bundle()
         bundle.depends = "plone,eventedit"
@@ -219,6 +261,19 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
 
 
 class TestStylesViewlet(PloneTestCase.PloneTestCase):
+    def _make_test_bundle(self):
+        registry = getUtility(IRegistry)
+
+        bundles = registry.collectionOfInterface(
+            IBundleRegistry, prefix="plone.bundles"
+        )
+        bundle = bundles.add("foobar")
+        bundle.name = "foobar"
+        bundle.jscompilation = "http://foo.bar/foobar.js"
+        bundle.csscompilation = "http://foo.bar/foobar.css"
+        bundle.resources = ["foobar"]
+        return bundle
+
     def test_styles_viewlet(self):
         styles = StylesView(self.layer["portal"], self.layer["request"], None)
         styles.update()
@@ -324,6 +379,86 @@ class TestStylesViewlet(PloneTestCase.PloneTestCase):
         scripts.update()
         result = scripts.render()
         self.assertNotIn("http://test.foo/test.min.js", result)
+
+    def test_css_bundle_depends_all(self):
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        _make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # last.
+        _make_test_bundle(name="last", depends="all")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        _make_test_bundle(name="b")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is our CSS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/last.css",
+            styles[-1].attrib["href"],
+        )
+
+        # The second last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-2].attrib["href"],
+        )
+
+        # The first resource is our CSS, which was defined with unspecified
+        # dependency.
+        self.assertEqual(
+            "http://foo.bar/a.css",
+            styles[0].attrib["href"],
+        )
+
+        # The second resource is our CSS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/b.css",
+            styles[1].attrib["href"],
+        )
+
+    def test_css_bundle_depends_all_but_custom(self):
+        registry = getUtility(IRegistry)
+
+        custom_key = "plone.app.theming.interfaces.IThemeSettings.custom_css"
+        registry[custom_key] = "html { background-color: red; }"
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # after all except the custom styles.
+        _make_test_bundle(name="almost-last", depends="all")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is are the custom styles.
+        self.assertTrue(
+            "@@custom.css" in styles[-1].attrib["href"],
+        )
+
+        # The second last element is now our CSS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/almost-last.css",
+            styles[-2].attrib["href"],
+        )
+
+        # The third last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-3].attrib["href"],
+        )
 
 
 class TestExpressions(PloneTestCase.PloneTestCase):

--- a/news/4074.feature
+++ b/news/4074.feature
@@ -1,0 +1,17 @@
+Allow bundles to be rendered after all other.
+
+JS and CSS resources can now be rendered after all other resources in their
+resource group including the theme (e.g. the Barceloneta theme CSS).
+
+There is a exception for custom CSS which can be defined in the theming
+controlpanel. This one is always rendered as last style resource.
+
+To render a resource after all other give it the "depends" value of "all". This
+indicates that the resource depends on all other being rendered before. The
+resource is then rendered as last resource of it's resource group.
+
+This allows to override a theme with custom CSS from a bundle instead of having
+to add the CSS customizations to the registry via the "custom_css" settings.
+As a consequence, theme customization can now be done in the filesystem in
+ordinary CSS files instead of being bound to a time consuming workflow which
+involces upgrading the custom_css registry after every change.


### PR DESCRIPTION
**This is the Plone 6.0 backport of: https://github.com/plone/Products.CMFPlone/pull/4054**

JS and CSS resources can now be rendered after all other resources in their
resource group including the theme (e.g. the Barceloneta theme CSS).

There is a exception for custom CSS which can be defined in the theming
controlpanel. This one is always rendered as last style resource.

To render a resource after all other give it the "depends" value of "all". This
indicates that the resource depends on all other being rendered before. The
resource is then rendered as last resource of it's resource group.

This allows to override a theme with custom CSS from a bundle instead of having
to add the CSS customizations to the registry via the "custom_css" settings.
As a consequence, theme customization can now be done in the filesystem in
ordinary CSS files instead of being bound to a time consuming workflow which
involces upgrading the custom_css registry after every change.

## Docs
https://github.com/plone/documentation/pull/1802
https://github.com/plone/documentation/pull/1803