### PR TITLE
Preserve query parameters in redirect after login

### DIFF
--- a/news/4201.bugfix.md
+++ b/news/4201.bugfix.md
@@ -1,0 +1,3 @@
+Preserve query parameters in redirect after login.
+URLs with query strings (e.g. ``?foo=bar``) no longer redirect to the portal root.
+@jensens

--- a/src/Products/CMFPlone/browser/login/login.py
+++ b/src/Products/CMFPlone/browser/login/login.py
@@ -226,7 +226,13 @@ class LoginForm(form.EditForm):
             came_from = adapter(came_from, is_initial_login)
 
         if came_from:
-            came_from_path = self.request.physicalPathFromURL(came_from)
+            # Strip query string and fragment before path validation,
+            # physicalPathFromURL does not handle them.
+            came_from_url = parse.urlsplit(came_from)
+            came_from_bare = parse.urlunsplit(
+                (came_from_url.scheme, came_from_url.netloc, came_from_url.path, "", "")
+            )
+            came_from_path = self.request.physicalPathFromURL(came_from_bare)
 
             nav_root_path = self.portal_state.navigation_root_path().split("/")
 

--- a/src/Products/CMFPlone/tests/test_redirect_after_login.py
+++ b/src/Products/CMFPlone/tests/test_redirect_after_login.py
@@ -136,6 +136,26 @@ class TestRedirectAfterLogin(unittest.TestCase):
             "Logout status message not displayed.",
         )
 
+    def test_redirect_to_came_from_with_query_params(self):
+        # https://github.com/plone/Products.CMFPlone/issues/4201
+        self.browser.open("http://nohost/plone/login")
+        self.browser.getLink("Log in").click()
+
+        self.browser.getControl("Login Name").value = TEST_USER_NAME
+        self.browser.getControl("Password").value = TEST_USER_PASSWORD
+        self.browser.getControl(name="came_from").value = (
+            "http://nohost/plone/contact-info?foo=bar&baz=1"
+        )
+
+        self.browser.getControl("Log in").click()
+
+        self.assertIn("You are now logged in.", self.browser.contents)
+        self.assertEqual(
+            self.browser.url,
+            "http://nohost/plone/contact-info?foo=bar&baz=1",
+            "Query parameters in came_from were lost after login redirect.",
+        )
+
     def test_redirect_to_adapter_result(self):
         # Register our redirect adapter
         from zope.component import getGlobalSiteManager


### PR DESCRIPTION
## Summary

- `came_from` URLs with query strings (e.g. `?foo=bar`) were silently dropped after login, redirecting to the portal root instead
- Root cause: `physicalPathFromURL` doesn't handle query strings — a URL like `/page?foo=bar` produces a path ending in `page?foo=bar`, which fails `unrestrictedTraverse`, triggering the fallback to portal root
- Fix: strip query string and fragment with `urlsplit` before path validation, while preserving the original `came_from` URL for the final redirect

**Security note:** No new attack surface — the URL is already validated as internal via `isURLInPortal()`, and users can visit any internal URL with any params directly anyway.

## Test plan

- [x] New test `test_redirect_to_came_from_with_query_params` verifies params are preserved
- [x] All 12 existing redirect-after-login tests pass

Fixes #4201

🤖 Generated with [Claude Code](https://claude.ai/code)