### PR TITLE
Fix #4183: Add guard clause for self.form in z3c_form patch

### DIFF
--- a/src/Products/CMFPlone/patches/z3c_form.py
+++ b/src/Products/CMFPlone/patches/z3c_form.py
@@ -44,7 +44,8 @@ def _wrap_update(update):
                 if req_url_parsed.netloc != referrer_parsed.netloc:
                     # We do not trust data from outside referrers.
                     self.ignoreRequest = True
-                    self.form.ignoreRequest = True
+                    if getattr(self, "form", None) is not None:
+                        self.form.ignoreRequest = True
         return update(self)
 
     return _wrapped


### PR DESCRIPTION
-This Pull Request addresses the AttributeError: 'NoneType' object has no attribute 'ignoreRequest' reported in issue #4183.

The error occurs within the z3c_form monkey patch when a widget (specifically the RichText widget) is rendered in a context where its parent form attribute has not yet been initialized or is set to None. This was notably triggered when navigating to forms via external referrers.

Changes

Modified src/Products/CMFPlone/patches/z3c_form.py.

Added a safety check using getattr(self, "form", None) to ensure the ignoreRequest attribute is only modified if the form object exists.

This ensures the security logic (ignoring untrusted external request data) remains intact without crashing the rendering process.

Testing

Verified the fix by running the official test suite using tox -e test.

Manually verified the logic to ensure it handles both cases (when self.form is present and when it is None).
