### PR TITLE
Remove the alias that links the searchResults method to the call of the portal catalog

### DIFF
--- a/Products/CMFPlone/CatalogTool.py
+++ b/Products/CMFPlone/CatalogTool.py
@@ -37,6 +37,7 @@ from zope.component.hooks import getSite
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import providedBy
+from ZPublisher import zpublish
 
 import logging
 import re
@@ -440,7 +441,9 @@ class CatalogTool(PloneBaseTool, BaseTool):
 
         return ZCatalog.searchResults(self, query, **kw)
 
-    __call__ = searchResults
+    @zpublish(False)
+    def __call__(self, *args, **kwargs):
+        return self.searchResults(*args, **kwargs)
 
     def search(self, query, sort_index=None, reverse=0, limit=None, merge=1):
         # Wrap search() the same way that searchResults() is

--- a/news/4248.bugfix.md
+++ b/news/4248.bugfix.md
@@ -1,0 +1,1 @@
+Remove the alias that links the searchResults method to the call of the portal catalog


### PR DESCRIPTION
Refs. https://github.com/plone/Products.CMFPlone/issues/4248 
Backports: https://github.com/plone/Products.CMFPlone/pull/4249

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.