### PR TITLE
Require 3.9 as minimum Python version on 6.0

### DIFF
--- a/news/38.breaking
+++ b/news/38.breaking
@@ -1,0 +1,3 @@
+Require 3.9 as minimum Python version.
+We already officially dropped 3.8 support in 6.0.14, but now Zope requires 3.9 as minimum, so we stop pretending you can get Plone running on this no longer security supported Python version.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     keywords="Plone CMF Python Zope CMS Webapplication",
     author="Plone Foundation",
     author_email="releasemanager@plone.org",


### PR DESCRIPTION
We already officially dropped 3.8 support in 6.0.14, but now Zope requires 3.9 as minimum, so we stop pretending you can get Plone running on this no longer security supported Python version. See also [my comment on the release checklist](https://github.com/plone/Products.CMFPlone/issues/4141#issuecomment-2722710581).