### PR TITLE
Reuse plone_layout from the main template view.

### DIFF
--- a/news/+reuse-plonelayout.internal.md
+++ b/news/+reuse-plonelayout.internal.md
@@ -1,0 +1,1 @@
+Reuse plone_layout from the main template view.

--- a/src/Products/CMFPlone/browser/templates/ajax_main_template.pt
+++ b/src/Products/CMFPlone/browser/templates/ajax_main_template.pt
@@ -9,7 +9,7 @@
           context_state python:context.restrictedTraverse('@@plone_context_state');
           plone_view python:context.restrictedTraverse('@@plone');
           icons python:context.restrictedTraverse('@@iconresolver');
-          plone_layout python:context.restrictedTraverse('@@plone_layout');
+          plone_layout python:view.plone_layout;
           lang python:portal_state.language();
           view nocall:view | nocall: plone_view;
           dummy python: plone_layout.mark_view(view);

--- a/src/Products/CMFPlone/browser/templates/main_template.pt
+++ b/src/Products/CMFPlone/browser/templates/main_template.pt
@@ -9,7 +9,7 @@
           context_state python:context.restrictedTraverse('@@plone_context_state');
           plone_view python:context.restrictedTraverse('@@plone');
           icons python:context.restrictedTraverse('@@iconresolver');
-          plone_layout python:context.restrictedTraverse('@@plone_layout');
+          plone_layout python:view.plone_layout;
           lang python:portal_state.language();
           view nocall:view | nocall: plone_view;
           dummy python: plone_layout.mark_view(view);


### PR DESCRIPTION
Plone layout is already used and memoized in the browser view: https://github.com/plone/Products.CMFPlone/blob/5fbf4d0c78ef50a5b4ce412e8b7451b62254399a/src/Products/CMFPlone/browser/main_template.py#L20-L23


----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

