### PR TITLE
Avoid a plone.protect warning on `index_html` documents in portal root.

### DIFF
--- a/news/4279.bugfix.md
+++ b/news/4279.bugfix.md
@@ -1,0 +1,10 @@
+Avoid a plone.protect warning on `index_html` documents in portal root.
+
+`index_html` are often used to create default pages in containers. On the
+portal root this was prevented by a problem in a name collision checker in
+plone.base, fixed in https://github.com/plone/plone.base/pull/107 and a
+plone.protect warning issued by a write-on-read by setting the
+`__replaceable__` attribute on the `index_html` object.
+
+Fixes: https://github.com/plone/Products.CMFPlone/issues/4279
+[thet]

--- a/src/Products/CMFPlone/Portal.py
+++ b/src/Products/CMFPlone/Portal.py
@@ -172,10 +172,9 @@ class PloneSite(Container, SkinnableObjectManager):
                 return result
             elif method not in ("GET", "HEAD", "POST"):
                 raise AttributeError("index_html")
-        # Acquire from skin.
+        # Acquire content from here.
         _target = self.__getattr__("index_html")
         result = aq_base(_target).__of__(self)
-        setattr(result, "__replaceable__", REPLACEABLE)
         return result
 
     index_html = ComputedAttribute(index_html, 1)

--- a/src/Products/CMFPlone/tests/testPortalCreation.py
+++ b/src/Products/CMFPlone/tests/testPortalCreation.py
@@ -481,6 +481,32 @@ class TestPortalCreation(PloneTestCase.PloneTestCase):
             if action.getId() == "syndication" and action.visible:
                 self.fail("Actions tool still has visible 'syndication' action")
 
+    def testIndexHtmlNotInvokingPloneProtect(self):
+        """A `index_html` in the portal root should not invoke a plone.protect
+        exception.
+        """
+        from plone.app.testing import SITE_OWNER_NAME
+        from plone.app.testing import SITE_OWNER_PASSWORD
+        from plone.testing.zope import Browser
+
+        browser = Browser(self.layer["app"])
+        browser.open(self.portal.absolute_url() + "/login_form")
+
+        browser.getControl("Login Name").value = SITE_OWNER_NAME
+        browser.getControl("Password").value = SITE_OWNER_PASSWORD
+        browser.getControl("Log in").click()
+
+        browser.open(self.portal.absolute_url() + "/++add++Document")
+        browser.getControl("Title").value = "index_html"
+        browser.getControl("Save").click()
+        browser.open(self.portal.absolute_url() + "/index_html")
+
+        contents = browser.contents
+
+        # Check, if plone.protect confirm view isn't shown.
+        self.assertNotIn("exploit", contents)
+        self.assertNotIn("Confirm action", contents)
+
     def testObjectButtonActionsInvisibleOnPortalDefaultDocument(self):
         # only a manager would have proper permissions
         self.setRoles(["Manager", "Member"])


### PR DESCRIPTION
`index_html` are often used to create default pages in containers. On the portal root this was prevented by a problem in a name collision checker in plone.base, fixed in https://github.com/plone/plone.base/pull/107 and a plone.protect warning issued by a write-on-read by setting the `__replaceable__` attribute on the `index_html` object.

Fixes: https://github.com/plone/Products.CMFPlone/issues/4279

**NOTE**: I think the `__replaceable__` attribute can be dropped when the index_html returns a content object. As I understood it, a replaceable attribute marks a path as an virtual alias or something, which can be just deleted. It is also barely used.



- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes https://github.com/plone/Products.CMFPlone/issues/4279