### PR TITLE
Contentbrowser UI fix [6.1]

### DIFF
--- a/Products/CMFPlone/tests/robot/test_edit.robot
+++ b/Products/CMFPlone/tests/robot/test_edit.robot
@@ -114,7 +114,7 @@ I select a related item
     # Click first element in first column
     Click item in contenbrowser column    1    1
     # Click the select Button in the Toolbar of column 2
-    Click    //div[contains(@class, "content-browser-wrapper")]//div[contains(@class, "levelColumns")]/div[2]/div[contains(@class, "levelToolbar")]//button[contains(@class, "btn-outline-primary")]
+    Click    //div[contains(@class, "content-browser-wrapper")]//div[contains(@class, "levelColumns")]/div[2]/div[contains(@class, "levelToolbar")]//button[contains(@class, "btn-primary")]
 
 I select a linked item
     # Click the select button
@@ -123,7 +123,7 @@ I select a linked item
     Click item in contenbrowser column    1    1
     # Click the select Button in the Toolbar of column 2
     # This selects the "test-folder"
-    Click    //div[contains(@class, "content-browser-wrapper")]//div[contains(@class, "levelColumns")]/div[2]/div[contains(@class, "levelToolbar")]//button[contains(@class, "btn-outline-primary")]
+    Click    //div[contains(@class, "content-browser-wrapper")]//div[contains(@class, "levelColumns")]/div[2]/div[contains(@class, "levelToolbar")]//button[contains(@class, "btn-primary")]
 
 I save the page
     Click    //button[@name="form.buttons.save"]

--- a/news/+contentbrowser_ui.tests.md
+++ b/news/+contentbrowser_ui.tests.md
@@ -1,0 +1,1 @@
+Fix robottests for UI changes in `pat-contentbrowser`. @petschki


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

test together on Jenkins:

```
https://github.com/plone/plone.staticresources/pull/443
https://github.com/plone/Products.CMFPlone/pull/4340
```

