### PR TITLE
Harden condition of external editor action to not fail [6.1]

### DIFF
--- a/Products/CMFPlone/profiles/default/actions.xml
+++ b/Products/CMFPlone/profiles/default/actions.xml
@@ -60,7 +60,7 @@
       />
       <property name="url_expr">string:$object_url/external_edit</property>
       <property name="icon_expr">string:$portal_url/extedit_icon.png</property>
-      <property name="available_expr">object/externalEditorEnabled</property>
+      <property name="available_expr">object/externalEditorEnabled|nothing</property>
       <property name="permissions">
         <element value="Modify portal content" />
       </property>

--- a/news/4179.bugfix
+++ b/news/4179.bugfix
@@ -1,0 +1,2 @@
+Harden condition of external editor action to not fail when the `externalEditorEnabled` script is not available.
+[maurits]


### PR DESCRIPTION
It could fail when the script is not available.

In a client project, getting the actions failed, because the `plone_scripts` skin layer was not available. This is where the ``externalEditorEnabled`` script still lives. So this gave a traceback, for example when getting the `@actions` rest api endpoint:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 390, in publish_module
  Module ZPublisher.WSGIPublisher, line 284, in publish
  Module ZPublisher.mapply, line 98, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module plone.rest.service, line 21, in __call__
  Module plone.restapi.services, line 19, in render
  Module plone.restapi.services.content.get, line 16, in reply
  Module plone.restapi.serializer.dxcontent, line 168, in __call__
  Module plone.restapi.serializer.dxcontent, line 127, in __call__
  Module plone.restapi.serializer.expansion, line 21, in expandable_elements
  Module plone.restapi.services.actions.get, line 32, in __call__
  Module plone.memoize.view, line 51, in memogetter
  Module plone.app.layout.globals.context, line 244, in actions
  Module Products.CMFPlone.ActionsTool, line 83, in listActionInfos
  Module Products.CMFCore.ActionInformation, line 211, in __getitem__
  Module Products.CMFCore.Expression, line 53, in __call__
  Module zope.tales.expressions, line 248, in __call__
  Module Products.PageTemplates.Expressions, line 217, in _eval
  Module zope.tales.expressions, line 153, in _eval
  Module Products.PageTemplates.Expressions, line 85, in boboAwareZopeTraverse
  Module OFS.Traversable, line 364, in restrictedTraverse
  Module OFS.Traversable, line 347, in unrestrictedTraverse
   - __traceback_info__: ([], 'externalEditorEnabled')
  Module OFS.Traversable, line 301, in unrestrictedTraverse
   - __traceback_info__: ([], 'externalEditorEnabled')
  Module plone.folder.ordered, line 229, in __getitem__
KeyError: 'externalEditorEnabled'
```

I think it is fine to only do this on new sites, and have no upgrade step.