### PR TITLE
[6.1] Fix the usergroup-userprefs form

### DIFF
--- a/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.py
+++ b/Products/CMFPlone/controlpanel/browser/usergroups_usersoverview.py
@@ -198,8 +198,17 @@ class UsersOverviewControlPanel(UsersGroupsControlPanelView):
                 roles = user.get("roles", [])
                 if not self.is_zope_manager:
                     # don't allow adding or removing the Manager role
-                    if ("Manager" in roles) != ("Manager" in current_roles):
-                        raise Forbidden
+                    if "Manager" in current_roles:
+                        # The manager checkbox is disabled in the form,
+                        # so if the user has it already, we need to manually restore it.
+                        if "Manager" not in roles:
+                            roles.append("Manager")
+                    else:
+                        # This should not happen because the Manager role
+                        # should not be available in the form, but just in case,
+                        # we want to make sure it cannot be added.
+                        if "Manager" in roles:
+                            raise Forbidden
 
                 acl_users.userFolderEditUser(
                     user.id, pw, roles, member.getDomains(), REQUEST=context.REQUEST

--- a/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
+++ b/Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_usergroups_siteadmin_role.py
@@ -121,6 +121,29 @@ class TestSiteAdministratorRoleFunctional(unittest.TestCase):
         roles = self.portal.acl_users.getUserById(self.normal_user).getRoles()
         self.assertEqual(["Member", "Authenticated"], roles)
 
+    def testNonManagersCanDelegateRolesIfAManagerEsists(self):
+        # A user without the Manager role cannot remove the Manager role
+        # but can still use the form
+        self.browser.addHeader("Authorization", f"Basic siteadmin:{TEST_USER_PASSWORD}")
+        self.browser.open(self.usergroups_url)
+        form = [
+            ("_authenticator", self._get_authenticator()),
+            ("users.id:records", self.normal_user),
+            ("users.roles:list:records", ["Member"]),
+            ("users.id:records", "root"),
+            ("users.roles:list:records", ["Member"]),
+            ("form.button.Modify", "Save"),
+            ("form.submitted", 1),
+        ]
+        post_data = urlencode(form, doseq=True)
+        self.browser.post(self.usergroups_url, post_data)
+
+        roles = set(self.portal.acl_users.getUserById(self.normal_user).getRoles())
+        self.assertSetEqual({"Member", "Authenticated"}, roles)
+
+        roles = set(self.portal.acl_users.getUserById("root").getRoles())
+        self.assertSetEqual({"Member", "Manager", "Authenticated"}, roles)
+
     def testNonManagersCanEditOtherRolesOfUsersWithManagerRole(self):
         roles = self.portal.acl_users.getUserById("root").getRoles()
         self.assertEqual(["Manager", "Authenticated"], roles)

--- a/news/4287.bugfix.md
+++ b/news/4287.bugfix.md
@@ -1,0 +1,2 @@
+Allow a Site Administrator to manage the users roles if there are users that have the Manager role set through the portal_role plugin.
+[ale-rt]


### PR DESCRIPTION
Fix an issue that prevents Site Administrators to use the form when we have some users that have the Manager role set through the portal_role plugin.

Backport of https://github.com/plone/Products.CMFPlone/pull/4288

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.
