### PR TITLE
Move Classic-UI @@sharing CSRF test to plone.app.layout

### DIFF
--- a/news/3953.tests.md
+++ b/news/3953.tests.md
@@ -1,1 +1,2 @@
 Move linkintegrity robottests to plone.app.layout, because they rely on classic-ui rendered HTML.  @petschki
+Move the Classic-UI ``@@sharing`` CSRF doctest from ``csrf.txt`` to plone.app.layout, because the sharing view (and its ``IPloneAppLayoutLayer``) now lives there.  @MrTango

--- a/src/Products/CMFPlone/tests/csrf.txt
+++ b/src/Products/CMFPlone/tests/csrf.txt
@@ -305,32 +305,8 @@ Now rename
   >>> browser.contents
   '...Info...Renamed...a-folder...to...folder...'
 
-"Sharing" the item is next:
-
-  >>> browser.getLink('Sharing').click()
-  >>> browser.url
-  'http://nohost/plone/folder/@@sharing?_auth...'
-  >>> browser.getControl(name='entries.role_Editor:records').value
-  []
-
-Change the value of the second _authenticator and check for Exception
-
-  >>> browser.getControl(name='_authenticator', index=1).value = 'invalid!'
-  >>> browser.getControl(name='entries.role_Editor:records').value = ['True']
-  >>> browser.getControl('Save').click()
-  Traceback (most recent call last):
-  ...
-  zExceptions.Forbidden
-
-  >>> browser.getLink('Sharing').click()
-  >>> browser.getControl(name='entries.role_Editor:records').value = ['True']
-  >>> browser.getControl('Save').click()
-  >>> browser.url
-  'http://nohost/plone/folder/@@sharing'
-  >>> browser.contents
-  '...Info...Changes saved...'
-  >>> browser.getControl(name='entries.role_Editor:records').value
-  ['True']
+The CSRF protection of the Classic-UI ``@@sharing`` view is tested in
+``plone.app.layout`` (``sharing_csrf.txt``), where that view now lives.
 
 And finally removing the item again:
 


### PR DESCRIPTION
## What

The Classic-UI `@@sharing` view moved from `plone.app.workflow` to `plone.app.layout`, where it is registered on the `IPloneAppLayoutLayer` browser layer (installed by the `plone.app.layout:default` profile). The CSRF doctest for that view moves along with it.

- Removed the "Sharing" CSRF block from `Products/CMFPlone/tests/csrf.txt`; the surrounding object-actions flow (create → rename → delete) is unchanged.
- The moved test now lives in `plone.app.layout` as `sharing_csrf.txt`, running under the layout functional layer which installs `plone.app.layout:default` so the layer is active and `@@sharing` resolves to the real view.

## Why

CMFPlone's test fixture does not install `plone.app.layout:default`, so after the move `@@sharing` fell back to the raising base view and `csrf.txt` failed. Real Classic-UI sites are unaffected — `plone.classicui` already installs `plone.app.layout:default`.

## Coordinated PRs (must be tested together)

- plone/plone.app.workflow#3953-move-plone-app-workflow-to-plone-app-layout
- plone/plone.app.layout#3953-move-plone-app-workflow-to-plone-app-layout

Please add this PR to the Jenkins `pull-request-6.3-3.10` job alongside the two above.

## Tests

- `bin/test -s Products.CMFPlone -t csrf` → 1/1 pass
- `bin/test -s plone.app.layout -t sharing_csrf` → 1/1 pass

## Needs

- https://github.com/plone/plone.app.layout/pull/390
- https://github.com/plone/plone.app.workflow/pull/58