### PR TITLE
Resource registry: Allow to use `*` dependencies.

### DIFF
--- a/news/+depends-star.feature.md
+++ b/news/+depends-star.feature.md
@@ -1,0 +1,8 @@
+Resource registry: Allow to use `*` dependencies.
+
+In #4076, #4077 and #4054 we added the `all` keyword for the `depends`
+attribute of resource registry entries to define a resource which should be
+loaded after all other. In Plone < 6 we had the `*` keyword for exactly that.
+This brings now back `*` in addition to `all` for the same purpose. This might
+also allow for a smoother upgrade experience.
+[thet]

--- a/src/Products/CMFPlone/resources/browser/resource.py
+++ b/src/Products/CMFPlone/resources/browser/resource.py
@@ -114,7 +114,7 @@ class ResourceBase:
             valid_dependencies = []
 
             for name in depend_names:
-                if name in bundles or name == "all":
+                if name in bundles or name in ("all", "*"):
                     valid_dependencies.append(name)
                     continue
                 if name in js_names + css_names:
@@ -159,7 +159,7 @@ class ResourceBase:
                     continue
                 external = self.is_external_url(record.jscompilation)
                 r_group = registry_group_js
-                if "all" in depends:
+                if "all" in depends or "*" in depends:
                     # move to a separate group which is rendered after all others
                     r_group = registry_group_js_deferred
                     depends = None
@@ -186,7 +186,7 @@ class ResourceBase:
                     continue
                 external = self.is_external_url(record.csscompilation)
                 r_group = registry_group_css
-                if "all" in depends:
+                if "all" in depends or "*" in depends:
                     # move to a separate group which is rendered after all others
                     r_group = registry_group_css_deferred
                     depends = None

--- a/src/Products/CMFPlone/tests/testResourceRegistries.py
+++ b/src/Products/CMFPlone/tests/testResourceRegistries.py
@@ -243,6 +243,77 @@ class TestScriptsViewlet(PloneTestCase.PloneTestCase):
             scripts[-3].attrib["src"],
         )
 
+    def test_js_bundle_depends_star(self):
+        # `*` is an alias for `all`, so this is the same test as above.
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "*" other and thus rendered
+        # last.
+        self._make_test_bundle(name="last", depends="*")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="b")
+
+        view = ScriptsView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        scripts = parsed.xpath("//script")
+
+        # The last element is our JS, depending on "*".
+        self.assertEqual(
+            "http://foo.bar/last.js",
+            scripts[-1].attrib["src"],
+        )
+
+        # The first resource is our JS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/a.js",
+            scripts[0].attrib["src"],
+        )
+
+        # The second resource is our JS, which was defined with unspecified
+        # dependency last.
+        self.assertEqual(
+            "http://foo.bar/b.js",
+            scripts[1].attrib["src"],
+        )
+
+        # When more bundles depend on "*", they are ordered alphabetically
+        # at the end.
+        self._make_test_bundle(name="x-very-last", depends="*")
+        self._make_test_bundle(name="a-last", depends="*")
+
+        # make sure cache purged
+        setattr(self.layer["request"], REQUEST_CACHE_KEY, None)
+
+        view.update()
+        results = view.render()
+
+        parsed = etree.fromstring(results, parser)
+        scripts = parsed.xpath("//script")
+
+        # All the "*" depending bundles are sorted alphabetically at the end.
+        self.assertEqual(
+            "http://foo.bar/x-very-last.js",
+            scripts[-1].attrib["src"],
+        )
+        self.assertEqual(
+            "http://foo.bar/last.js",
+            scripts[-2].attrib["src"],
+        )
+        self.assertEqual(
+            "http://foo.bar/a-last.js",
+            scripts[-3].attrib["src"],
+        )
+
     def test_bundle_depends_on_missing(self):
         bundle = self._make_test_bundle()
         bundle.depends = "nonexistsinbundle"
@@ -482,6 +553,90 @@ class TestStylesViewlet(PloneTestCase.PloneTestCase):
         )
 
         # The second last element is now our CSS, depending on "all".
+        self.assertEqual(
+            "http://foo.bar/almost-last.css",
+            styles[-2].attrib["href"],
+        )
+
+        # The third last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-3].attrib["href"],
+        )
+
+    def test_css_bundle_depends_star(self):
+        # `*` is an alias for `all`, so this is the same test as above.
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="a")
+
+        # Create a test bundle, which depends on "*" other and thus rendered
+        # last.
+        self._make_test_bundle(name="last", depends="*")
+
+        # Create a test bundle, which has unspecified dependencies and is
+        # rendered in order as defined.
+        self._make_test_bundle(name="b")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is our CSS, depending on "*".
+        self.assertEqual(
+            "http://foo.bar/last.css",
+            styles[-1].attrib["href"],
+        )
+
+        # The second last element is the theme barceloneta theme CSS.
+        self.assertTrue(
+            "++theme++barceloneta/css/barceloneta.min.css" in styles[-2].attrib["href"],
+        )
+
+        # The first resource is our CSS, which was defined with unspecified
+        # dependency.
+        self.assertEqual(
+            "http://foo.bar/a.css",
+            styles[0].attrib["href"],
+        )
+
+        # The second resource is our CSS, which was defined with unspecified
+        # dependency first.
+        self.assertEqual(
+            "http://foo.bar/b.css",
+            styles[1].attrib["href"],
+        )
+
+    def test_css_bundle_depends_star_but_custom(self):
+        # `*` is an alias for `all`, so this is the same test as above.
+
+        registry = getUtility(IRegistry)
+
+        custom_key = "plone.app.theming.interfaces.IThemeSettings.custom_css"
+        registry[custom_key] = "html { background-color: red; }"
+
+        # Create a test bundle, which depends on "*" other and thus rendered
+        # after all except the custom styles.
+        self._make_test_bundle(name="almost-last", depends="*")
+
+        view = StylesView(self.layer["portal"], self.layer["request"], None)
+        view.update()
+        results = view.render()
+
+        parser = etree.HTMLParser()
+        parsed = etree.fromstring(results, parser)
+        styles = parsed.xpath("//link")
+
+        # The last element is are the custom styles.
+        self.assertTrue(
+            "@@custom.css" in styles[-1].attrib["href"],
+        )
+
+        # The second last element is now our CSS, depending on "*".
         self.assertEqual(
             "http://foo.bar/almost-last.css",
             styles[-2].attrib["href"],


### PR DESCRIPTION
In #4076, #4077 and #4054 we added the `all` keyword for the `depends` attribute of resource registry entries to define a resource which should be loaded after all other. In Plone < 6 we had the `*` keyword for exactly that. This brings now back `*` in addition to `all` for the same purpose. This might also allow for a smoother upgrade experience.

Documentation: https://github.com/plone/documentation/pull/2052


- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

