### PR TITLE
In the Site Setup warn that Plone 6.0 is out of maintenance support.

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/overview.pt
+++ b/Products/CMFPlone/controlpanel/browser/overview.pt
@@ -21,6 +21,57 @@
         Configuration area for Plone and add-on Products.
     </p>
   </header>
+
+  <div class="alert alert-warning mb-5"
+        role="status"
+        tal:condition="view/python_warning">
+      <strong i18n:translate="">
+          Warning
+      </strong>
+      <span tal:omit-tag="" i18n:translate="text_python_warning">
+          You are using a Python version that is not supported.
+      </span>
+  </div>
+
+  <div class="alert alert-warning mb-5"
+        role="status"
+        tal:condition="view/plone_maintenance_warning">
+      <strong i18n:translate="">
+          Warning
+      </strong>
+      <span tal:omit-tag="" i18n:translate="text_plone_maintenance_warning">
+          You are using a Plone version that is out of maintenance support.
+      </span>
+  </div>
+
+  <div class="alert alert-warning mb-5"
+        role="status"
+        tal:condition="view/plone_security_warning">
+      <strong i18n:translate="">
+          Warning
+      </strong>
+      <span tal:omit-tag="" i18n:translate="text_plone_security_warning">
+          You are using a Plone version that is out of security support.
+      </span>
+  </div>
+
+  <div class="alert alert-warning mb-5"
+        role="status"
+        tal:condition="view/version_warning">
+      <strong i18n:translate="">
+          Warning
+      </strong>
+      <span tal:omit-tag="" i18n:translate="text_plone_release_schedule">
+          Go to the
+          <tal:link i18n:name="plone_release_schedule_link">
+              <a href="https://plone.org/download/release-schedule"
+                  i18n:translate="text_plone_release_schedule_link"
+              >Plone release schedule</a>
+          </tal:link>
+          for more information.
+      </span>
+  </div>
+
   <div class="alert alert-warning mb-5"
         role="status"
         tal:condition="view/upgrade_warning">

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
@@ -1,3 +1,4 @@
+from datetime import date
 from plone.app.testing import PLONE_INTEGRATION_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -24,6 +25,30 @@ def mock_getUtility4(iface):
     return {"plone.app.event.portal_timezone": "Europe/Amsterdam"}
 
 
+class MockVersionInfo:
+    def __init__(self, major, minor, micro=0):
+        self.major = major
+        self.minor = minor
+        self.micro = micro
+
+
+mock_python38 = MockVersionInfo(3, 8)
+mock_python39 = MockVersionInfo(3, 9)
+mock_python310 = MockVersionInfo(3, 10)
+mock_python311 = MockVersionInfo(3, 11)
+mock_python312 = MockVersionInfo(3, 12)
+mock_python313 = MockVersionInfo(3, 13)
+mock_python314 = MockVersionInfo(3, 14)
+
+
+class MockDate:
+    def __init__(self, today):
+        self._today = today
+
+    def today(self):
+        return self._today
+
+
 class TestControlPanel(unittest.TestCase):
     layer = PLONE_INTEGRATION_TESTING
 
@@ -31,6 +56,144 @@ class TestControlPanel(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.request = self.layer["request"]
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_version_warning(self):
+        # We always get a warning: Plone 6.0 is out of maintenance support.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.version_warning())
+
+    @mock.patch("sys.version_info", new=mock_python38)
+    def test_python38_warning(self):
+        # Test the warnings that get shows when using Python 3.8.
+        # Python 3.8 is already end-of-life at the time of writing this test,
+        # so we always warn.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python39)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 4, 1)),
+    )
+    def test_python39_warning_early(self):
+        # Test the warnings that get shows when using Python 3.9.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertFalse(view.python_warning())
+
+    @mock.patch("sys.version_info", new=mock_python39)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 11, 1)),
+    )
+    def test_python39_warning_late(self):
+        # Test the warnings that get shows when using Python 3.9.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python310)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 4, 1)),
+    )
+    def test_python310_warning_early(self):
+        # Test the warnings that get shows when using Python 3.10.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertFalse(view.python_warning())
+
+    @mock.patch("sys.version_info", new=mock_python310)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2026, 11, 1)),
+    )
+    def test_python310_warning_late(self):
+        # Test the warnings that get shows when using Python 3.10.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python311)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 4, 1)),
+    )
+    def test_python311_warning_early(self):
+        # Test the warnings that get shows when using Python 3.11.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertFalse(view.python_warning())
+
+    @mock.patch("sys.version_info", new=mock_python311)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2027, 11, 1)),
+    )
+    def test_python311_warning_late(self):
+        # Test the warnings that get shows when using Python 3.11.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python312)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 4, 1)),
+    )
+    def test_python312_warning_early(self):
+        # Test the warnings that get shows when using Python 3.12.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertFalse(view.python_warning())
+
+    @mock.patch("sys.version_info", new=mock_python312)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2028, 12, 1)),
+    )
+    def test_python312_warning_late(self):
+        # Test the warnings that get shows when using Python 3.12.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python313)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2025, 4, 1)),
+    )
+    def test_python313_warning_early(self):
+        # Test the warnings that get shows when using Python 3.13.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertFalse(view.python_warning())
+
+    @mock.patch("sys.version_info", new=mock_python313)
+    @mock.patch(
+        "Products.CMFPlone.controlpanel.browser.overview.date",
+        new=MockDate(date(2029, 11, 1)),
+    )
+    def test_python313_warning_late(self):
+        # Test the warnings that get shows when using Python 3.13.
+        # This depends on the date.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
+
+    @mock.patch("sys.version_info", new=mock_python314)
+    def test_python314_warning(self):
+        # Test the warnings that get shows when using Python 3.14.
+        # 3.14 is too new, so we always warn.
+        view = self.portal.restrictedTraverse("@@overview-controlpanel")
+        self.assertTrue(view.python_warning())
+        self.assertTrue(view.version_warning())
+        self.assertIn("You are using a Python version that is not supported.", view())
 
     @mock.patch(
         "Products.CMFPlone.controlpanel.browser.overview.getUtility",

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_overview.py
@@ -64,7 +64,7 @@ class TestControlPanel(unittest.TestCase):
 
     @mock.patch("sys.version_info", new=mock_python38)
     def test_python38_warning(self):
-        # Test the warnings that get shows when using Python 3.8.
+        # Test the warnings that get shown when using Python 3.8.
         # Python 3.8 is already end-of-life at the time of writing this test,
         # so we always warn.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
@@ -77,7 +77,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 4, 1)),
     )
     def test_python39_warning_early(self):
-        # Test the warnings that get shows when using Python 3.9.
+        # Test the warnings that get shown when using Python 3.9.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertFalse(view.python_warning())
@@ -88,7 +88,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 11, 1)),
     )
     def test_python39_warning_late(self):
-        # Test the warnings that get shows when using Python 3.9.
+        # Test the warnings that get shown when using Python 3.9.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())
@@ -100,7 +100,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 4, 1)),
     )
     def test_python310_warning_early(self):
-        # Test the warnings that get shows when using Python 3.10.
+        # Test the warnings that get shown when using Python 3.10.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertFalse(view.python_warning())
@@ -111,7 +111,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2026, 11, 1)),
     )
     def test_python310_warning_late(self):
-        # Test the warnings that get shows when using Python 3.10.
+        # Test the warnings that get shown when using Python 3.10.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())
@@ -123,7 +123,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 4, 1)),
     )
     def test_python311_warning_early(self):
-        # Test the warnings that get shows when using Python 3.11.
+        # Test the warnings that get shown when using Python 3.11.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertFalse(view.python_warning())
@@ -134,7 +134,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2027, 11, 1)),
     )
     def test_python311_warning_late(self):
-        # Test the warnings that get shows when using Python 3.11.
+        # Test the warnings that get shown when using Python 3.11.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())
@@ -146,7 +146,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 4, 1)),
     )
     def test_python312_warning_early(self):
-        # Test the warnings that get shows when using Python 3.12.
+        # Test the warnings that get shown when using Python 3.12.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertFalse(view.python_warning())
@@ -157,7 +157,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2028, 12, 1)),
     )
     def test_python312_warning_late(self):
-        # Test the warnings that get shows when using Python 3.12.
+        # Test the warnings that get shown when using Python 3.12.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())
@@ -169,7 +169,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2025, 4, 1)),
     )
     def test_python313_warning_early(self):
-        # Test the warnings that get shows when using Python 3.13.
+        # Test the warnings that get shown when using Python 3.13.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertFalse(view.python_warning())
@@ -180,7 +180,7 @@ class TestControlPanel(unittest.TestCase):
         new=MockDate(date(2029, 11, 1)),
     )
     def test_python313_warning_late(self):
-        # Test the warnings that get shows when using Python 3.13.
+        # Test the warnings that get shown when using Python 3.13.
         # This depends on the date.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())
@@ -188,7 +188,7 @@ class TestControlPanel(unittest.TestCase):
 
     @mock.patch("sys.version_info", new=mock_python314)
     def test_python314_warning(self):
-        # Test the warnings that get shows when using Python 3.14.
+        # Test the warnings that get shown when using Python 3.14.
         # 3.14 is too new, so we always warn.
         view = self.portal.restrictedTraverse("@@overview-controlpanel")
         self.assertTrue(view.python_warning())

--- a/news/60.bugfix
+++ b/news/60.bugfix
@@ -1,3 +1,3 @@
-In the Site Setup warn that Plone 6.0 is out of maintenance support.
+In the Site Setup, warn that Plone 6.0 is out of maintenance support.
 Also check the Python version and warn when that is out of support.
 [maurits]

--- a/news/60.bugfix
+++ b/news/60.bugfix
@@ -1,0 +1,3 @@
+In the Site Setup warn that Plone 6.0 is out of maintenance support.
+Also check the Python version and warn when that is out of support.
+[maurits]


### PR DESCRIPTION
Also check the Python version and warn when that is out of support. We did this in 5.2 as well.  I adapted the code from there.

Screen shot:

![Screenshot 2025-03-15 at 02 07 48](https://github.com/user-attachments/assets/ba158d2b-f6ed-479c-9c0b-697d9fcf20d5)

The next screen shot is what you would see when the Python version is out of support:

![Screenshot 2025-03-15 at 01 58 58](https://github.com/user-attachments/assets/28123553-1e3c-4b4a-b99e-8781cce4576c)
