### PR TITLE
Automatically set the ajax_load request parameter.

### DIFF
--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -131,6 +131,12 @@
       name="plone"
       />
 
+  <subscriber
+      for="*
+           zope.traversing.interfaces.IBeforeTraverseEvent"
+      handler=".traversal.set_ajax"
+      />
+
   <!-- Adapter for default workflow lookup -->
   <adapter
       factory=".workflow.ToolWorkflowChain"

--- a/Products/CMFPlone/traversal.py
+++ b/Products/CMFPlone/traversal.py
@@ -72,3 +72,12 @@ def get_zope_page_template_engine(engine):
         return getEngine()
     if isinstance(engine, zpt_engine.TrustedZopeEngine):
         return getTrustedEngine()
+
+
+def set_ajax(obj, event):
+    """Set ajax_load, if applicable."""
+    request = event.request
+
+    # Set the ajax_load parameter depending on an AJAX request or not.
+    if request.getHeader("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest":
+        request.set("ajax_load", "1")

--- a/news/+set_ajax.feature.md
+++ b/news/+set_ajax.feature.md
@@ -1,0 +1,9 @@
+Automatically set the ajax_load request parameter.
+
+Zope maintains the "HTTP_X_REQUESTED_WITH" request header.
+If this is set to "XMLHttpRequest", we have an AJAX request.
+If so, the ajax_load parameter is set to "true", regardless if it was set
+manually or not.
+
+This should make use for the ajax_main_template for any AJAX request,
+potentially speeding up classic Plone by avoiding loading unnecessary stuff.


### PR DESCRIPTION
Zope maintains the "HTTP_X_REQUESTED_WITH" request header. If this is set to "XMLHttpRequest", we have an AJAX request. If so, the ajax_load parameter is set to "true", regardless if it was set manually or not.

This should make use for the ajax_main_template for any AJAX request, potentially speeding up classic Plone by avoiding loading unnecessary stuff.