### PR TITLE
Update classifier to Framework Zope 6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+    rev: 25.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -63,16 +63,16 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.23.0"
+    rev: "0.24.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
         pass_filenames: false

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Framework :: Plone",
         "Framework :: Plone :: 6.2",
         "Framework :: Plone :: Core",
-        "Framework :: Zope :: 5",
+        "Framework :: Zope :: 6",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",


### PR DESCRIPTION
Let's be the first to use [use this classifier](https://pypi.org/search/?c=Framework+%3A%3A+Zope+%3A%3A+6). :-)

And do `pre-commit autoupdate`.  Otherwise `pyroma` fails due to an outdated list of classifiers:

```
Some of your classifiers are not standard classifiers:
Framework :: Zope :: 6
```

Let's ignore Jenkins and not care about a missing changelog entry.
