### PR TITLE
Preserve configlet title i18n Messages on edits - fixes #4344

### DIFF
--- a/news/4344.bugfix.md
+++ b/news/4344.bugfix.md
@@ -1,0 +1,2 @@
+Preserve i18n ``Message`` titles of control panel configlets when editing them via the ZMI "Actions" form.
+@szakitibi

--- a/src/Products/CMFPlone/PloneControlPanel.py
+++ b/src/Products/CMFPlone/PloneControlPanel.py
@@ -168,6 +168,14 @@ class PloneControlPanel(
             return
         self.deleteActions(selection)
 
+    def _queryActionById(self, id):
+        """Returns the currently stored action for the input id if exists."""
+        if not id:
+            return
+        for action in self.listActions():
+            if action.getId() == id:
+                return action
+
     def _extractAction(self, properties, index):
         # Extract an ActionInformation from the funky form properties.
         id = str(properties.get("id_%d" % index, ""))
@@ -183,6 +191,13 @@ class PloneControlPanel(
 
         if not name:
             raise ValueError("A name is required.")
+
+        # Restore extracted name string to i18n Message
+        current_action = self._queryActionById(id)
+        if current_action:
+            current_name = current_action.Title()
+            if isinstance(current_name, Message) and name == str(current_name):
+                name = current_name
 
         if action != "":
             action = Expression(text=action)

--- a/src/Products/CMFPlone/tests/testControlPanel.py
+++ b/src/Products/CMFPlone/tests/testControlPanel.py
@@ -1,4 +1,5 @@
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
+from zope.i18nmessageid import Message
 
 import unittest
 
@@ -41,3 +42,74 @@ class TestControlPanel(unittest.TestCase):
                 in [a.getAction(self)["id"] for a in self.controlpanel.listActions()],
                 "Missing configlet with id '%s'" % title,
             )
+
+    def _add_configlet(self):
+        self.controlpanel.addAction(
+            id="my-configlet",
+            name=Message("My Configlet", domain="test.domain"),
+            action="",
+            permission="",
+            category="Plone",
+        )
+        return len(self.controlpanel.listActions()) - 1
+
+    def _form_properties(self):
+        """Builds the form data the way manage_editActionsForm does.
+
+        The title (name) is the stringified current title.
+        """
+        properties = {}
+        for i, a in enumerate(self.controlpanel.listActions()):
+            properties["id_%d" % i] = a.getId()
+            properties["name_%d" % i] = str(a.Title())
+        return properties
+
+    def testChangeActionsPreservesI18nTitle(self):
+        """The submitted title is a plain string, not a Message."""
+        index = self._add_configlet()
+        properties = self._form_properties()
+        self.assertNotIsInstance(properties["name_%d" % index], Message)
+
+        self.controlpanel.changeActions(properties=properties)
+
+        new_action = self.controlpanel.listActions()[index]
+        self.assertIsInstance(new_action.title, Message)
+        self.assertEqual(new_action.title.domain, "test.domain")
+
+    def testChangeActionsAllowsTitleChange(self):
+        """Manual changes to the title should be applied."""
+        index = self._add_configlet()
+        properties = self._form_properties()
+        properties[f"name_{index}"] = "Renamed Configlet"
+
+        self.controlpanel.changeActions(properties=properties)
+
+        new_action = self.controlpanel.listActions()[index]
+        self.assertEqual(new_action.title, "Renamed Configlet")
+        self.assertNotIsInstance(new_action.title, Message)
+
+    def testExtractActionMatchesOldTitleById(self):
+        """A stale form may submit the rows with different indexes."""
+        index = self._add_configlet()
+        stale_index = index + 1
+        properties = {
+            f"id_{stale_index}": "my-configlet",
+            f"name_{stale_index}": "My Configlet",
+        }
+
+        action = self.controlpanel._extractAction(properties, stale_index)
+
+        self.assertIsInstance(action.title, Message)
+        self.assertEqual(action.title.domain, "test.domain")
+
+    def testExtractActionWithUnknownIdDoesNotFail(self):
+        """A stale form may reference a configlet that no longer exists."""
+        properties = {
+            "id_0": "removed-configlet",
+            "name_0": "Removed Configlet",
+        }
+
+        action = self.controlpanel._extractAction(properties, 0)
+
+        self.assertEqual(action.title, "Removed Configlet")
+        self.assertNotIsInstance(action.title, Message)


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

GenericSetup `controlpanel.xml` allows configlets to be registered with translated titles (`i18n:attributes="title"`). This works in multilingual sites and Site Setup on classic UI show translated configlets.

However using ZMI/portal_controlpanel/manage_editActionsForm breaks translations here:

https://github.com/plone/Products.CMFPlone/blob/6212f6f92be78a429aea573bcb3d8188bb30dfe9/src/Products/CMFPlone/PloneControlPanel.py#L174

The `zope.i18n.message.Message` is replaced with a plain `str`.

This PR fixes the issue by restoring the i18n Message from the stored action if there is no change to the name.

Closes #4344 

