### PR TITLE
Dont break resource registry (Plone 6.1)

### DIFF
--- a/news/dont-break-resource-registry.bugfix.md
+++ b/news/dont-break-resource-registry.bugfix.md
@@ -1,0 +1,8 @@
+Make resource registry more robust against broken resources.
+
+Don't break the resource registry when a resource error happens (missing
+dependency, circular dependency, file not found, etc). Admins will see a
+warning badge and can fix the problem in the resource registry user interface.
+Previously such errors broke the rendering of the whole site, making fixes very
+fiddly.
+[thet]


### PR DESCRIPTION
Plone 6.1: https://github.com/plone/Products.CMFPlone/pull/4165 (this)
Plone 6.2: https://github.com/plone/Products.CMFPlone/pull/4186

Dependency problem with resources without this fix:

![image](https://github.com/user-attachments/assets/5019cb5d-dffc-4e85-98c1-cf41d6b131f3)

Dependency problem with this fix in place:

![image](https://github.com/user-attachments/assets/ccc08015-d02a-4d90-9f49-947d560de4b5)


If a CSS‌ problem occurs, the design is broken.
But thanks to the `<details>` change on the collapsibles in this form, the form is still usable and the problem can still be fixed:
![image](https://github.com/user-attachments/assets/7c12c59c-1941-42d2-859b-74b9b40a42c2)

