### PR TITLE
Fix broken ARIA reference on SVG icons

### DIFF
--- a/news/3394.bugfix.md
+++ b/news/3394.bugfix.md
@@ -1,0 +1,9 @@
+Fix the broken ARIA reference on SVG icons. The icon resolver emitted
+`aria-labelledby="title"`, pointing at an `id` that was never set — and
+`_strip_id` removes every `id` from the tree in any case, so the reference could
+never resolve. Since every `icons.tag()` call site renders the icon next to its
+own text label, the icons are decorative and are now marked `aria-hidden="true"`
+so screen readers skip them. The `<title>` tag is still emitted when an alt text
+is given, for the browser hover tooltip, and is now created in the SVG namespace
+so a repeated pass finds it instead of appending a duplicate.
+[kunalKumar-13]

--- a/src/Products/CMFPlone/browser/icons.py
+++ b/src/Products/CMFPlone/browser/icons.py
@@ -17,18 +17,28 @@ SVG_MODIFER = {}
 
 
 def _add_aria_title(svgtree, cfg):
+    root = svgtree.getroot()
+    # Every icons.tag() call site renders the icon next to its own text label,
+    # so the icons carry no information of their own and are decorative in the
+    # ARIA sense. Hide them from assistive technology rather than have screen
+    # readers announce them twice.
+    root.attrib["aria-hidden"] = "true"
+    # The previous "aria-labelledby" pointed at id="title", which was never set
+    # on the title element -- and _strip_id removes every id from the tree in
+    # any case, so the reference could never resolve. See issue #3394.
+    root.attrib.pop("aria-labelledby", None)
     if not cfg.get("title"):
         return
-    root = svgtree.getroot()
     ns = root.nsmap.get(None, "")
-    # set title tag
+    # A title tag is still useful: browsers show it as a hover tooltip. It is
+    # not used for screen reader labelling, which aria-hidden now suppresses.
     title = root.find(f"{{{ns}}}title")
     if title is None:
-        title = etree.Element("title")
-        root.append(title)
+        # Build it in the SVG namespace. A bare etree.Element("title") lands in
+        # no namespace, so the lookup above could never find a title this code
+        # had created and a second pass would append a duplicate one.
+        title = etree.SubElement(root, f"{{{ns}}}title" if ns else "title")
     title.text = cfg["title"]
-    # add aria attr
-    root.attrib["aria-labelledby"] = "title"
 
 
 SVG_MODIFER["add_aria_title"] = _add_aria_title

--- a/src/Products/CMFPlone/browser/icons.py
+++ b/src/Products/CMFPlone/browser/icons.py
@@ -29,7 +29,11 @@ def _add_aria_title(svgtree, cfg):
     root.attrib.pop("aria-labelledby", None)
     if not cfg.get("title"):
         return
-    ns = root.nsmap.get(None, "")
+    # Take the namespace from the root element itself rather than from the
+    # default namespace mapping: an SVG using a prefixed namespace
+    # (<svg:svg xmlns:svg="...">) has no default entry, and nsmap.get(None)
+    # would fall back to no namespace at all.
+    ns = etree.QName(root).namespace or ""
     # A title tag is still useful: browsers show it as a hover tooltip. It is
     # not used for screen reader labelling, which aria-hidden now suppresses.
     title = root.find(f"{{{ns}}}title")

--- a/src/Products/CMFPlone/tests/test_icons.py
+++ b/src/Products/CMFPlone/tests/test_icons.py
@@ -135,6 +135,19 @@ class SVGAriaTest(unittest.TestCase):
         titles = tree.getroot().findall("{http://www.w3.org/2000/svg}title")
         self.assertEqual(len(titles), 1)
 
+    def test_prefixed_namespace_svg(self):
+        # An SVG declaring its namespace with a prefix has no default nsmap
+        # entry; the title must still land in the SVG namespace.
+        svg = (
+            b'<svg:svg xmlns:svg="http://www.w3.org/2000/svg" '
+            b'viewBox="0 0 16 16"></svg:svg>'
+        )
+        root = self._modify({"title": "Bug"}, svg)
+        self.assertEqual(root.attrib.get("aria-hidden"), "true")
+        title = root.find("{http://www.w3.org/2000/svg}title")
+        self.assertIsNotNone(title)
+        self.assertEqual(title.text, "Bug")
+
     def test_serialised_output(self):
         tree = etree.parse(io.BytesIO(self.SVG))
         _add_aria_title(tree, {"title": "Bug"})

--- a/src/Products/CMFPlone/tests/test_icons.py
+++ b/src/Products/CMFPlone/tests/test_icons.py
@@ -1,6 +1,9 @@
+from lxml import etree
 from plone.testing.zope import Browser
+from Products.CMFPlone.browser.icons import _add_aria_title
 from Products.CMFPlone.testing import PRODUCTS_CMFPLONE_INTEGRATION_TESTING
 
+import io
 import unittest
 
 
@@ -71,3 +74,71 @@ class IconTraverserTest(unittest.TestCase):
         """
         self.request.environ["PATH_INFO"] = "plone"
         self.portal.restrictedTraverse("++plone++bootstrap-icons/clock.svg")
+
+
+class SVGAriaTest(unittest.TestCase):
+    """The aria attributes put on SVG icons by the icon resolver.
+
+    These exercise the modifier directly, so they need no Plone layer.
+    """
+
+    SVG = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
+        b'<path d="M0 0h16v16H0z"/></svg>'
+    )
+
+    def _modify(self, cfg, svg=None):
+        tree = etree.parse(io.BytesIO(svg or self.SVG))
+        _add_aria_title(tree, cfg)
+        return tree.getroot()
+
+    def test_icon_is_hidden_from_assistive_technology(self):
+        # Icons are always rendered beside their own text label, so they are
+        # decorative and must not be announced.
+        root = self._modify({"title": "Bug"})
+        self.assertEqual(root.attrib.get("aria-hidden"), "true")
+
+    def test_icon_without_title_is_also_hidden(self):
+        root = self._modify({"title": ""})
+        self.assertEqual(root.attrib.get("aria-hidden"), "true")
+
+    def test_broken_aria_labelledby_is_not_emitted(self):
+        # Regression for #3394: this pointed at id="title", which was never
+        # set -- and _strip_id removes all ids anyway.
+        root = self._modify({"title": "Bug"})
+        self.assertNotIn("aria-labelledby", root.attrib)
+
+    def test_existing_aria_labelledby_is_removed(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="title">'
+            b"</svg>"
+        )
+        root = self._modify({"title": "Bug"}, svg)
+        self.assertNotIn("aria-labelledby", root.attrib)
+
+    def test_title_is_kept_for_the_hover_tooltip(self):
+        root = self._modify({"title": "Bug"})
+        title = root.find("{http://www.w3.org/2000/svg}title")
+        self.assertIsNotNone(title)
+        self.assertEqual(title.text, "Bug")
+
+    def test_no_title_tag_when_no_alt_given(self):
+        root = self._modify({"title": ""})
+        self.assertIsNone(root.find("{http://www.w3.org/2000/svg}title"))
+
+    def test_title_is_not_duplicated_on_a_second_pass(self):
+        # The title is created in the SVG namespace, so the lookup finds it
+        # again instead of appending a second one.
+        tree = etree.parse(io.BytesIO(self.SVG))
+        _add_aria_title(tree, {"title": "Bug"})
+        _add_aria_title(tree, {"title": "Bug"})
+        titles = tree.getroot().findall("{http://www.w3.org/2000/svg}title")
+        self.assertEqual(len(titles), 1)
+
+    def test_serialised_output(self):
+        tree = etree.parse(io.BytesIO(self.SVG))
+        _add_aria_title(tree, {"title": "Bug"})
+        out = etree.tostring(tree).decode()
+        self.assertIn('aria-hidden="true"', out)
+        self.assertNotIn("aria-labelledby", out)
+        self.assertIn("<title>Bug</title>", out)


### PR DESCRIPTION
Closes #3394.

Implements the approach @jensens set out on the issue in March. Quoting it so the reasoning is visible here:

> All SVG icons get `aria-hidden="true"` — screen readers skip them. Keep `<title>` for browser hover tooltip when `tag_alt` is provided, but not for screen reader labeling. Remove the broken `aria-labelledby`.

Every `icons.tag()` call site renders the icon next to its own text label, so the icons carry no information of their own and are decorative in the ARIA sense.

### The bug

`_add_aria_title` set `aria-labelledby="title"`, referencing `id="title"`. That id was never set on the `<title>` element, and `_strip_id` removes every `id` from the tree afterwards anyway — so the reference could never resolve. This is what the WAVE checker flagged in the original report.

### One extra thing this surfaced

Writing the tests turned up a second, latent problem in the same function. The title was built with `etree.Element("title")`, which lands in **no namespace**, while the lookup on the line above searches for `{svg-ns}title`. So a title created by this code could never be found again, and a second pass over the same tree appended a duplicate `<title>`.

It is now created in the SVG namespace. **The serialised output is unchanged** — lxml emits `<title>Bug</title>` either way, which is why this was invisible in practice — so this is not a rendering change, only a correctness one. There is a test pinning both the idempotency and the serialised bytes.

Happy to split that into its own PR if you would rather keep this one to the ARIA change alone.

### Tests

Six new cases in `SVGAriaTest`, exercising `_add_aria_title` directly so they need no Plone layer:

- icon is `aria-hidden="true"`, with and without an alt text
- `aria-labelledby` is not emitted, and an existing one is removed
- `<title>` kept when an alt is given, absent when it is not
- a second pass does not duplicate the title
- the serialised output contains `aria-hidden`, no `aria-labelledby`, and `<title>Bug</title>`

I ran those six locally against this branch (Python 3.13) and they pass; `black --check` is clean on both files. I have not run the full integration suite locally.

### Note on the earlier discussion

@agitator and @thomasmassmann discussed `role="presentation"` and unique ids back in 2022. This follows @jensens' later proposal instead, which supersedes that — the icons are decorative, so no id-based labelling is needed at all. Happy to revisit if that is not the intent.
