### PR TITLE
pat-tinymce: Document, what the importcss_file_filter is for.

### DIFF
--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -93,6 +93,12 @@ class TinyMCESettingsGenerator:
 
     def get_tiny_config(self):
         settings = self.settings
+
+        # NOTE: The `importcss_file_filter` is used to filter the CSS files
+        # from `content_css` which should be used to automatically create the
+        # styles dropdown.
+        # Also see:
+        # https://www.tiny.cloud/docs/tinymce/latest/importcss/#importcss_file_filter
         importcss_file_filter = "tinymce-formats.css"
 
         theme = self.get_theme()

--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -98,7 +98,7 @@ class TinyMCESettingsGenerator:
         # from `content_css` which should be used to automatically create the
         # styles dropdown.
         # Also see:
-        # https://www.tiny.cloud/docs/tinymce/latest/importcss/#importcss_file_filter
+        # https://6.docs.plone.org/classic-ui/tinymce-customization.html#inject-formats-with-files-named-tinymce-formats-css
         importcss_file_filter = "tinymce-formats.css"
 
         theme = self.get_theme()


### PR DESCRIPTION
I was scratching my head for a while what this `importcss_file_filter` is for. Don't scratch yours!

There is intentionally no news file as I think this change should not go into the changelog.

# PRs
https://github.com/plone/mockup/pull/1467
https://github.com/plone/Products.CMFPlone/pull/4184
