### PR TITLE
Fix broken link and outdated buildout references

### DIFF
--- a/news/1607.bugfix.md
+++ b/news/1607.bugfix.md
@@ -1,0 +1,3 @@
+Fix broken link and outdated buildout references in add-ons control panel and site overview.
+Fixes: https://github.com/plone/Products.CMFPlone/issues/1607
+[jensens]

--- a/src/Products/CMFPlone/controlpanel/browser/overview.pt
+++ b/src/Products/CMFPlone/controlpanel/browser/overview.pt
@@ -167,9 +167,8 @@
       operation for a live Plone site, but means that some
       configuration changes will not take effect until your server is
       restarted or a product refreshed. If this is a development instance,
-      and you want to enable debug mode, stop the server, set 'debug-mode=on'
-      in your buildout.cfg, re-run bin/buildout and then restart the server
-      process.
+      and you want to enable debug mode, stop the server, enable debug
+      mode in your configuration and then restart the server process.
     </p>
 
     <p tal:condition="view/is_dev_mode"
@@ -178,9 +177,8 @@
       You are running in "debug mode". This mode is intended for sites that
       are under development. This allows many configuration changes to be
       immediately visible, but will make your site run more slowly. To turn
-      off debug mode, stop the server, set 'debug-mode=off' in your
-      buildout.cfg, re-run bin/buildout and then restart the server
-      process.
+      off debug mode, stop the server, disable debug mode in your
+      configuration and then restart the server process.
     </p>
   </section>
 

--- a/src/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
+++ b/src/Products/CMFPlone/controlpanel/browser/quickinstaller.pt
@@ -19,11 +19,11 @@
       add-ons in the lists below.
     </p>
     <p class="discreet" i18n:translate="">
-      To make new add-ons show up here, add them to your buildout
-      configuration, run buildout, and restart the server process.
+      To make new add-ons show up here, install them into your Python
+      environment and restart the server process.
       For detailed instructions see
       <span i18n:name="third_party_product">
-      <a i18n:translate="" href="http://docs.plone.org/manage/installing/installing_addons.html">
+      <a i18n:translate="" href="https://6.docs.plone.org/admin-guide/add-ons.html">
         Installing a third party add-on
       </a>
       </span>.


### PR DESCRIPTION
- Add-ons panel: fix dead `docs.plone.org` link → `6.docs.plone.org/admin-guide/add-ons.html`, replace "add them to your buildout configuration, run buildout" with generic "install them into your Python environment"
- Overview panel: replace "set debug-mode in your buildout.cfg, re-run bin/buildout" with generic "enable/disable debug mode in your configuration"

Fixes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)