### PR TITLE
Fix broken links in accessibility-info page

### DIFF
--- a/news/3697.bugfix.md
+++ b/news/3697.bugfix.md
@@ -1,0 +1,3 @@
+Fix broken links in accessibility-info page: VPAT PDF and state.gov reference.
+Fixes: https://github.com/plone/Products.CMFPlone/issues/3697
+[jensens]

--- a/src/Products/CMFPlone/browser/templates/accessibility-info.pt
+++ b/src/Products/CMFPlone/browser/templates/accessibility-info.pt
@@ -64,11 +64,11 @@
         <p i18n:translate="description_vpat">
           View
             <a title="Plone's Voluntary Product Accessibility Template (VPAT)"
-               href="https://plone.org/plone-vpat.pdf/view"
+               href="https://plone.org/accessibility"
                i18n:attributes="title title_plone_vpat;">
                Plone's VPAT
             </a>
-            <a href="https://www.state.gov/m/irm/impact/126340.htm">
+            <a href="https://www.section508.gov/sell/acr/">
                 <acronym i18n:name="vpat" title="About VPAT" i18n:attributes="title title_vpat;">(about VPAT)</acronym>
             </a>
         </p>


### PR DESCRIPTION
- VPAT PDF link: `plone.org/plone-vpat.pdf/view` (404) → `plone.org/accessibility` (overview page with all VPATs)
- About VPAT link: `state.gov/m/irm/impact/126340.htm` (dead) → `section508.gov/sell/acr/` (current VPAT/ACR page)

Fixes #3697

🤖 Generated with [Claude Code](https://claude.com/claude-code)