### PR TITLE
add login to the list of button names that show the primary button

### DIFF
--- a/Products/CMFPlone/browser/login/login.py
+++ b/Products/CMFPlone/browser/login/login.py
@@ -131,10 +131,6 @@ class LoginForm(form.EditForm):
                 return
         return came_from
 
-    def updateActions(self):
-        super().updateActions()
-        self.actions["login"].addClass("btn-primary")
-
     def _post_login(self):
         membership_tool = getToolByName(self.context, "portal_membership")
         member = membership_tool.getAuthenticatedMember()

--- a/news/4180.bugfix
+++ b/news/4180.bugfix
@@ -1,0 +1,1 @@
+add login to the list of button names that showbmit button @erral


### PR DESCRIPTION
Fixes #4180 

Test together: https://github.com/plone/plone.app.z3cform/pull/234