### PR TITLE
Start the Plone 6.2 development cycle

### DIFF
--- a/Products/CMFPlone/factory.py
+++ b/Products/CMFPlone/factory.py
@@ -27,6 +27,7 @@ _IMREALLYPLONE5 = True
 PLONE52MARKER = True
 PLONE60MARKER = True
 PLONE61MARKER = True
+PLONE62MARKER = True
 
 logger = getLogger("Plone")
 

--- a/Products/CMFPlone/meta.zcml
+++ b/Products/CMFPlone/meta.zcml
@@ -21,6 +21,7 @@
   <meta:provides feature="plone-52" />
   <meta:provides feature="plone-60" />
   <meta:provides feature="plone-61" />
+  <meta:provides feature="plone-62" />
 
   <include
       package="Products.CMFCore"

--- a/Products/CMFPlone/profiles/default/metadata.xml
+++ b/Products/CMFPlone/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>6108</version>
+  <version>6200</version>
 </metadata>

--- a/news/3861.feature.md
+++ b/news/3861.feature.md
@@ -1,0 +1,1 @@
+Start the Plone 6.2 development cycle by fixing the profile version, adding the `plone-62` zcml feature, and defining `PLONE62MARKER` as True.


### PR DESCRIPTION
- add `plone-62` as zcml feature
- define `PLONE62MARKER` as `True`
- bump the profile version to 6200

Based on https://github.com/plone/Products.CMFPlone/pull/3861