### PR TITLE
Always allow access to the scripts and styles viewlets.

### DIFF
--- a/news/4239.bugfix.md
+++ b/news/4239.bugfix.md
@@ -1,0 +1,3 @@
+Always allow access to the scripts and styles viewlets.
+Otherwise the site may look ugly when you don't have access to the context.
+@mauritsvanrees

--- a/src/Products/CMFPlone/resources/browser/configure.zcml
+++ b/src/Products/CMFPlone/resources/browser/configure.zcml
@@ -8,14 +8,14 @@
       name="plone.resourceregistries.scripts"
       manager="plone.app.layout.viewlets.interfaces.IScripts"
       class="Products.CMFPlone.resources.browser.resource.ScriptsView"
-      permission="zope2.View"
+      permission="zope.Public"
       />
 
   <browser:viewlet
       name="plone.resourceregistries.styles"
       manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
       class="Products.CMFPlone.resources.browser.resource.StylesView"
-      permission="zope2.View"
+      permission="zope.Public"
       />
 
   <adapter


### PR DESCRIPTION
Otherwise the site may look ugly when you don't have access to the context. See discussion in [alternative PR](https://github.com/plone/Products.CMFPlone/pull/4293)
