### PR TITLE
Automatically set the ajax_load request parameter.

### DIFF
--- a/Products/CMFPlone/browser/main_template.py
+++ b/Products/CMFPlone/browser/main_template.py
@@ -1,3 +1,4 @@
+from plone.base.utils import is_truthy
 from Products.CMFPlone.browser.interfaces import IMainTemplate
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -14,7 +15,8 @@ class MainTemplate(BrowserView):
 
     @property
     def template_name(self):
-        if self.request.form.get("ajax_load"):
+        # Directly query the request object, which includes the form.
+        if is_truthy(self.request.get("ajax_load")):
             return self.ajax_template_name
         else:
             return self.main_template_name

--- a/Products/CMFPlone/browser/templates/ajax_main_template.pt
+++ b/Products/CMFPlone/browser/templates/ajax_main_template.pt
@@ -16,7 +16,7 @@
           portal_url python:portal_state.portal_url();
           checkPermission python:context.restrictedTraverse('portal_membership').checkPermission;
           ajax_include_head python:request.get('ajax_include_head', False);
-          ajax_load python:False;"
+          ajax_load python:True;"
       i18n:domain="plone"
       tal:attributes="lang lang;">
 

--- a/Products/CMFPlone/configure.zcml
+++ b/Products/CMFPlone/configure.zcml
@@ -128,6 +128,12 @@
       name="plone"
       />
 
+  <subscriber
+      for="*
+           zope.traversing.interfaces.IBeforeTraverseEvent"
+      handler=".traversal.set_ajax"
+      />
+
   <!-- Adapter for default workflow lookup -->
   <adapter
       factory=".workflow.ToolWorkflowChain"

--- a/Products/CMFPlone/tests/test_main_template.py
+++ b/Products/CMFPlone/tests/test_main_template.py
@@ -13,6 +13,17 @@ class TestMainTemplate(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.request = self.layer["request"]
 
+    def test_request_containment(self):
+        """Very basic test to show that the following works:
+        `"ajax_load" in request`
+        instead of:
+        `request.get("ajax_load", MARKER) is not MARKER1`
+        """
+        request = self.request.clone()
+        request.form["ajax_load"] = True
+        self.assertTrue("ajax_load" in request.form)
+        self.assertTrue("ajax_load" in request)
+
     def test_main_template_standard(self):
         view = getMultiAdapter((self.portal, self.request), name="main_template")
         self.assertEqual(view.template_name, "templates/main_template.pt")

--- a/Products/CMFPlone/tests/test_main_template.py
+++ b/Products/CMFPlone/tests/test_main_template.py
@@ -1,0 +1,67 @@
+from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+from zope.component import getMultiAdapter
+from zope.event import notify
+from zope.traversing.interfaces import BeforeTraverseEvent
+
+import unittest
+
+
+class TestMainTemplate(unittest.TestCase):
+    layer = PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+    def test_main_template_standard(self):
+        view = getMultiAdapter((self.portal, self.request), name="main_template")
+        self.assertEqual(view.template_name, "templates/main_template.pt")
+
+    def test_main_template_ajax_parameter(self):
+        request = self.request.clone()
+        request.form["ajax_load"] = True
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/ajax_main_template.pt")
+
+    def test_main_template_ajax_manually(self):
+        request = self.request.clone()
+        request.set("ajax_load", True)
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/ajax_main_template.pt")
+
+    def test_main_template_auto(self):
+        request = self.request.clone()
+        request.environ["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"
+        # Manually trigger the BeforeTraverseEvent to set the ajax_load
+        # parameter - using restrictedTraverse would not work here
+        notify(BeforeTraverseEvent(self.portal, request))
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/ajax_main_template.pt")
+
+    def test_main_template_noauto_if_set(self):
+        request = self.request.clone()
+        request.form["ajax_load"] = "False"
+        request.environ["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"
+        # Manually trigger the BeforeTraverseEvent to set the ajax_load
+        # parameter - using restrictedTraverse would not work here
+        notify(BeforeTraverseEvent(self.portal, request))
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/main_template.pt")
+
+    def test_main_template_no_ajax_1(self):
+        request = self.request.clone()
+        request.form["ajax_load"] = False
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/main_template.pt")
+
+    def test_main_template_no_ajax_2(self):
+        request = self.request.clone()
+        request.form["ajax_load"] = "0"
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/main_template.pt")
+
+    def test_main_template_no_ajax_3(self):
+        request = self.request.clone()
+        request.form["ajax_load"] = "off"
+        view = getMultiAdapter((self.portal, request), name="main_template")
+        self.assertEqual(view.template_name, "templates/main_template.pt")

--- a/Products/CMFPlone/traversal.py
+++ b/Products/CMFPlone/traversal.py
@@ -10,9 +10,6 @@ from zope.interface import implementer
 from zope.pagetemplate import engine as zpt_engine
 
 
-MARKER = object()
-
-
 class PloneBundlesTraverser(ResourceTraverser):
     # the name is misleading - it is used not only for bundles.
     # in fact in Plone 6 bundles are no longer used, despite that the traverser
@@ -85,7 +82,7 @@ def set_ajax(obj, event):
     # it again.
     if (
         request.getHeader("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"
-        and not request.get("ajax_load", MARKER) is not MARKER
+        and "ajax_load" not in request
     ):
         # Directly set on the request object
         request.set("ajax_load", True)

--- a/Products/CMFPlone/traversal.py
+++ b/Products/CMFPlone/traversal.py
@@ -10,6 +10,9 @@ from zope.interface import implementer
 from zope.pagetemplate import engine as zpt_engine
 
 
+MARKER = object()
+
+
 class PloneBundlesTraverser(ResourceTraverser):
     # the name is misleading - it is used not only for bundles.
     # in fact in Plone 6 bundles are no longer used, despite that the traverser
@@ -72,3 +75,17 @@ def get_zope_page_template_engine(engine):
         return getEngine()
     if isinstance(engine, zpt_engine.TrustedZopeEngine):
         return getTrustedEngine()
+
+
+def set_ajax(obj, event):
+    """Set the ajax_load parameter automatically for XMLHttpRequest requests."""
+    request = event.request
+
+    # If ajax_load was already set to a true-ish or false-ish value, don't set
+    # it again.
+    if (
+        request.getHeader("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"
+        and not request.get("ajax_load", MARKER) is not MARKER
+    ):
+        # Directly set on the request object
+        request.set("ajax_load", True)

--- a/news/+set_ajax.feature.md
+++ b/news/+set_ajax.feature.md
@@ -1,0 +1,11 @@
+Automatically set the ajax_load request parameter.
+
+Zope maintains the "HTTP_X_REQUESTED_WITH" request header. If this is set to
+"XMLHttpRequest", we have an AJAX request. In this case the ajax_load parameter
+is set to True directly on the request object.
+If the ajax_load parameter was already set to a true-ish or false-ish value, it
+is not overwritten.
+
+This should make use for the ajax_main_template for any AJAX request,
+regardless if the ajax_load parameter was manually set or not and potentially
+speed up Plone Classic UI rendering.


### PR DESCRIPTION
Related:
https://github.com/plone/Products.CMFPlone/pull/4188
https://github.com/plone/plone.base/pull/85
https://github.com/plone/plonetheme.barceloneta/pull/404
https://github.com/plone/plone.app.portlets/pull/203


Plone 6.1: https://github.com/plone/Products.CMFPlone/pull/4188  (this one)
Plone 6.2: https://github.com/plone/Products.CMFPlone/pull/4169

Zope maintains the "HTTP_X_REQUESTED_WITH" request header. If this is set to "XMLHttpRequest", we have an AJAX request. In this case the ajax_load parameter is set to 1 directly on the request object.

This should make use for the ajax_main_template for any AJAX request, regardless if the ajax_load parameter was manually set or not and potentially speed up Plone Classic UI rendering.