### PR TITLE
Implement resource bundle depends on `all` to be rendered at last

### DIFF
--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -154,7 +154,7 @@ class ResourceBase:
                 external = self.is_external_url(record.jscompilation)
                 r_group = registry_group_js
                 if "all" in depends:
-                    # move to a separate group which is rendered at last
+                    # move to a separate group which is rendered after all others
                     r_group = registry_group_js_deferred
                     depends = None
                 PloneScriptResource(

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -257,7 +257,7 @@ class ResourceBase:
         root_group_js.add(registry_group_js_deferred)
         root_group_css.add(registry_group_css_deferred)
 
-        # add Custom CSS always after everything
+        # add Custom CSS always after everything else
         registry = getUtility(IRegistry)
         theme_settings = registry.forInterface(IThemeSettings, False)
         if theme_settings.custom_css:

--- a/Products/CMFPlone/resources/browser/resource.py
+++ b/Products/CMFPlone/resources/browser/resource.py
@@ -181,7 +181,7 @@ class ResourceBase:
                 external = self.is_external_url(record.csscompilation)
                 r_group = registry_group_css
                 if "all" in depends:
-                    # move to a separate group which is rendered at last
+                    # move to a separate group which is rendered after all others
                     r_group = registry_group_css_deferred
                     depends = None
                 PloneStyleResource(

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -215,9 +215,10 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
             scripts[1].attrib["src"],
         )
 
-        # When a second bundle depends on "all" it is ordered alphabetically
-        # with the other bundles
+        # When more bundles depend on "all", they are ordered alphabetically
+        # at the end.
         self._make_test_bundle(name="x-very-last", depends="all")
+        self._make_test_bundle(name="a-last", depends="all")
 
         # make sure cache purged
         setattr(self.layer["request"], REQUEST_CACHE_KEY, None)
@@ -228,16 +229,18 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         parsed = etree.fromstring(results, parser)
         scripts = parsed.xpath("//script")
 
-        # our new bundle ist last
+        # All the "all" depending bundles are sorted alphabetically at the end.
         self.assertEqual(
             "http://foo.bar/x-very-last.js",
             scripts[-1].attrib["src"],
         )
-
-        # The previously last element is now second last
         self.assertEqual(
             "http://foo.bar/last.js",
             scripts[-2].attrib["src"],
+        )
+        self.assertEqual(
+            "http://foo.bar/a-last.js",
+            scripts[-3].attrib["src"],
         )
 
     def test_bundle_depends_on_missing(self):

--- a/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/Products/CMFPlone/tests/testResourceRegistries.py
@@ -1,3 +1,4 @@
+from lxml import etree
 from OFS.Image import File
 from plone.app.testing import logout
 from plone.app.testing import setRoles
@@ -20,17 +21,17 @@ from zope.component import getUtility
 
 
 class TestScriptsViewlet(PloneTestCase.PloneTestCase):
-    def _make_test_bundle(self):
+    def _make_test_bundle(self, name="foobar", depends=""):
         registry = getUtility(IRegistry)
 
         bundles = registry.collectionOfInterface(
             IBundleRegistry, prefix="plone.bundles"
         )
-        bundle = bundles.add("foobar")
-        bundle.name = "foobar"
-        bundle.jscompilation = "http://foo.bar/foobar.js"
-        bundle.csscompilation = "http://foo.bar/foobar.css"
-        bundle.resources = ["foobar"]
+        bundle = bundles.add(name)
+        bundle.name = name
+        bundle.jscompilation = f"http://foo.bar/{name}.js"
+        bundle.csscompilation = f"http://foo.bar/{name}.css"
+        bundle.depends = depends
         return bundle
 
     def test_bundle_defernot_asyncnot(self):
@@ -173,6 +174,72 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
         results = view.render()
         self.assertIn("http://foo.bar/foobar.js", results)
 
+    def test_js_bundle_depends_all(self):
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # last.
+        self._make_test_bundle(name="last", depends="all")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="b")
+
+        view = ScriptsView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        scripts = parsed.xpath("//script")
+
+        # The last element is our JS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/last.js",
+            scripts[-1].attrib["src"],
+        )
+
+        # The first resource is our JS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/a.js",
+            scripts[0].attrib["src"],
+        )
+
+        # The second resource is our JS, which was defined with unspecified
+        # dependency last.
+        self.assertEqual(
+            "http://foo.bar/b.js",
+            scripts[1].attrib["src"],
+        )
+
+        # When a second bundle depends on "all" it is ordered alphabetically
+        # with the other bundles
+        self._make_test_bundle(name="x-very-last", depends="all")
+
+        # make sure cache purged
+        setattr(self.layer["request"], REQUEST_CACHE_KEY, None)
+
+        view.update()
+        results = view.render()
+
+        parsed = etree.fromstring(results, parser)
+        scripts = parsed.xpath("//script")
+
+        # our new bundle ist last
+        self.assertEqual(
+            "http://foo.bar/x-very-last.js",
+            scripts[-1].attrib["src"],
+        )
+
+        # The previously last element is now second last
+        self.assertEqual(
+            "http://foo.bar/last.js",
+            scripts[-2].attrib["src"],
+        )
+
     def test_bundle_depends_on_missing(self):
         bundle = self._make_test_bundle()
         bundle.depends = "nonexistsinbundle"
@@ -217,6 +284,19 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
 
 
 class TestStylesViewlet(PloneTestCase.PloneTestCase):
+    def _make_test_bundle(self, name="foobar", depends=""):
+        registry = getUtility(IRegistry)
+
+        bundles = registry.collectionOfInterface(
+            IBundleRegistry, prefix="plone.bundles"
+        )
+        bundle = bundles.add(name)
+        bundle.name = name
+        bundle.jscompilation = f"http://foo.bar/{name}.js"
+        bundle.csscompilation = f"http://foo.bar/{name}.css"
+        bundle.depends = depends
+        return bundle
+
     def test_styles_viewlet(self):
         styles = StylesView(self.layer["portal"], self.layer["request"], None)
         styles.update()
@@ -322,6 +402,86 @@ class TestStylesViewlet(PloneTestCase.PloneTestCase):
         scripts.update()
         result = scripts.render()
         self.assertNotIn("http://test.foo/test.min.js", result)
+
+    def test_css_bundle_depends_all(self):
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # last.
+        self._make_test_bundle(name="last", depends="all")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="b")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is our CSS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/last.css",
+            styles[-1].attrib["href"],
+        )
+
+        # The second last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-2].attrib["href"],
+        )
+
+        # The first resource is our CSS, which was defined with unspecified
+        # dependency.
+        self.assertEqual(
+            "http://foo.bar/a.css",
+            styles[0].attrib["href"],
+        )
+
+        # The second resource is our CSS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/b.css",
+            styles[1].attrib["href"],
+        )
+
+    def test_css_bundle_depends_all_but_custom(self):
+        registry = getUtility(IRegistry)
+
+        custom_key = "plone.app.theming.interfaces.IThemeSettings.custom_css"
+        registry[custom_key] = "html { background-color: red; }"
+
+        # Create a test bundle, which depends on "all" other and thus rendered
+        # after all except the custom styles.
+        self._make_test_bundle(name="almost-last", depends="all")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is are the custom styles.
+        self.assertTrue(
+            "@@custom.css" in styles[-1].attrib["href"],
+        )
+
+        # The second last element is now our CSS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/almost-last.css",
+            styles[-2].attrib["href"],
+        )
+
+        # The third last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-3].attrib["href"],
+        )
 
 
 class TestExpressions(PloneTestCase.PloneTestCase):

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -1,0 +1,18 @@
+Allow bundles to be rendered after all other.
+
+JS and CSS resources can now be rendered after all other resources in their
+resource group including the theme (e.g. the Barceloneta theme CSS).
+
+There is a exception for custom CSS which can be defined in the theming
+controlpanel. This one is always rendered as last style resource.
+
+To render a resource after all other give it the "depends" value of "all". This
+indicates that the resource depends on all other being rendered before. The
+resource is then rendered as last resource of it's resource group.
+
+This allows to override a theme with custom CSS from a bundle instead of having
+to add the CSS customizations to the registry via the "custom_css" settings.
+As a consequence, theme customization can now be done in the filesystem in
+ordinary CSS files instead of being bound to a time consuming workflow which
+involves upgrading the custom_css registry after every change.
+[thet, petschki]

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -1,4 +1,4 @@
-Allow bundles to be rendered after all other.
+Allow bundles to be rendered after all others.
 
 JS and CSS resources can now be rendered after all other resources in their
 resource group including the theme (e.g. the Barceloneta theme CSS).

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -6,7 +6,7 @@ resource group including the theme (e.g. the Barceloneta theme CSS).
 There is an exception for custom CSS which can be defined in the theming
 controlpanel. This one is always rendered as last style resource.
 
-To render a resource after all other give it the "depends" value of "all". This
+To render resources after all others, give them the "depends" value of "all".
 indicates that the resource depends on all other being rendered before. The
 resource is then rendered as last resource of it's resource group.
 

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -3,7 +3,7 @@ Allow bundles to be rendered after all others.
 JS and CSS resources can now be rendered after all other resources in their
 resource group including the theme (e.g. the Barceloneta theme CSS).
 
-There is a exception for custom CSS which can be defined in the theming
+There is an exception for custom CSS which can be defined in the theming
 controlpanel. This one is always rendered as last style resource.
 
 To render a resource after all other give it the "depends" value of "all". This

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -8,7 +8,7 @@ controlpanel. This one is always rendered as last style resource.
 
 To render resources after all others, give them the "depends" value of "all".
 For each of these resources, "all" indicates that the resource depends on all other resources, making it render after its dependencies.
-resource is then rendered as last resource of it's resource group.
+If you set multiple resources with "all", then they will render alphabetically after all other.
 
 This allows to override a theme with custom CSS from a bundle instead of having
 to add the CSS customizations to the registry via the "custom_css" settings.

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -7,7 +7,7 @@ There is an exception for custom CSS which can be defined in the theming
 controlpanel. This one is always rendered as last style resource.
 
 To render resources after all others, give them the "depends" value of "all".
-indicates that the resource depends on all other being rendered before. The
+For each of these resources, "all" indicates that the resource depends on all other resources, making it render after its dependencies.
 resource is then rendered as last resource of it's resource group.
 
 This allows to override a theme with custom CSS from a bundle instead of having

--- a/news/4054.feature
+++ b/news/4054.feature
@@ -10,7 +10,7 @@ To render resources after all others, give them the "depends" value of "all".
 For each of these resources, "all" indicates that the resource depends on all other resources, making it render after its dependencies.
 If you set multiple resources with "all", then they will render alphabetically after all other.
 
-This allows to override a theme with custom CSS from a bundle instead of having
+This lets you override a theme with custom CSS from a bundle instead of having
 to add the CSS customizations to the registry via the "custom_css" settings.
 As a consequence, theme customization can now be done in the filesystem in
 ordinary CSS files instead of being bound to a time consuming workflow which


### PR DESCRIPTION
This is a successor of #4054 with the simplified `webresource.ResourceGroup` approach.
Tests are copied 1:1 from the previous PR