### PR TITLE
Remove unittest.makeSuite for Py 3.13 compatibility [6.0]

### DIFF
--- a/Products/CMFPlone/exportimport/tests/testControlPanel.py
+++ b/Products/CMFPlone/exportimport/tests/testControlPanel.py
@@ -51,9 +51,8 @@ class ControlPanelXMLAdapterTests(BodyAdapterTestCase):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
-    suite.addTest(makeSuite(ControlPanelXMLAdapterTests))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(ControlPanelXMLAdapterTests),
+    ))

--- a/Products/CMFPlone/exportimport/tests/testPropertiesTool.py
+++ b/Products/CMFPlone/exportimport/tests/testPropertiesTool.py
@@ -86,10 +86,9 @@ class PropertiesToolXMLAdapterTests(BodyAdapterTestCase):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
-    suite.addTest(makeSuite(PropertySheetXMLAdapterTests))
-    suite.addTest(makeSuite(PropertiesToolXMLAdapterTests))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(PropertySheetXMLAdapterTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(PropertiesToolXMLAdapterTests),
+    ))

--- a/Products/CMFPlone/tests/testNavigationView.py
+++ b/Products/CMFPlone/tests/testNavigationView.py
@@ -462,12 +462,11 @@ class TestPhysicalBreadCrumbs(TestBaseBreadCrumbs):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestCatalogPortalTabs))
-    suite.addTest(makeSuite(TestSiteMap))
-    suite.addTest(makeSuite(TestCatalogBreadCrumbs))
-    suite.addTest(makeSuite(TestPhysicalBreadCrumbs))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCatalogPortalTabs),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSiteMap),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCatalogBreadCrumbs),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPhysicalBreadCrumbs),
+    ))

--- a/Products/CMFPlone/tests/testWebDAV.py
+++ b/Products/CMFPlone/tests/testWebDAV.py
@@ -486,13 +486,15 @@ class TestDAVOperations(PloneTestCase.FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import makeSuite
-    from unittest import TestSuite
+    import unittest
 
-    suite = TestSuite()
     if bbb.HAS_ZSERVER:
-        suite.addTest(makeSuite(TestDAVProperties))
-        suite.addTest(makeSuite(TestPUTObjects))
-        suite.addTest(makeSuite(TestPUTIndexHtml))
-        suite.addTest(makeSuite(TestDAVOperations))
-    return suite
+        return unittest.TestSuite((
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestDAVProperties),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestPUTObjects),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestPUTIndexHtml),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestDAVOperations),
+        ))
+
+    # return empty suite
+    return unittest.TestSuite()

--- a/news/4066.bugfix
+++ b/news/4066.bugfix
@@ -1,0 +1,2 @@
+Fix removed `unittest.makeSuite` in python 3.13
+[petschki]

--- a/news/4066.bugfix
+++ b/news/4066.bugfix
@@ -1,2 +1,2 @@
-Fix removed `unittest.makeSuite` in python 3.13
-[petschki]
+Fix removed `unittest.makeSuite` in Python 3.13.
+[petschki, maurits]


### PR DESCRIPTION
This back ports PR #4066 from @petschki to Plone 6.0.
Here is needed an extra fix because 6.0 still has a `testPropertiesTool.py` file which used `makeSuite`.