### PR TITLE
Fix deprecated robottest keyword [6.1]

### DIFF
--- a/Products/CMFPlone/tests/robot/test_querystring.robot
+++ b/Products/CMFPlone/tests/robot/test_querystring.robot
@@ -304,7 +304,7 @@ a bunch of folders
     ...    title=Link
     ...    remoteUrl=/front-page
     ...    container=${F3}
-    [Return]  ${F1}
+    RETURN  ${F1}
 
 
 a bunch of events

--- a/news/4132.bugfix
+++ b/news/4132.bugfix
@@ -1,0 +1,2 @@
+Fix deprecated robottest keyword.
+[petschki]


### PR DESCRIPTION
See updated robotframework: https://github.com/plone/buildout.coredev/pull/1002

https://jenkins.plone.org/job/pull-request-6.1-3.13/179/console