### PR TITLE
Fix flaky robot tests: use Wait For Condition instead of Get Text

### DIFF
--- a/news/+flaky-robot-tests.bugfix.md
+++ b/news/+flaky-robot-tests.bugfix.md
@@ -1,0 +1,2 @@
+Fix flaky robot tests: replace ``Get Text //body`` with ``Wait For Condition Text //body`` to properly wait for page content after navigation.
+@jensens

--- a/src/Products/CMFPlone/tests/robot/test_actionmenu.robot
+++ b/src/Products/CMFPlone/tests/robot/test_actionmenu.robot
@@ -92,7 +92,7 @@ Scenario:
 an actionsmenu page
     Create content    type=Document    title=${TITLE}
     Go To    ${PLONE_URL}/${PAGE_ID}
-    Get Text    //body    contains    An actionsmenu page
+    Wait For Condition    Text    //body    contains    An actionsmenu page
 
 # WHEN
 
@@ -111,12 +111,12 @@ workflow link is clicked
     Set Suite Variable    ${OLD_STATE}    ${OLD_STATE}
     Click    xpath=//li[@id='plone-contentmenu-workflow']/a
     Click    xpath=(//li[@id='plone-contentmenu-workflow']/ul/li/a)[1]
-    Get Text    //body    contains    Item state changed.
+    Wait For Condition    Text    //body    contains    Item state changed.
 
 I copy the page
     Open Action Menu
     Click    xpath=//li[@id='plone-contentmenu-actions']//a[contains(@class,'actionicon-object_buttons-copy')]
-    Get Text    //body    contains    copied
+    Wait For Condition    Text    //body    contains    copied
 
 I paste
     Go to  ${PLONE_URL}
@@ -152,7 +152,7 @@ state should have changed
     Should Not Be Equal As Strings    ${NEW_STATE}    ${OLD_STATE}
 
 I should see '${message}' in the page
-    Get Text    //body    contains    ${message}
+    Wait For Condition    Text    //body    contains    ${message}
 
 
 # DRY

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_actions.robot
@@ -66,7 +66,7 @@ Scenario: Move an action to new category in Actions Control Panel
 
 the actions control panel
     Go to    ${PLONE_URL}/@@actions-controlpanel
-    Get Text    //body    contains    Portal actions
+    Wait For Condition    Text    //body    contains    Portal actions
 
 # WHEN
 
@@ -121,7 +121,7 @@ I change category of an action
 anonymous users can see the new action title
     Disable autologin
     Go to    ${PLONE_URL}
-    Get Text    //body    contains    A new site map
+    Wait For Condition    Text    //body    contains    A new site map
 
 
 anonymous users can see the actions new ordering
@@ -142,13 +142,13 @@ logged-in users can see the new action
 anonymous users cannot see the action anymore
     Disable autologin
     Go to  ${PLONE_URL}
-    Get Text    //body    not contains    Site Map
+    Wait For Condition    Text    //body    not contains    Site Map
 
 
 anonymous users can see the action again
     Disable autologin
     Go to  ${PLONE_URL}
-    Get Text    //body    contains    Site Map
+    Wait For Condition    Text    //body    contains    Site Map
 
 logged in users can see action in new category
     Get Text    //*[@id="portal-globalnav"]    contains    Log out

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_editing.robot
@@ -56,13 +56,13 @@ the editing control panel
 I disable the standard editor
     Select Options By    //select[@name="form.widgets.default_editor:list"]    label    None
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 I enable the standard editor
     Select Options By    //select[@name="form.widgets.default_editor:list"]    label    TinyMCE
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 I go to the editing control panel
@@ -72,18 +72,18 @@ I go to the editing control panel
 I enable link integrity checks
     Check Checkbox    //input[@name="form.widgets.enable_link_integrity_checks:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 I enable lock on through the web
     Check Checkbox    //input[@name="form.widgets.lock_on_ttw_edit:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I edit the document
     Go to    ${PLONE_URL}/${PAGE_ID}
     Click    //li[@id="contentview-edit"]/a
-    Get Text    //body    contains    Edit Page
+    Wait For Condition    Text    //body    contains    Edit Page
 
 
 # THEN

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_filter.robot
@@ -59,7 +59,7 @@ I add '${tag}' to the nasty tags list and remove it from the valid tags list
 
 I save the form
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 I remove '${tag}' from the valid tags list
@@ -90,8 +90,8 @@ the 'h1' tag is filtered out when a document is saved
     Fill text to tinymce editor    heading\nSpanish Inquisition
     Mark text heading as h1 in tinymce editor
     I save the form
-    Get Text    //body    contains    Spanish Inquisition
-    Get Text    //body    not contains    heading
+    Wait For Condition    Text    //body    contains    Spanish Inquisition
+    Wait For Condition    Text    //body    not contains    heading
 
 
 the 'h1' tag is stripped when a document is saved
@@ -104,8 +104,8 @@ the 'h1' tag is stripped when a document is saved
     Fill text to tinymce editor    heading\nSpanish Inquisition
     Mark text heading as h1 in tinymce editor
     I save the form
-    Get Text    //body    contains    Spanish Inquisition
-    Get Text    //body    contains    heading
+    Wait For Condition    Text    //body    contains    Spanish Inquisition
+    Wait For Condition    Text    //body    contains    heading
     Get Element Count    //div[@id='content-core']//h1    should be    0    message=h1 should have been stripped out
 
 
@@ -118,7 +118,7 @@ the '${tag}' tag is preserved when a document is saved
     Go To    ${PLONE_URL}/doc1/edit
     Fill source code to tinymce editor    <${tag}>lorem ipsum</${tag}><p>Spanish Inquisition</p>
     I save the form
-    Get Text    //body    contains    Spanish Inquisition
+    Wait For Condition    Text    //body    contains    Spanish Inquisition
     Get Element Count    //div[@id='content-core']//${tag}    should be    1    message=the ${tag} tag should have been preserved
 
 
@@ -131,7 +131,7 @@ the '${attribute}' attribute is preserved when a document is saved
     Go To    ${PLONE_URL}/doc1/edit
     Fill source code to tinymce editor    <span ${attribute}="foo">lorem ipsum</span><p>Spanish Inquisition</p>
     I save the form
-    Get Text    //body    contains    Spanish Inquisition
+    Wait For Condition    Text    //body    contains    Spanish Inquisition
     Get Element Count    //span[@${attribute}]    should be    1    message=the ${attribute} tag should have been preserved
 
 

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_language.robot
@@ -23,7 +23,7 @@ Scenario: Set Site Language in the Language Control Panel
 
 the language control panel
     Go to  ${PLONE_URL}/@@language-controlpanel
-    Get Text    //body    contains    Language Settings
+    Wait For Condition    Text    //body    contains    Language Settings
 
 
 # WHEN
@@ -33,11 +33,11 @@ I set the site language to German
     Select Options By    //select[@name="form.widgets.available_languages.from"]    label    Deutsch
     Click    //button[@value="→"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 
 # THEN
 
 the Plone user interface is in German
     Go to    ${PLONE_URL}
-    Get Text    //body    contains    Lizensiert unter der
+    Wait For Condition    Text    //body    contains    Lizensiert unter der

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_markup.robot
@@ -33,7 +33,7 @@ Scenario: Set Default Markup to be Restructured Text
 
 the markup control panel
     Go to    ${PLONE_URL}/@@markup-controlpanel
-    Get Text    //body    contains    Markup Settings
+    Wait For Condition    Text    //body    contains    Markup Settings
 
 
 # --- WHEN -------------------------------------------------------------------
@@ -45,7 +45,7 @@ I set allowed types to
     Uncheck Checkbox    //input[@name="form.widgets.allowed_types:list" and @value="text/html"]
     Uncheck Checkbox    //input[@name="form.widgets.allowed_types:list" and @value="text/x-web-textile"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
     Get Element States    //input[@name="form.widgets.allowed_types:list" and @value="${type}"]    contains    checked
     Get Element States    //input[@name="form.widgets.allowed_types:list" and @value="text/html"]    not contains    checked
@@ -56,7 +56,7 @@ I set the default type to
 
     Select Options By    //select[@name="form.widgets.default_type:list"]    value    ${type}
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 # I disable the standard editor
 #   Select from list by label  name=form.widgets.default_editor:list  None

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_navigation.robot
@@ -51,7 +51,7 @@ Scenario: Filter Navigation By Workflow States in the Navigation Control Panel
 
 the navigation control panel
     Go to  ${PLONE_URL}/@@navigation-controlpanel
-    Get Text    //body    contains    Navigation Settings
+    Wait For Condition    Text    //body    contains    Navigation Settings
 
 a published document '${title}'
     ${uid}=    Create content
@@ -72,32 +72,32 @@ a private document '${title}'
 I disable generate tabs
     Uncheck Checkbox    //input[@name="form.widgets.generate_tabs:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 I disable non-folderish tabs
     Uncheck Checkbox  //input[@value='Document']
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 I remove '${portal_type}' from the displayed types list
     Uncheck Checkbox  //input[@value='Document']
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 I enable filtering by workflow states
     Check Checkbox    //input[@name="form.widgets.filter_on_workflow:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 I choose to show '${workflow_state}' items
     Check Checkbox    //input[@value='${workflow_state}']
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 I choose to not show '${workflow_state}' items
     Uncheck Checkbox    //input[@value='${workflow_state}']
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 
 # THEN

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_redirection.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_redirection.robot
@@ -89,7 +89,7 @@ I do not get redirected when visiting
     [Arguments]    ${old}
     Go to    ${PLONE_URL}/${old}
     Get Url    should be    ${PLONE_URL}/${old}
-    Get Text    //body    contains    This page does not seem to exist
+    Wait For Condition    Text    //body    contains    This page does not seem to exist
 
 
 I can download all redirects as CSV

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_search.robot
@@ -32,20 +32,20 @@ Scenario: Exclude Content Types from Search
 
 the search control panel
     Go to    ${PLONE_URL}/@@search-controlpanel
-    Get Text    //body    contains    Search Settings
+    Wait For Condition    Text    //body    contains    Search Settings
 
 # WHEN
 
 I enable livesearch
     Check Checkbox  //input[@name="form.widgets.enable_livesearch:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I exclude the '${portal_type}' type from search
     # Make sure we see the checkbox, in expanded in jenkins it gets a bit under the toolbar
     Check Checkbox  //input[@name='form.widgets.types_not_searched:list' and @value='${portal_type}']
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 # THEN
@@ -58,8 +58,8 @@ then searching for 'My Document' will show a live search
 
 searching for '${search_term}' will not return any results
     Go to    ${PLONE_URL}/@@search
-    Get Text    //body    contains    No results were found
+    Wait For Condition    Text    //body    contains    No results were found
     Type Text    //form[@id='searchform']//input[@name='SearchableText']    ${search_term}
     Click    //input[@type="submit" and @value="Search"]
-    Get Text    //body    contains    items matching your search terms
+    Wait For Condition    Text    //body    contains    items matching your search terms
     Get Text    //span[@id='search-results-number']    should be    0

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_security.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_security.robot
@@ -54,52 +54,52 @@ Scenario: Enable use uuid as uid in the Security Control Panel
 
 the security control panel
     Go to    ${PLONE_URL}/@@security-controlpanel
-    Get Text    //body    contains    Security Settings
+    Wait For Condition    Text    //body    contains    Security Settings
 
 a published test folder
     Go to    ${PLONE_URL}/test-folder
     Click    //li[@id="plone-contentmenu-workflow"]/a
     Click    //*[@id="workflow-transition-publish"]
-    Get Text    //body    contains    Item state changed
+    Wait For Condition    Text    //body    contains    Item state changed
 
 # WHEN
 
 I enable self registration
     Check Checkbox  //input[@name="form.widgets.enable_self_reg:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable users to select their own passwords
     Check Checkbox    //input[@name="form.widgets.enable_self_reg:list"]
     Check Checkbox    //input[@name="form.widgets.enable_user_pwd_choice:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable user folders
     Check Checkbox    //input[@name="form.widgets.enable_self_reg:list"]
     Check Checkbox    //input[@name="form.widgets.enable_user_pwd_choice:list"]
     Check Checkbox    //input[@name="form.widgets.enable_user_folders:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable anyone to view 'about' information
     Check Checkbox    //input[@name="form.widgets.allow_anon_views_about:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable email to be used as a login name
     Check Checkbox    //input[@name="form.widgets.enable_self_reg:list"]
     Check Checkbox    //input[@name="form.widgets.enable_user_pwd_choice:list"]
     Check Checkbox    //input[@name="form.widgets.use_email_as_login:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable UUID to be used as a user id
     Check Checkbox    //input[@name="form.widgets.enable_self_reg:list"]
     Check Checkbox    //input[@name="form.widgets.enable_user_pwd_choice:list"]
     Check Checkbox    //input[@name="form.widgets.use_uuid_as_userid:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 # THEN
@@ -107,19 +107,19 @@ I enable UUID to be used as a user id
 Anonymous users can register to the site
     Disable autologin
     Go to    ${PLONE_URL}
-    Get Text    //body    contains    Plone site
+    Wait For Condition    Text    //body    contains    Plone site
     Get Element States    //a[@id="personaltools-join"]    contains    visible
 
 Users can select their own passwords when registering
     Disable autologin
     Go to    ${PLONE_URL}/@@register
-    Get Text    //body    contains    Registration form
+    Wait For Condition    Text    //body    contains    Registration form
     Get Element States    //input[@id="form-widgets-password"]    contains    visible
 
 Users can use email as their login name
     Disable autologin
     Go to    ${PLONE_URL}/@@register
-    Get Text    //body    contains    Registration form
+    Wait For Condition    Text    //body    contains    Registration form
     Get Element States    //input[@id="form-widgets-email"]    contains    visible
     Get Element States    //input[@id="form-widgets-username"]    not contains    visible
 
@@ -131,12 +131,12 @@ A user folder should be created when a user registers and logs in to the site
     # The user folder should be created
     Go to    ${PLONE_URL}/Members/joe
     Get Element Count    //h1[contains(text(),'joe doe')]    should be    1
-    Get Text    //body    not contains    This page does not seem to exist
+    Wait For Condition    Text    //body    not contains    This page does not seem to exist
 
 Anonymous users can view 'about' information
     Disable autologin
     Go to    ${PLONE_URL}/@@search?SearchableText=test
-    Get Text    //body    contains    Search results
+    Wait For Condition    Text    //body    contains    Search results
     Get Element States    //span[contains(@class, 'documentAuthor')]    contains    visible
 
 UUID should be used for the user id
@@ -155,7 +155,7 @@ UUID should be used for the user id
 
 I register to the site
     Go to  ${PLONE_URL}/@@register
-    Get Text    //body    contains    Registration form
+    Wait For Condition    Text    //body    contains    Registration form
     Type Text    //input[@name="form.widgets.fullname"]    joe doe
     Type Text    //input[@name="form.widgets.username"]    joe
     Type Text    //input[@name="form.widgets.email"]    joe@test.com
@@ -165,8 +165,8 @@ I register to the site
 
 I login to the site
     Go to    ${PLONE_URL}/login
-    Get Text    //body    contains    Login Name
+    Wait For Condition    Text    //body    contains    Login Name
     Type Text    //input[@name="__ac_name"]    joe
     Type Text    //input[@name="__ac_password"]    supersecret
     Click    //button[@name="buttons.login"]
-    Get Text    //body    contains    You are now logged in
+    Wait For Condition    Text    //body    contains    You are now logged in

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_site.robot
@@ -49,7 +49,7 @@ Scenario: Add Webstats Javascript in the Site Control Panel
 
 the site control panel
     Go to    ${PLONE_URL}/@@site-controlpanel
-    Get Text    //body    contains    Site Settings
+    Wait For Condition    Text    //body    contains    Site Settings
 
 
 # WHEN
@@ -57,27 +57,27 @@ the site control panel
 I enable the sitemap
     Check Checkbox    //input[@name="form.widgets.enable_sitemap:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I set the site title to '${site_title}'
     Type Text    //input[@name="form.widgets.site_title"]    ${site_title}
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I set a custom logo
     Upload File By Selector    //input[@name="form.widgets.site_logo"]    ${PATH_TO_TEST_FILES}/pixel.png
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I enable dublin core metadata
     Check Checkbox    //input[@name="form.widgets.exposeDCMetaTags:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I add a Javascript snippet to the webstats javascript
     Type Text    //textarea[@name="form.widgets.webstats_js"]    <script id="webstats_snippet"></script>
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 # THEN

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_social.robot
@@ -31,7 +31,7 @@ Scenario: Social tags are disabled
 
 the social control panel
     Go to  ${PLONE_URL}/@@social-controlpanel
-    Get Text    //body    contains    Social Media Settings
+    Wait For Condition    Text    //body    contains    Social Media Settings
 
 
 # WHEN
@@ -39,14 +39,14 @@ the social control panel
 I disable social
     Uncheck Checkbox    //input[@name="form.widgets.share_social_data:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I provide social settings
     Type Text    //input[@name="form.widgets.twitter_username"]    plonecms
     Type Text    //input[@name="form.widgets.facebook_app_id"]    123456
     Type Text    //input[@name="form.widgets.facebook_username"]    plonecms
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 # THEN

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_types.robot
@@ -23,7 +23,7 @@ Scenario: Change default workflow
 # GIVEN
 the types control panel
     Go to    ${PLONE_URL}/@@content-controlpanel
-    Get Text    //body    contains    Content Settings
+    Wait For Condition    Text    //body    contains    Content Settings
 
 
 # WHEN

--- a/src/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
+++ b/src/Products/CMFPlone/tests/robot/test_controlpanel_usergroups.robot
@@ -44,26 +44,26 @@ Scenario: Enable many groups and many users settings in usergroups control panel
 
 the users control panel
     Go to    ${PLONE_URL}/@@usergroup-userprefs
-    Get Text    //body    contains    User Search
+    Wait For Condition    Text    //body    contains    User Search
 
 the groups control panel
     Go to    ${PLONE_URL}/@@usergroup-groupprefs
-    Get Text    //body    contains    Group Search
+    Wait For Condition    Text    //body    contains    Group Search
 
 the user group settings control panel
     Go to    ${PLONE_URL}/@@usergroup-controlpanel
-    Get Text    //body    contains    User and Groups Settings
+    Wait For Condition    Text    //body    contains    User and Groups Settings
 
 
 # WHEN
 
 I click show all users
     Click    //button[@name="form.button.FindAll"]
-    Get Text    //body    contains    User Search
+    Wait For Condition    Text    //body    contains    User Search
 
 I click show all groups
     Click    //button[@name="form.button.FindAll"]
-    Get Text    //body    contains    Group Search
+    Wait For Condition    Text    //body    contains    Group Search
 
 I create new group
     Click    //a[@id="add-group"]
@@ -77,27 +77,27 @@ I enable many groups and many users settings
     Check Checkbox    //input[@name="form.widgets.many_groups:list"]
     Check Checkbox    //input[@name="form.widgets.many_users:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Data successfully updated.
+    Wait For Condition    Text    //body    contains    Data successfully updated.
 
 # THEN
 
 all users should be shown
-    Get Text    //body    contains    test-user
-    Get Text    //body    contains    admin
+    Wait For Condition    Text    //body    contains    test-user
+    Wait For Condition    Text    //body    contains    admin
 
 all groups should be shown
-    Get Text    //body    contains    Administrators
-    Get Text    //body    contains    Authenticated Users (Virtual Group) (AuthenticatedUsers)
-    Get Text    //body    contains    Reviewers
-    Get Text    //body    contains    Site Administrators
+    Wait For Condition    Text    //body    contains    Administrators
+    Wait For Condition    Text    //body    contains    Authenticated Users (Virtual Group) (AuthenticatedUsers)
+    Wait For Condition    Text    //body    contains    Reviewers
+    Wait For Condition    Text    //body    contains    Site Administrators
 
 showing all users is disabled
     the users control panel
-    Get Text    //body    not contains    Show all
+    Wait For Condition    Text    //body    not contains    Show all
 
 showing all groups is disabled
     the groups control panel
-    Get Text    //body    not contains    Show all
+    Wait For Condition    Text    //body    not contains    Show all
 
 new group should show under all groups
-    Get Text    //body    contains    my-new-group
+    Wait For Condition    Text    //body    contains    my-new-group

--- a/src/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/src/Products/CMFPlone/tests/robot/test_edit.robot
@@ -85,14 +85,14 @@ an edited page
     ...    type=Document
     ...    title=${TITLE}
     Go to    ${PLONE_URL}/${PAGE_ID}/edit
-    Get Text    //body    contains    Edit Page
+    Wait For Condition    Text    //body    contains    Edit Page
 
 an edited link item
     Create content
     ...    type=Link
     ...    title=${LINK_TITLE}
     Go to    ${PLONE_URL}/${LINK_ID}/edit
-    Get Text    //body    contains    Edit Link
+    Wait For Condition    Text    //body    contains    Edit Link
 
 
 # WHEN
@@ -173,4 +173,4 @@ at least one other item
     Wait For Condition    Classes    //body    contains    patterns-loaded
     Type Text    //input[@id="form-widgets-IDublinCore-title"]    ${TITLE}
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Item created
+    Wait For Condition    Text    //body    contains    Item created

--- a/src/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
+++ b/src/Products/CMFPlone/tests/robot/test_edit_user_schema.robot
@@ -62,10 +62,10 @@ Scenario: As a manager I can add a field with constraints to the registration fo
 
 site registration enabled
     Go To  ${PLONE_URL}/@@security-controlpanel
-    Get Text    //body    contains    Security Settings
+    Wait For Condition    Text    //body    contains    Security Settings
     Check Checkbox    //input[@name="form.widgets.enable_self_reg:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved.
+    Wait For Condition    Text    //body    contains    Changes saved.
 
 # WHEN
 
@@ -76,7 +76,7 @@ I add a new text field to the member fields
     Press Keys  //form[@id="add-field-form"]//input[@name="form.widgets.title"]    Tab
     Select Options By    //form[@id="add-field-form"]//select[@name="form.widgets.factory:list"]    label    Text line (String)
     Click    //div[@class="modal-footer"]//button[@name="form.buttons.add"]
-    Get Text    //body    contains    Field added successfully.
+    Wait For Condition    Text    //body    contains    Field added successfully.
 
 I Open the test_field Settings
     Go to    ${PLONE_URL}/@@member-fields
@@ -90,19 +90,19 @@ I add a new required text field to the member fields
     Select Options By    //form[@id="add-field-form"]//select[@name="form.widgets.factory:list"]    label    Text line (String)
     Check Checkbox    //input[@name="form.widgets.required:list"]
     Click    //div[@class="modal-footer"]//button[@name="form.buttons.add"]
-    Get Text    //body    contains    Field added successfully.
+    Wait For Condition    Text    //body    contains    Field added successfully.
 
 choose to show the field on registration
     I Open the test_field Settings
     Check Checkbox  //input[@name="form.widgets.IUserFormSelection.forms:list" and @value="On Registration"]
     Click    //div[@class="modal-footer"]//button[@name="form.buttons.save"]
-    Get Text    //body    contains    Data successfully updated.
+    Wait For Condition    Text    //body    contains    Data successfully updated.
 
 choose to show the field in the user profile
     I Open the test_field Settings
     Check Checkbox  //input[@name="form.widgets.IUserFormSelection.forms:list" and @value="In User Profile"]
     Click    //div[@class="modal-footer"]//button[@name="form.buttons.save"]
-    Get Text    //body    contains    Data successfully updated.
+    Wait For Condition    Text    //body    contains    Data successfully updated.
 
 I move the new field to the top
     Drag And Drop    //div[@data-field_id="test_field"]//span[contains(@class, "draghandle")]    //div[@data-field_id="home_page"]
@@ -113,7 +113,7 @@ add a min/max constraint to the field
     Type Text    //input[@name="form.widgets.min_length"]    4
     Type Text    //input[@name="form.widgets.max_length"]    6
     Click    //div[@class="modal-footer"]//button[@name="form.buttons.save"]
-    Get Text    //body    contains    Data successfully updated.
+    Wait For Condition    Text    //body    contains    Data successfully updated.
 
 
 # THEN
@@ -121,7 +121,7 @@ add a min/max constraint to the field
 an anonymous user will see the field in the registration form
     Disable Autologin
     Go to    ${PLONE_URL}/@@register
-    Get Text    //body    contains    Register
+    Wait For Condition    Text    //body    contains    Register
     Get Element Count    //input[@name="form.widgets.test_field"]    should be    1
 
 a logged-in user will see the field in the user profile
@@ -143,5 +143,5 @@ a logged-in user will see a field with min/max constraints
     Type Text    //input[@name="form.widgets.email"]    test@plone.org
     Type Text    //input[@name="form.widgets.test_field"]    1
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    There were some errors.
-    Get Text    //body    contains    Value is too short
+    Wait For Condition    Text    //body    contains    There were some errors.
+    Wait For Condition    Text    //body    contains    Value is too short

--- a/src/Products/CMFPlone/tests/robot/test_linkintegrity.robot
+++ b/src/Products/CMFPlone/tests/robot/test_linkintegrity.robot
@@ -65,7 +65,7 @@ I add a link in rich text
     Click    //div[contains(@class, "content-browser-wrapper")]//div[contains(@class, "levelColumns")]/div[contains(@class, "preview")]/div[contains(@class, "levelToolbar")]//button
     Click    //div[contains(@class,"modal-footer")]//input[@name="insert"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 I remove link to page
     Go To    ${PLONE_URL}/bar
@@ -74,7 +74,7 @@ I remove link to page
     Mark text foo in tinymce editor
     Click    //button[@aria-label="Remove link"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 # Then
 
@@ -110,7 +110,7 @@ I should not see a warning when deleting page from folder_contents
     Get Element States    //*[@id="popover-delete"]//*[contains(@class,"popover-content")]    contains    visible
     Get Element Count    //*[contains(@class,"breach-container")]//*[contains(@class,"breach-item")]    should be    0
     Click    //*[contains(@class,"popover-content")]//button[contains(@class,"applyBtn")]
-    Get Text    //body    contains    Successfully delete items
+    Wait For Condition    Text    //body    contains    Successfully delete items
     Get Element Count      //tr[@data-id="foo"]//input    should be    0
 
 # DRY

--- a/src/Products/CMFPlone/tests/robot/test_livesearch.robot
+++ b/src/Products/CMFPlone/tests/robot/test_livesearch.robot
@@ -49,7 +49,7 @@ a news item
     Type text    //input[@name="form.widgets.IDublinCore.title"]    ${title}
     Upload File By Selector    //input[@name="form.widgets.ILeadImageBehavior.image"]    ${PATH_TO_TEST_FILES}/pixel.png
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Item created    message=Image could not be created.
+    Wait For Condition    Text    //body    contains    Item created    message=Image could not be created.
 
 I search for
     [Arguments]    ${searchtext}
@@ -79,4 +79,4 @@ I disable images in results in search controlpanel
     Go to    ${PLONE_URL}/@@search-controlpanel
     Uncheck Checkbox    //input[@name="form.widgets.search_show_images:list"]
     Click    //button[@name="form.buttons.save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved

--- a/src/Products/CMFPlone/tests/robot/test_overlays.robot
+++ b/src/Products/CMFPlone/tests/robot/test_overlays.robot
@@ -205,7 +205,7 @@ a document as the default view of the test folder
 
 the users and groups configlet
     Go to    ${PLONE_URL}/@@usergroup-userprefs
-    Get Text    //body    contains    User Search
+    Wait For Condition    Text    //body    contains    User Search
 
 # WHEN
 

--- a/src/Products/CMFPlone/tests/robot/test_portlets.robot
+++ b/src/Products/CMFPlone/tests/robot/test_portlets.robot
@@ -50,17 +50,17 @@ Scenario: Delete Login Portlet from right column
 
 a manage portlets view
     Go to    ${PLONE_URL}/@@manage-portlets
-    Get Text    //body    contains    Manage portlets
+    Wait For Condition    Text    //body    contains    Manage portlets
 
 # When
 
 I add a '${portletname}' portlet to the left column
     Select Options By    //div[@id="portletmanager-plone-leftcolumn"]//select[contains(@class,"add-portlet")]    label    ${portletname}
-    Get Text    //body    contains    Portlet added
+    Wait For Condition    Text    //body    contains    Portlet added
 
 I add a '${portletname}' portlet to the right column
     Select Options By    //div[@id="portletmanager-plone-rightcolumn"]//select[contains(@class,"add-portlet")]    label    ${portletname}
-    Get Text    //body    contains    Portlet added
+    Wait For Condition    Text    //body    contains    Portlet added
 
 I go to portal root
     Disable autologin

--- a/src/Products/CMFPlone/tests/robot/test_tinymce.robot
+++ b/src/Products/CMFPlone/tests/robot/test_tinymce.robot
@@ -27,7 +27,7 @@ Scenario: A page is opened to edit in TinyMCE
       and insert image
 
     Click    //*[@id="form-buttons-save"]
-    Get Text    //body    contains    Changes saved
+    Wait For Condition    Text    //body    contains    Changes saved
 
 
 *** Keywords *****************************************************************
@@ -37,7 +37,7 @@ Scenario: A page is opened to edit in TinyMCE
 an edited page
     Create content  type=Document  title=${TITLE}
     Go to  ${PLONE_URL}/${PAGE_ID}/edit
-    Get Text    //body    contains    Edit Page
+    Wait For Condition    Text    //body    contains    Edit Page
 
 an uploaded image
     Create content  type=Image  title=an-image


### PR DESCRIPTION
## Summary
- Replace all `Get Text //body contains` with `Wait For Condition Text //body contains` across 21 robot test files (~100 assertions)
- `Get Text` asserts immediately and fails if page hasn't fully rendered after navigation
- `Wait For Condition` retries with a timeout, matching the pattern already used in `keywords.robot`

This fixes the randomly failing "Set Site Language in the Language Control Panel" test and prevents similar flaky failures across all other robot tests.

## Test plan
- [ ] All robot tests should still pass (same assertions, just with retry)
- [ ] The language control panel test should no longer fail randomly

🤖 Generated with [Claude Code](https://claude.com/claude-code)