### PR TITLE
Fix history action permission

### DIFF
--- a/news/4059.bugfix.md
+++ b/news/4059.bugfix.md
@@ -1,0 +1,3 @@
+Fix history action permission from "Modify portal content" to "CMFEditions: Access previous versions".
+Fixes: https://github.com/plone/Products.CMFPlone/issues/4059
+[jensens]

--- a/src/Products/CMFPlone/profiles/default/actions.xml
+++ b/src/Products/CMFPlone/profiles/default/actions.xml
@@ -169,7 +169,7 @@
       <property name="icon_expr">string:toolbar-action/history</property>
       <property name="available_expr" />
       <property name="permissions">
-        <element value="Modify portal content" />
+        <element value="CMFEditions: Access previous versions" />
       </property>
       <property name="visible">True</property>
     </object>


### PR DESCRIPTION
Change history action permission from `Modify portal content` to `CMFEditions: Access previous versions`.

Users without edit rights could see the history button but got Forbidden when clicking it.

Fixes #4059

Companion PR: upgrade step in plone/plone.app.upgrade (forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)